### PR TITLE
[BE] feat: 발자국 - image URL 필드 추가, 쿨타임 검증 추가, 마지막 발자국 조회 기능 구현

### DIFF
--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
@@ -25,7 +25,7 @@ public class FootprintController {
     private final FootprintQueryService footprintQueryService;
 
     @PostMapping
-    public ResponseEntity<Void> save(@RequestBody SaveFootprintRequest request) {
+    public ResponseEntity<Void> save(@Valid @RequestBody SaveFootprintRequest request) {
         Long id = footprintCommandService.save(request);
         return ResponseEntity.created(URI.create("/footprints/" + id))
             .build();

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -52,7 +53,7 @@ public class FootprintController {
         return ResponseEntity.ok(response);
     }
 
-    @PostMapping("/image/{footprintId}")
+    @PatchMapping("/image/{footprintId}")
     public ResponseEntity<UpdateFootprintImageResponse> updateFootprintImage(
         @PathVariable Long footprintId,
         @ModelAttribute UpdateFootprintImageRequest request

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
@@ -2,8 +2,10 @@ package com.woowacourse.friendogly.footprint.controller;
 
 import com.woowacourse.friendogly.footprint.dto.request.FindNearFootprintRequest;
 import com.woowacourse.friendogly.footprint.dto.request.SaveFootprintRequest;
+import com.woowacourse.friendogly.footprint.dto.request.UpdateFootprintImageRequest;
 import com.woowacourse.friendogly.footprint.dto.response.FindMyLatestFootprintTimeResponse;
 import com.woowacourse.friendogly.footprint.dto.response.FindNearFootprintResponse;
+import com.woowacourse.friendogly.footprint.dto.response.UpdateFootprintImageResponse;
 import com.woowacourse.friendogly.footprint.service.FootprintCommandService;
 import com.woowacourse.friendogly.footprint.service.FootprintQueryService;
 import jakarta.validation.Valid;
@@ -12,6 +14,8 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -44,5 +48,13 @@ public class FootprintController {
         // memberId == 1L 로 dummy data 사용
         // TODO: 추후 토큰에서 memberId를 가져오도록 변경
         return footprintQueryService.findMyLatestFootprintTime(1L);
+    }
+
+    @PostMapping("/image/{footprintId}")
+    public UpdateFootprintImageResponse updateFootprintImage(
+        @PathVariable Long footprintId,
+        @ModelAttribute UpdateFootprintImageRequest request
+    ) {
+        return footprintCommandService.updateFootprintImage(footprintId, request);
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
@@ -11,7 +11,6 @@ import com.woowacourse.friendogly.footprint.service.FootprintQueryService;
 import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -23,12 +22,19 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequiredArgsConstructor
 @RequestMapping("/footprints")
 public class FootprintController {
 
     private final FootprintCommandService footprintCommandService;
     private final FootprintQueryService footprintQueryService;
+
+    public FootprintController(
+        FootprintCommandService footprintCommandService,
+        FootprintQueryService footprintQueryService
+    ) {
+        this.footprintCommandService = footprintCommandService;
+        this.footprintQueryService = footprintQueryService;
+    }
 
     @PostMapping
     public ResponseEntity<Void> save(@Valid @RequestBody SaveFootprintRequest request) {

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
@@ -5,6 +5,7 @@ import com.woowacourse.friendogly.footprint.dto.request.SaveFootprintRequest;
 import com.woowacourse.friendogly.footprint.dto.response.FindNearFootprintResponse;
 import com.woowacourse.friendogly.footprint.service.FootprintCommandService;
 import com.woowacourse.friendogly.footprint.service.FootprintQueryService;
+import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +32,7 @@ public class FootprintController {
     }
 
     @GetMapping("/near")
-    public List<FindNearFootprintResponse> findNear(FindNearFootprintRequest request) {
+    public List<FindNearFootprintResponse> findNear(@Valid FindNearFootprintRequest request) {
         return footprintQueryService.findNear(request);
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
@@ -33,6 +33,8 @@ public class FootprintController {
 
     @GetMapping("/near")
     public List<FindNearFootprintResponse> findNear(@Valid FindNearFootprintRequest request) {
-        return footprintQueryService.findNear(request);
+        // memberId == 1L 로 dummy data 사용
+        // 추후 토큰에서 memberId를 가져오도록 변경
+        return footprintQueryService.findNear(1L, request);
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
@@ -2,6 +2,7 @@ package com.woowacourse.friendogly.footprint.controller;
 
 import com.woowacourse.friendogly.footprint.dto.request.FindNearFootprintRequest;
 import com.woowacourse.friendogly.footprint.dto.request.SaveFootprintRequest;
+import com.woowacourse.friendogly.footprint.dto.response.FindMyLatestFootprintTimeResponse;
 import com.woowacourse.friendogly.footprint.dto.response.FindNearFootprintResponse;
 import com.woowacourse.friendogly.footprint.service.FootprintCommandService;
 import com.woowacourse.friendogly.footprint.service.FootprintQueryService;
@@ -34,7 +35,14 @@ public class FootprintController {
     @GetMapping("/near")
     public List<FindNearFootprintResponse> findNear(@Valid FindNearFootprintRequest request) {
         // memberId == 1L 로 dummy data 사용
-        // 추후 토큰에서 memberId를 가져오도록 변경
+        // TODO: 추후 토큰에서 memberId를 가져오도록 변경
         return footprintQueryService.findNear(1L, request);
+    }
+
+    @GetMapping("/mine/latest")
+    public FindMyLatestFootprintTimeResponse findMyLatestFootprintTime() {
+        // memberId == 1L 로 dummy data 사용
+        // TODO: 추후 토큰에서 memberId를 가져오도록 변경
+        return footprintQueryService.findMyLatestFootprintTime(1L);
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
@@ -37,24 +37,27 @@ public class FootprintController {
     }
 
     @GetMapping("/near")
-    public List<FindNearFootprintResponse> findNear(@Valid FindNearFootprintRequest request) {
+    public ResponseEntity<List<FindNearFootprintResponse>> findNear(@Valid FindNearFootprintRequest request) {
         // memberId == 1L 로 dummy data 사용
         // TODO: 추후 토큰에서 memberId를 가져오도록 변경
-        return footprintQueryService.findNear(1L, request);
+        List<FindNearFootprintResponse> response = footprintQueryService.findNear(1L, request);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/mine/latest")
-    public FindMyLatestFootprintTimeResponse findMyLatestFootprintTime() {
+    public ResponseEntity<FindMyLatestFootprintTimeResponse> findMyLatestFootprintTime() {
         // memberId == 1L 로 dummy data 사용
         // TODO: 추후 토큰에서 memberId를 가져오도록 변경
-        return footprintQueryService.findMyLatestFootprintTime(1L);
+        FindMyLatestFootprintTimeResponse response = footprintQueryService.findMyLatestFootprintTime(1L);
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/image/{footprintId}")
-    public UpdateFootprintImageResponse updateFootprintImage(
+    public ResponseEntity<UpdateFootprintImageResponse> updateFootprintImage(
         @PathVariable Long footprintId,
         @ModelAttribute UpdateFootprintImageRequest request
     ) {
-        return footprintCommandService.updateFootprintImage(footprintId, request);
+        UpdateFootprintImageResponse response = footprintCommandService.updateFootprintImage(footprintId, request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/domain/Footprint.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/domain/Footprint.java
@@ -15,8 +15,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class Footprint {
 
     private static final int RADIUS_AS_METER = 1000;
@@ -28,8 +28,8 @@ public class Footprint {
     @ManyToOne(optional = false)
     private Member member;
 
-    @Column(nullable = false)
     @Embedded
+    @Column(nullable = false)
     private Location location;
 
     private String imageUrl;

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/domain/Footprint.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/domain/Footprint.java
@@ -32,6 +32,8 @@ public class Footprint {
     @Embedded
     private Location location;
 
+    private String imageUrl;
+
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
@@ -42,11 +44,16 @@ public class Footprint {
     public Footprint(Member member, Location location) {
         this.member = member;
         this.location = location;
+        this.imageUrl = "";
         this.createdAt = LocalDateTime.now();
         this.isDeleted = false;
     }
 
     public boolean isNear(Location location) {
         return this.location.isWithin(location, RADIUS_AS_METER);
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/domain/Footprint.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/domain/Footprint.java
@@ -1,6 +1,7 @@
 package com.woowacourse.friendogly.footprint.domain;
 
 import com.woowacourse.friendogly.member.domain.Member;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -23,14 +24,17 @@ public class Footprint {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(optional = false)
     private Member member;
 
+    @Column(nullable = false)
     @Embedded
     private Location location;
 
+    @Column(nullable = false)
     private LocalDateTime createdAt;
 
+    @Column(nullable = false)
     private boolean isDeleted;
 
     @Builder

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/domain/Footprint.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/domain/Footprint.java
@@ -53,6 +53,11 @@ public class Footprint {
         return this.location.isWithin(location, RADIUS_AS_METER);
     }
 
+    public boolean isCreatedBy(Long memberId) {
+        return this.member.getId()
+            .equals(memberId);
+    }
+
     public void updateImageUrl(String imageUrl) {
         this.imageUrl = imageUrl;
     }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/domain/Footprint.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/domain/Footprint.java
@@ -53,7 +53,7 @@ public class Footprint {
         return this.location.isWithin(location, RADIUS_AS_METER);
     }
 
-    public void setImageUrl(String imageUrl) {
+    public void updateImageUrl(String imageUrl) {
         this.imageUrl = imageUrl;
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/domain/Footprint.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/domain/Footprint.java
@@ -9,13 +9,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Footprint {
 
     private static final int RADIUS_AS_METER = 1000;

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/domain/Location.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/domain/Location.java
@@ -14,8 +14,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
-@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class Location {
 
     private static final double MIN_LATITUDE = -90.0;

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/domain/Location.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/domain/Location.java
@@ -7,20 +7,31 @@ import static java.lang.Math.sin;
 import static java.lang.Math.toDegrees;
 import static java.lang.Math.toRadians;
 
+import com.woowacourse.friendogly.exception.FriendoglyException;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class Location {
+
+    private static final double MIN_LATITUDE = -90.0;
+    private static final double MAX_LATITUDE = 90.0;
+
+    private static final double MIN_LONGITUDE = -180.0;
+    private static final double MAX_LONGITUDE = 180.0;
 
     private double latitude;
     private double longitude;
+
+    public Location(double latitude, double longitude) {
+        validate(latitude, longitude);
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
 
     public boolean isWithin(Location other, int radius) {
         return calculateDistanceInMeters(other) <= radius;
@@ -33,5 +44,14 @@ public class Location {
 
         dist = toDegrees(acos(dist));
         return abs(dist * 60 * 1.1515 * 1609.344);
+    }
+
+    private void validate(double latitude, double longitude) {
+        if (latitude < MIN_LATITUDE || latitude > MAX_LATITUDE) {
+            throw new FriendoglyException("위도 범위가 올바르지 않습니다.");
+        }
+        if (longitude < MIN_LONGITUDE || longitude > MAX_LONGITUDE) {
+            throw new FriendoglyException("경도 범위가 올바르지 않습니다.");
+        }
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/request/FindNearFootprintRequest.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/request/FindNearFootprintRequest.java
@@ -13,6 +13,7 @@ public record FindNearFootprintRequest(
     @NotNull
     @DecimalMin(value = "-180.0", message = "경도는 -180도 이상 180도 이하로 입력해 주세요.")
     @DecimalMax(value = "180.0", message = "경도는 -180도 이상 180도 이하로 입력해 주세요.")
-    double longitude) {
+    double longitude
+) {
 
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/request/FindNearFootprintRequest.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/request/FindNearFootprintRequest.java
@@ -1,5 +1,18 @@
 package com.woowacourse.friendogly.footprint.dto.request;
 
-public record FindNearFootprintRequest(double latitude, double longitude) {
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+
+public record FindNearFootprintRequest(
+    @NotNull
+    @DecimalMin(value = "-90.0", message = "위도는 -90도 이상 90도 이하로 입력해 주세요.")
+    @DecimalMax(value = "90.0", message = "위도는 -90도 이상 90도 이하로 입력해 주세요.")
+    double latitude,
+
+    @NotNull
+    @DecimalMin(value = "-180.0", message = "경도는 -180도 이상 180도 이하로 입력해 주세요.")
+    @DecimalMax(value = "180.0", message = "경도는 -180도 이상 180도 이하로 입력해 주세요.")
+    double longitude) {
 
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/request/SaveFootprintRequest.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/request/SaveFootprintRequest.java
@@ -18,6 +18,7 @@ public record SaveFootprintRequest(
     @NotNull
     @DecimalMin(value = "-180.0", message = "경도는 -180도 이상 180도 이하로 입력해 주세요.")
     @DecimalMax(value = "180.0", message = "경도는 -180도 이상 180도 이하로 입력해 주세요.")
-    double longitude) {
+    double longitude
+) {
 
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/request/SaveFootprintRequest.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/request/SaveFootprintRequest.java
@@ -3,9 +3,11 @@ package com.woowacourse.friendogly.footprint.dto.request;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 public record SaveFootprintRequest(
     @NotNull
+    @Positive(message = "memberId는 1 이상이어야 합니다.")
     Long memberId,
 
     @NotNull

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/request/SaveFootprintRequest.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/request/SaveFootprintRequest.java
@@ -1,5 +1,21 @@
 package com.woowacourse.friendogly.footprint.dto.request;
 
-public record SaveFootprintRequest(Long memberId, double latitude, double longitude) {
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+
+public record SaveFootprintRequest(
+    @NotNull
+    Long memberId,
+
+    @NotNull
+    @DecimalMin(value = "-90.0", message = "위도는 -90도 이상 90도 이하로 입력해 주세요.")
+    @DecimalMax(value = "90.0", message = "위도는 -90도 이상 90도 이하로 입력해 주세요.")
+    double latitude,
+
+    @NotNull
+    @DecimalMin(value = "-180.0", message = "경도는 -180도 이상 180도 이하로 입력해 주세요.")
+    @DecimalMax(value = "180.0", message = "경도는 -180도 이상 180도 이하로 입력해 주세요.")
+    double longitude) {
 
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/request/UpdateFootprintImageRequest.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/request/UpdateFootprintImageRequest.java
@@ -1,0 +1,7 @@
+package com.woowacourse.friendogly.footprint.dto.request;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record UpdateFootprintImageRequest(MultipartFile imageFile) {
+
+}

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindMyLatestFootprintTimeResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindMyLatestFootprintTimeResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 
 public record FindMyLatestFootprintTimeResponse(
+    // TODO: 패턴을 통일시키고 나서 어노테이션 지우기
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt
 ) {
 

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindMyLatestFootprintTimeResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindMyLatestFootprintTimeResponse.java
@@ -1,0 +1,10 @@
+package com.woowacourse.friendogly.footprint.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+
+public record FindMyLatestFootprintTimeResponse(
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt
+) {
+
+}

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindNearFootprintResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindNearFootprintResponse.java
@@ -13,8 +13,8 @@ public record FindNearFootprintResponse(
     boolean isMine
 ) {
 
-    public static FindNearFootprintResponse from(Footprint footprint, Long memberId) {
-        return new FindNearFootprintResponse(
+    public FindNearFootprintResponse(Footprint footprint, Long memberId) {
+        this(
             footprint.getId(),
             footprint.getLocation().getLatitude(),
             footprint.getLocation().getLongitude(),

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindNearFootprintResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindNearFootprintResponse.java
@@ -13,13 +13,13 @@ public record FindNearFootprintResponse(
     boolean isMine
 ) {
 
-    public FindNearFootprintResponse(Footprint footprint, Long memberId) {
+    public FindNearFootprintResponse(Footprint footprint, boolean isMine) {
         this(
             footprint.getId(),
             footprint.getLocation().getLatitude(),
             footprint.getLocation().getLongitude(),
             footprint.getCreatedAt(),
-            footprint.isCreatedBy(memberId)
+            isMine
         );
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindNearFootprintResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindNearFootprintResponse.java
@@ -1,21 +1,24 @@
 package com.woowacourse.friendogly.footprint.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.woowacourse.friendogly.footprint.domain.Footprint;
 import java.time.LocalDateTime;
 
 public record FindNearFootprintResponse(
-        Long memberId,
-        double latitude,
-        double longitude,
-        LocalDateTime createdAt
+    Long footprintId,
+    double latitude,
+    double longitude,
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
+    boolean isMine
 ) {
 
-    public static FindNearFootprintResponse from(Footprint footprint) {
+    public static FindNearFootprintResponse from(Footprint footprint, Long memberId) {
         return new FindNearFootprintResponse(
-                footprint.getMember().getId(),
-                footprint.getLocation().getLatitude(),
-                footprint.getLocation().getLongitude(),
-                footprint.getCreatedAt()
+            footprint.getId(),
+            footprint.getLocation().getLatitude(),
+            footprint.getLocation().getLongitude(),
+            footprint.getCreatedAt(),
+            memberId.equals(footprint.getMember().getId())
         );
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindNearFootprintResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindNearFootprintResponse.java
@@ -8,6 +8,7 @@ public record FindNearFootprintResponse(
     Long footprintId,
     double latitude,
     double longitude,
+    // TODO: 패턴을 통일시키고 나서 어노테이션 지우기
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
     boolean isMine
 ) {

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindNearFootprintResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindNearFootprintResponse.java
@@ -19,7 +19,7 @@ public record FindNearFootprintResponse(
             footprint.getLocation().getLatitude(),
             footprint.getLocation().getLongitude(),
             footprint.getCreatedAt(),
-            memberId.equals(footprint.getMember().getId())
+            footprint.isCreatedBy(memberId)
         );
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/UpdateFootprintImageResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/UpdateFootprintImageResponse.java
@@ -1,0 +1,5 @@
+package com.woowacourse.friendogly.footprint.dto.response;
+
+public record UpdateFootprintImageResponse(String imageUrl) {
+
+}

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/repository/FootprintRepository.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/repository/FootprintRepository.java
@@ -3,6 +3,7 @@ package com.woowacourse.friendogly.footprint.repository;
 import com.woowacourse.friendogly.footprint.domain.Footprint;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FootprintRepository extends JpaRepository<Footprint, Long> {
@@ -10,4 +11,6 @@ public interface FootprintRepository extends JpaRepository<Footprint, Long> {
     List<Footprint> findByCreatedAtAfter(LocalDateTime since);
 
     boolean existsByMemberIdAndCreatedAtAfter(Long memberId, LocalDateTime createdAt);
+
+    Optional<Footprint> findTopOneByMemberIdOrderByCreatedAtDesc(Long memberId);
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/repository/FootprintRepository.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/repository/FootprintRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface FootprintRepository extends JpaRepository<Footprint, Long> {
 
     List<Footprint> findByCreatedAtAfter(LocalDateTime since);
+
+    boolean existsByMemberIdAndCreatedAtAfter(Long memberId, LocalDateTime createdAt);
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintCommandService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintCommandService.java
@@ -47,7 +47,7 @@ public class FootprintCommandService {
     private void validateRecentFootprintExists(Long memberId) {
         boolean exists = footprintRepository.existsByMemberIdAndCreatedAtAfter(
             memberId,
-            LocalDateTime.now().minusSeconds(FootprintCommandService.FOOTPRINT_COOLDOWN)
+            LocalDateTime.now().minusSeconds(FOOTPRINT_COOLDOWN)
         );
 
         if (exists) {

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintCommandService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintCommandService.java
@@ -60,7 +60,7 @@ public class FootprintCommandService {
         // TODO: 더미 데이터 URL입니다. 나중에 이미지 저장소(AWS S3)와 연동 필요 !!!
         // TODO: 연동 완료되면 테스트도 작성 필요합니다.
         String imageUrl = "https://img.extmovie.com/files/attach/images/148/921/189/074/6a71e831234e113e3ed215405098109c.jpg";
-        footprint.setImageUrl(imageUrl);
+        footprint.updateImageUrl(imageUrl);
         return new UpdateFootprintImageResponse(imageUrl);
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintCommandService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintCommandService.java
@@ -10,20 +10,23 @@ import com.woowacourse.friendogly.footprint.repository.FootprintRepository;
 import com.woowacourse.friendogly.member.domain.Member;
 import com.woowacourse.friendogly.member.repository.MemberRepository;
 import java.time.LocalDateTime;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Transactional
-@RequiredArgsConstructor
 public class FootprintCommandService {
 
     private static final int FOOTPRINT_COOLDOWN = 30;
 
     private final FootprintRepository footprintRepository;
     private final MemberRepository memberRepository;
+
+    public FootprintCommandService(FootprintRepository footprintRepository, MemberRepository memberRepository) {
+        this.footprintRepository = footprintRepository;
+        this.memberRepository = memberRepository;
+    }
 
     public Long save(SaveFootprintRequest request) {
         Member member = memberRepository.findById(request.memberId())

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintCommandService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintCommandService.java
@@ -4,6 +4,8 @@ import com.woowacourse.friendogly.exception.FriendoglyException;
 import com.woowacourse.friendogly.footprint.domain.Footprint;
 import com.woowacourse.friendogly.footprint.domain.Location;
 import com.woowacourse.friendogly.footprint.dto.request.SaveFootprintRequest;
+import com.woowacourse.friendogly.footprint.dto.request.UpdateFootprintImageRequest;
+import com.woowacourse.friendogly.footprint.dto.response.UpdateFootprintImageResponse;
 import com.woowacourse.friendogly.footprint.repository.FootprintRepository;
 import com.woowacourse.friendogly.member.domain.Member;
 import com.woowacourse.friendogly.member.repository.MemberRepository;
@@ -11,6 +13,7 @@ import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Transactional
@@ -47,5 +50,17 @@ public class FootprintCommandService {
         if (exists) {
             throw new FriendoglyException("마지막 발자국을 찍은 뒤 30초가 경과되지 않았습니다.");
         }
+    }
+
+    public UpdateFootprintImageResponse updateFootprintImage(Long footprintId, UpdateFootprintImageRequest request) {
+        Footprint footprint = footprintRepository.findById(footprintId)
+            .orElseThrow(() -> new FriendoglyException("존재하지 않는 Footprint ID입니다."));
+
+        MultipartFile multipartFile = request.imageFile();
+        // TODO: 더미 데이터 URL입니다. 나중에 이미지 저장소(AWS S3)와 연동 필요 !!!
+        // TODO: 연동 완료되면 테스트도 작성 필요합니다.
+        String imageUrl = "https://img.extmovie.com/files/attach/images/148/921/189/074/6a71e831234e113e3ed215405098109c.jpg";
+        footprint.setImageUrl(imageUrl);
+        return new UpdateFootprintImageResponse(imageUrl);
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintQueryService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintQueryService.java
@@ -8,18 +8,20 @@ import com.woowacourse.friendogly.footprint.dto.response.FindNearFootprintRespon
 import com.woowacourse.friendogly.footprint.repository.FootprintRepository;
 import java.time.LocalDateTime;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
-@RequiredArgsConstructor
 public class FootprintQueryService {
 
     private static final int FOOTPRINT_DURATION_HOURS = 24;
 
     private final FootprintRepository footprintRepository;
+
+    public FootprintQueryService(FootprintRepository footprintRepository) {
+        this.footprintRepository = footprintRepository;
+    }
 
     public List<FindNearFootprintResponse> findNear(Long memberId, FindNearFootprintRequest request) {
         LocalDateTime startTime = LocalDateTime.now().minusHours(FOOTPRINT_DURATION_HOURS);

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintQueryService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintQueryService.java
@@ -31,7 +31,7 @@ public class FootprintQueryService {
 
         return recentFootprints.stream()
             .filter(footprint -> footprint.isNear(currentLocation))
-            .map(footprint -> FindNearFootprintResponse.from(footprint, memberId))
+            .map(footprint -> new FindNearFootprintResponse(footprint, memberId))
             .toList();
     }
 

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintQueryService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintQueryService.java
@@ -3,6 +3,7 @@ package com.woowacourse.friendogly.footprint.service;
 import com.woowacourse.friendogly.footprint.domain.Footprint;
 import com.woowacourse.friendogly.footprint.domain.Location;
 import com.woowacourse.friendogly.footprint.dto.request.FindNearFootprintRequest;
+import com.woowacourse.friendogly.footprint.dto.response.FindMyLatestFootprintTimeResponse;
 import com.woowacourse.friendogly.footprint.dto.response.FindNearFootprintResponse;
 import com.woowacourse.friendogly.footprint.repository.FootprintRepository;
 import java.time.LocalDateTime;
@@ -30,5 +31,11 @@ public class FootprintQueryService {
             .filter(footprint -> footprint.isNear(currentLocation))
             .map(footprint -> FindNearFootprintResponse.from(footprint, memberId))
             .toList();
+    }
+
+    public FindMyLatestFootprintTimeResponse findMyLatestFootprintTime(Long memberId) {
+        return footprintRepository.findTopOneByMemberIdOrderByCreatedAtDesc(memberId)
+            .map(footprint -> new FindMyLatestFootprintTimeResponse(footprint.getCreatedAt()))
+            .orElse(new FindMyLatestFootprintTimeResponse(null));
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintQueryService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintQueryService.java
@@ -31,7 +31,7 @@ public class FootprintQueryService {
 
         return recentFootprints.stream()
             .filter(footprint -> footprint.isNear(currentLocation))
-            .map(footprint -> new FindNearFootprintResponse(footprint, memberId))
+            .map(footprint -> new FindNearFootprintResponse(footprint, footprint.isCreatedBy(memberId)))
             .toList();
     }
 

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintQueryService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintQueryService.java
@@ -20,7 +20,7 @@ public class FootprintQueryService {
 
     private final FootprintRepository footprintRepository;
 
-    public List<FindNearFootprintResponse> findNear(FindNearFootprintRequest request) {
+    public List<FindNearFootprintResponse> findNear(Long memberId, FindNearFootprintRequest request) {
         LocalDateTime startTime = LocalDateTime.now().minusHours(FOOTPRINT_DURATION_HOURS);
         List<Footprint> recentFootprints = footprintRepository.findByCreatedAtAfter(startTime);
 
@@ -28,7 +28,7 @@ public class FootprintQueryService {
 
         return recentFootprints.stream()
             .filter(footprint -> footprint.isNear(currentLocation))
-            .map(FindNearFootprintResponse::from)
+            .map(footprint -> FindNearFootprintResponse.from(footprint, memberId))
             .toList();
     }
 }

--- a/backend/src/test/java/com/woowacourse/friendogly/docs/FootprintApiDocsTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/docs/FootprintApiDocsTest.java
@@ -2,6 +2,8 @@ package com.woowacourse.friendogly.docs;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.HttpHeaders.LOCATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -78,13 +80,17 @@ public class FootprintApiDocsTest extends RestDocsTest {
     void findNear() throws Exception {
         FindNearFootprintRequest request = new FindNearFootprintRequest(37.5173316, 127.1011661);
         List<FindNearFootprintResponse> response = List.of(
-            new FindNearFootprintResponse(1L, 37.5136533, 127.0983182, LocalDateTime.now().minusMinutes(10)),
-            new FindNearFootprintResponse(3L, 37.5131474, 127.1042528, LocalDateTime.now().minusMinutes(20)),
-            new FindNearFootprintResponse(6L, 37.5171728, 127.1047797, LocalDateTime.now().minusMinutes(30)),
-            new FindNearFootprintResponse(11L, 37.516183, 127.1068874, LocalDateTime.now().minusMinutes(40))
+            new FindNearFootprintResponse(
+                1L, 37.5136533, 127.0983182, LocalDateTime.now().minusMinutes(10), true),
+            new FindNearFootprintResponse(
+                3L, 37.5131474, 127.1042528, LocalDateTime.now().minusMinutes(20), false),
+            new FindNearFootprintResponse(
+                6L, 37.5171728, 127.1047797, LocalDateTime.now().minusMinutes(30), false),
+            new FindNearFootprintResponse(
+                11L, 37.516183, 127.1068874, LocalDateTime.now().minusMinutes(40), true)
         );
 
-        given(footprintQueryService.findNear(request))
+        given(footprintQueryService.findNear(any(Long.class), eq(request)))
             .willReturn(response);
 
         mockMvc
@@ -103,10 +109,11 @@ public class FootprintApiDocsTest extends RestDocsTest {
                         parameterWithName("longitude").description("현재 위치의 경도")
                     )
                     .responseFields(
-                        fieldWithPath("[].memberId").description("발자국을 찍은 사용자 ID"),
+                        fieldWithPath("[].footprintId").description("발자국 ID"),
                         fieldWithPath("[].latitude").description("발자국 위치의 위도"),
                         fieldWithPath("[].longitude").description("발자국 위치의 경도"),
-                        fieldWithPath("[].createdAt").description("발자국 생성 시간")
+                        fieldWithPath("[].createdAt").description("발자국 생성 시간"),
+                        fieldWithPath("[].isMine").description("나의 발자국인지 여부")
                     )
                     .build()
                 )

--- a/backend/src/test/java/com/woowacourse/friendogly/footprint/domain/LocationTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/footprint/domain/LocationTest.java
@@ -1,11 +1,43 @@
 package com.woowacourse.friendogly.footprint.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.woowacourse.friendogly.exception.FriendoglyException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class LocationTest {
+
+    @DisplayName("생성 성공 - 올바른 위도, 경도 범위")
+    @ParameterizedTest
+    @CsvSource(value = {"90.000, 180.000", "-90.000, -180.000", "0.000, 0.000"})
+    void constructor_Success(double latitude, double longitude) {
+        assertThatCode(() -> new Location(latitude, longitude))
+            .doesNotThrowAnyException();
+    }
+
+    @DisplayName("생성 실패 - 올바르지 않은 위도 범위")
+    @ParameterizedTest
+    @ValueSource(doubles = {-90.001, 90.001})
+    void constructor_Fail_IllegalLatitude(double latitude) {
+        assertThatThrownBy(() -> new Location(latitude, 0.0))
+            .isInstanceOf(FriendoglyException.class)
+            .hasMessage("위도 범위가 올바르지 않습니다.");
+    }
+
+    @DisplayName("생성 실패 - 올바르지 않은 위도 범위")
+    @ParameterizedTest
+    @ValueSource(doubles = {-180.001, 180.001})
+    void constructor_Fail_IllegalLongitude(double longitude) {
+        assertThatThrownBy(() -> new Location(0.0, longitude))
+            .isInstanceOf(FriendoglyException.class)
+            .hasMessage("경도 범위가 올바르지 않습니다.");
+    }
 
     @DisplayName("약 999m 차이 나는 두 위치는 주변에 있다.")
     @Test

--- a/backend/src/test/java/com/woowacourse/friendogly/footprint/domain/LocationTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/footprint/domain/LocationTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class LocationTest {
 
-    @DisplayName("생성 성공 - 올바른 위도, 경도 범위")
+    @DisplayName("올바른 위도, 경도 범위로 생성하면 예외가 발생하지 않는다.")
     @ParameterizedTest
     @CsvSource(value = {"90.000, 180.000", "-90.000, -180.000", "0.000, 0.000"})
     void constructor_Success(double latitude, double longitude) {
@@ -21,7 +21,7 @@ class LocationTest {
             .doesNotThrowAnyException();
     }
 
-    @DisplayName("생성 실패 - 올바르지 않은 위도 범위")
+    @DisplayName("올바르지 않은 위도 범위로 생성하면 예외가 발생한다.")
     @ParameterizedTest
     @ValueSource(doubles = {-90.001, 90.001})
     void constructor_Fail_IllegalLatitude(double latitude) {
@@ -30,7 +30,7 @@ class LocationTest {
             .hasMessage("위도 범위가 올바르지 않습니다.");
     }
 
-    @DisplayName("생성 실패 - 올바르지 않은 위도 범위")
+    @DisplayName("올바르지 않은 경도 범위로 생성하면 예외가 발생한다.")
     @ParameterizedTest
     @ValueSource(doubles = {-180.001, 180.001})
     void constructor_Fail_IllegalLongitude(double longitude) {

--- a/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintCommandServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintCommandServiceTest.java
@@ -1,7 +1,9 @@
 package com.woowacourse.friendogly.footprint.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.woowacourse.friendogly.exception.FriendoglyException;
 import com.woowacourse.friendogly.footprint.dto.request.SaveFootprintRequest;
 import com.woowacourse.friendogly.footprint.repository.FootprintRepository;
 import com.woowacourse.friendogly.member.domain.Member;
@@ -11,9 +13,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 @SpringBootTest
 class FootprintCommandServiceTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
 
     @Autowired
     private FootprintCommandService footprintCommandService;
@@ -42,5 +48,36 @@ class FootprintCommandServiceTest {
 
         footprintCommandService.save(new SaveFootprintRequest(member.getId(), 30.0, 30.0));
         assertThat(footprintRepository.findAll()).hasSize(1);
+    }
+
+    @DisplayName("발자국 저장 실패 - 존재하지 않는 Member ID")
+    @Test
+    void save_Fail_IllegalMemberId() {
+        assertThatThrownBy(
+            () -> footprintCommandService.save(new SaveFootprintRequest(1L, 30.0, 30.0))
+        ).isInstanceOf(FriendoglyException.class)
+            .hasMessage("존재하지 않는 사용자 ID입니다.");
+    }
+
+    @DisplayName("발자국 저장 실패 - 30초 전에 이미 발자국을 남긴 경우")
+    @Test
+    void save_Fail_TooOftenSave() {
+        Member member = memberRepository.save(
+            Member.builder()
+                .name("name")
+                .email("test@test.com")
+                .build()
+        );
+
+        jdbcTemplate.update("""
+            INSERT INTO footprint (member_id, latitude, longitude, created_at, is_deleted)
+            VALUES
+            (?, 0.00000, 0.00000, TIMESTAMPADD(SECOND, -29, NOW()), FALSE)
+            """, member.getId());
+
+        assertThatThrownBy(
+            () -> footprintCommandService.save(new SaveFootprintRequest(member.getId(), 30.0, 30.0))
+        ).isInstanceOf(FriendoglyException.class)
+            .hasMessage("마지막 발자국을 찍은 뒤 30초가 경과되지 않았습니다.");
     }
 }

--- a/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintQueryServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintQueryServiceTest.java
@@ -1,6 +1,7 @@
 package com.woowacourse.friendogly.footprint.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.friendogly.footprint.dto.request.FindNearFootprintRequest;
 import com.woowacourse.friendogly.footprint.dto.request.SaveFootprintRequest;
@@ -12,7 +13,6 @@ import com.woowacourse.friendogly.member.repository.MemberRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -72,7 +72,7 @@ class FootprintQueryServiceTest {
         List<FindNearFootprintResponse> nearFootprints = footprintQueryService.findNear(
             member1.getId(), new FindNearFootprintRequest(0.0, 0.0));
 
-        Assertions.assertAll(
+        assertAll(
             () -> assertThat(nearFootprints).extracting(FindNearFootprintResponse::latitude)
                 .containsExactly(0.0),
             () -> assertThat(nearFootprints).extracting(FindNearFootprintResponse::longitude)
@@ -101,7 +101,7 @@ class FootprintQueryServiceTest {
         List<FindNearFootprintResponse> nearFootprints = footprintQueryService.findNear(
             member.getId(), new FindNearFootprintRequest(0.0, 0.0));
 
-        Assertions.assertAll(
+        assertAll(
             () -> assertThat(nearFootprints).extracting(FindNearFootprintResponse::latitude)
                 .containsExactly(0.00000, 0.00000),
             () -> assertThat(nearFootprints).extracting(FindNearFootprintResponse::longitude)
@@ -129,9 +129,13 @@ class FootprintQueryServiceTest {
             (?, 0.22222, 0.22222, ?, FALSE);
             """, member.getId(), member.getId(), member.getId(), oneMinuteAgo);
 
-        assertThat(footprintQueryService.findMyLatestFootprintTime(member.getId()))
-            .extracting(FindMyLatestFootprintTimeResponse::createdAt)
-            .isEqualTo(oneMinuteAgo);
+        LocalDateTime time = footprintQueryService.findMyLatestFootprintTime(member.getId()).createdAt();
+
+        assertAll(
+            () -> assertThat(time.getHour()).isEqualTo(oneMinuteAgo.getHour()),
+            () -> assertThat(time.getMinute()).isEqualTo(oneMinuteAgo.getMinute()),
+            () -> assertThat(time.getSecond()).isEqualTo(oneMinuteAgo.getSecond())
+        );
     }
 
     @DisplayName("자신이 마지막으로 발자국 찍은 시간 조회 - 찍은 발자국이 없는 경우")

--- a/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintQueryServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintQueryServiceTest.java
@@ -44,9 +44,16 @@ class FootprintQueryServiceTest {
     @DisplayName("현재 위치 기준 1km 이내 발자국의 수가 1개일 때, 1개의 발자국만 조회된다.")
     @Test
     void findNear() {
-        Member member = memberRepository.save(
+        Member member1 = memberRepository.save(
             Member.builder()
-                .name("name")
+                .name("name1")
+                .email("test@test.com")
+                .build()
+        );
+
+        Member member2 = memberRepository.save(
+            Member.builder()
+                .name("name2")
                 .email("test@test.com")
                 .build()
         );
@@ -55,17 +62,15 @@ class FootprintQueryServiceTest {
         double farLongitude = 0.009001209;
 
         // 999m 떨어진 발자국 저장
-        footprintCommandService.save(new SaveFootprintRequest(member.getId(), 0.0, nearLongitude));
+        footprintCommandService.save(new SaveFootprintRequest(member1.getId(), 0.0, nearLongitude));
 
         // 1001m 떨어진 발자국 저장
-        footprintCommandService.save(new SaveFootprintRequest(member.getId(), 0.0, farLongitude));
+        footprintCommandService.save(new SaveFootprintRequest(member2.getId(), 0.0, farLongitude));
 
         List<FindNearFootprintResponse> nearFootprints = footprintQueryService.findNear(
-            new FindNearFootprintRequest(0.0, 0.0));
+            member1.getId(), new FindNearFootprintRequest(0.0, 0.0));
 
         Assertions.assertAll(
-            () -> assertThat(nearFootprints).extracting(FindNearFootprintResponse::memberId)
-                .containsExactly(member.getId()),
             () -> assertThat(nearFootprints).extracting(FindNearFootprintResponse::latitude)
                 .containsExactly(0.0),
             () -> assertThat(nearFootprints).extracting(FindNearFootprintResponse::longitude)
@@ -92,11 +97,9 @@ class FootprintQueryServiceTest {
             """, member.getId(), member.getId(), member.getId());
 
         List<FindNearFootprintResponse> nearFootprints = footprintQueryService.findNear(
-            new FindNearFootprintRequest(0.0, 0.0));
+            member.getId(), new FindNearFootprintRequest(0.0, 0.0));
 
         Assertions.assertAll(
-            () -> assertThat(nearFootprints).extracting(FindNearFootprintResponse::memberId)
-                .containsExactly(member.getId(), member.getId()),
             () -> assertThat(nearFootprints).extracting(FindNearFootprintResponse::latitude)
                 .containsExactly(0.00000, 0.00000),
             () -> assertThat(nearFootprints).extracting(FindNearFootprintResponse::longitude)


### PR DESCRIPTION
## 이슈
- #84 

## 개발 사항

- 발자국은 30초마다 찍을 수 있다.
- 발자국에 image url 필드 추가(일단은 이미지가 1장이라고 생각하고 구현)
- 자신이 마지막으로 발자국 찍은 시간 조회 API 구현
  - 안드로이드에서 오른쪽 아래 시간초(쿨타임)를 렌더링할 때 필요해요.

## 전달 사항
- 앨범 기능이 확정되고 나서 기능을 더 붙여야 할 것 같아요.
- 발자국에 이미지가 몇 장까지 가능한지 회의로 정해 보아요.
- AWS S3 연동 관련 코드가 완성되고 나면 이미지 업로드 관련 작업할게요.
- 아직 다른 기능이 완성되지 않아 작성하지 못한 코드는 주석을 남겨 놓았어요.
