### PR TITLE
[BE] feat: 커스텀 예외 도입 및 GlobalExceptionHandler 처리 예외 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/friendogly/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/GlobalExceptionHandler.java
@@ -1,9 +1,11 @@
 package com.woowacourse.friendogly;
 
+import com.woowacourse.friendogly.exception.FriendoglyException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
@@ -11,9 +13,14 @@ import org.springframework.web.servlet.resource.NoResourceFoundException;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<String> handle(RuntimeException exception) {
+    @ExceptionHandler(FriendoglyException.class)
+    public ResponseEntity<String> handle(FriendoglyException exception) {
         return new ResponseEntity<>(exception.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<String> handle(MethodArgumentNotValidException exception) {
+        return new ResponseEntity<>("유효하지 않은 요청 값입니다.", HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)

--- a/backend/src/main/java/com/woowacourse/friendogly/exception/FriendoglyException.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/exception/FriendoglyException.java
@@ -1,0 +1,8 @@
+package com.woowacourse.friendogly.exception;
+
+public class FriendoglyException extends RuntimeException {
+
+    public FriendoglyException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## 이슈
- close #91 

## 개발 사항
- MethodArgumentNotValidException 예외도 캐치하도록 수정
- Custom Exception 도입

# 전달 사항
- 표준 예외 메시지를 그대로 응답하면 민감한 정보가 노출될 수 있고, 애플리케이션 내에서 의도적으로 예외를 던진 부분을 트래킹하기 힘듭니다.
- 비즈니스 로직에서 의도적으로 예외를 발생시키는 경우, 추가된 Custom Exception인 FriendoglyException을 사용해주세요.