### PR TITLE
[BE] fix: 배포가 안되는 버그 수정

### DIFF
--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           working-directory: ./backend
           name: friendogly-be-develop-jar
-          path: ./**/friendogly-0.0.1-SNAPSHOT.jar
+          path: ./build/libs/friendogly-0.0.1-SNAPSHOT.jar
           
   deploy:
     needs: build

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -2,7 +2,7 @@ name: deploy
 
 on:
   pull_request:
-    branches: [ "develop","fix/be/swagger-connection" ]
+    branches: [ "develop", "fix/be/swagger-connection" ]
   push:
     branches: ['develop']
      
@@ -60,9 +60,11 @@ jobs:
           echo "Checking if port 8080 is in use..."
           PID=$(lsof -t -i:8080 || true)
           if [ -n "$PID" ]; then
+            echo "Port 8080 is in use by process $PID."
             echo "server_running=true" >> $GITHUB_ENV
             echo "PID=$PID" >> $GITHUB_ENV
           else
+            echo "Port 8080 is not in use."
             echo "server_running=false" >> $GITHUB_ENV
           fi
 
@@ -73,9 +75,20 @@ jobs:
           kill -9 ${{ env.PID }}
           echo "Previous running Server stopped."
 
+      - name: Check if room-esc server is running on port 8080 after stop
+        run: |
+          PID=$(lsof -t -i:8080 || true)
+          if [ -n "$PID" ]; then
+            echo "Server is still running with PID: $PID"
+            exit 1
+          else
+            echo "Server successfully stopped."
+          fi
+
       - name: Start server
         run: |
           cd backend/build/libs
           ls -l friendogly-0.0.1-SNAPSHOT.jar
           sudo nohup java -jar friendogly-0.0.1-SNAPSHOT.jar > /dev/null 2>&1 &
           echo "Latest Backend API Server started."
+

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -32,7 +32,7 @@ jobs:
         
       - name: Build project using Gradle
         working-directory: ./backend
-        run: ./gradlew build
+        run: ./gradlew clean build
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -53,36 +53,10 @@ jobs:
           name: friendogly-be-develop-jar
           path: ./backend/build/libs
 
-      - name: List all running processes
-        run: |
-          echo "Listing all running processes..."
-          ps aux
-
-      - name: Find Java Application PID
+      - name: Find Java Application PID And Kill PID
         id: find_pid
         run: |
           sudo pgrep -f friendogly-0.0.1-SNAPSHOT.jar | xargs sudo kill -9 | true
-          
-      - name: Check if room-esc server is running on port 8080
-        id: check-server-on-port
-        run: |
-          echo "Checking if port 8080 is in use..."
-          PID=$(lsof -t -i:8080 || true)
-          if [ -n "$PID" ]; then
-            echo "Port 8080 is in use by process $PID."
-            echo "server_running=true" >> $GITHUB_ENV
-            echo "PID=$PID" >> $GITHUB_ENV
-          else
-            echo "Port 8080 is not in use."
-            echo "server_running=false" >> $GITHUB_ENV
-          fi
-
-      - name: Stop server if running
-        if: env.server_running == 'true'
-        run: |
-          echo "Stopping server running on port 8080..."
-          kill -9 ${{ env.PID }}
-          echo "Previous running Server stopped."
 
       - name: Check if room-esc server is running on port 8080 after stop
         run: |
@@ -97,6 +71,5 @@ jobs:
       - name: Start server
         run: |
           cd backend/build/libs
-          ls -l friendogly-0.0.1-SNAPSHOT.jar
-          sudo nohup java -jar friendogly-0.0.1-SNAPSHOT.jar > /dev/null 2>&1 &
-          echo "Latest Backend API Server started."
+          sudo nohup java -jar friendogly-0.0.1-SNAPSHOT.jar &
+          echo "start backend server"

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           working-directory: ./backend
           name: friendogly-be-develop-jar
-          path: ./build/libs/friendogly-0.0.1-SNAPSHOT.jar
+          path: ./backend/build/libs/friendogly-0.0.1-SNAPSHOT.jar
           
   deploy:
     needs: build

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -74,5 +74,7 @@ jobs:
       - name: Start server
         run: |
           cd backend/build/libs
+          cd backend/build/libs
+          ls -l friendogly-0.0.1-SNAPSHOT.jar
           sudo nohup java -jar friendogly-0.0.1-SNAPSHOT.jar &
           echo "Lastest Backend API Server started."

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -79,11 +79,11 @@ jobs:
 
       - name: Check if port 8080 
         run: |
-          lsof -t -i:8080
+          lsof -t -i:8080 | true
 
       - name: Check if port 80
         run: |
-          lsof -t -i:80
+          lsof -t -i:80 | true
           
       - name: Check if port 8080 is in use
         id: check-port
@@ -105,7 +105,7 @@ jobs:
       - name: Stop server if running
         run: |
           echo "Stopping server running on port 8080..."
-          kill -9 ${{ env.PORT_8080_PID }}
+          kill -9 ${{ env.PORT_8080_PID }} | true
           echo "Preivous running Server stopped."
           
       - name: Start server

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -36,9 +36,8 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v3
         with:
-          working-directory: ./backend
           name: friendogly-be-develop-jar
-          path: ./**/friendogly-0.0.1-SNAPSHOT.jar
+          path: ./backend/build/libs/friendogly-0.0.1-SNAPSHOT.jar
           
   deploy:
     needs: build
@@ -53,6 +52,11 @@ jobs:
         with:
           name: friendogly-be-develop-jar
           path: ./backend/build/libs
+
+      - name: List all running processes
+        run: |
+          echo "Listing all running processes..."
+          ps aux
 
       - name: Check if room-esc server is running on port 8080
         id: check-server-on-port
@@ -91,4 +95,3 @@ jobs:
           ls -l friendogly-0.0.1-SNAPSHOT.jar
           sudo nohup java -jar friendogly-0.0.1-SNAPSHOT.jar > /dev/null 2>&1 &
           echo "Latest Backend API Server started."
-

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -61,16 +61,7 @@ jobs:
       - name: Find Java Application PID
         id: find_pid
         run: |
-          pgrep -f friendogly-0.0.1-SNAPSHOT.jar
-          lsof -Pan -p 20012 | grep LISTEN
-          lsof -Pan -p 20013 | grep LISTEN
-          lsof -Pan -p 20014 | grep LISTEN
-          
-      - name: Find Java Application PID
-        run: |
-          lsof -Pan -p 20012 | grep LISTEN
-          lsof -Pan -p 20013 | grep LISTEN
-          lsof -Pan -p 20014 | grep LISTEN
+          pgrep -f friendogly-0.0.1-SNAPSHOT.jar | xargs kill -9
           
       - name: Check if room-esc server is running on port 8080
         id: check-server-on-port

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Find Java Application PID
         id: find_pid
         run: |
-          sudo pgrep -f friendogly-0.0.1-SNAPSHOT.jar | xargs sudo kill -9
+          sudo pgrep -f friendogly-0.0.1-SNAPSHOT.jar | xargs sudo kill -9 | true
           
       - name: Check if room-esc server is running on port 8080
         id: check-server-on-port

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -34,6 +34,15 @@ jobs:
         working-directory: ./backend
         run: ./gradlew clean build
 
+
+      - name: 디렉토리 경로 확인
+        working-directory: ./backend
+        run: pwd
+
+      - name: 파일 경로 찾기
+        working-directory: ./backend
+        run: find . -name "friendogly-0.0.1-SNAPSHOT.jar"
+        
       - name: Upload build artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -65,6 +65,10 @@ jobs:
       - name: change permission
         run: |
           sudo chown -R ubuntu:ubuntu /home/ubuntu/actions-runner/_work/2024-friendogly 
+      - name: change permission
+        run: |
+          cd ./backend/build/libs
+          rm -rf friendogly-be-develop-jar
       - name: Download build artifact
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -89,7 +89,6 @@ jobs:
             echo "server_running=false" >> $GITHUB_ENV
           fi
       - name: Stop server if running
-        if: env.server_running == 'true'
         run: |
           echo "Stopping server running on port 8080..."
           kill -9 ${{ env.PID }}

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -65,10 +65,9 @@ jobs:
       - name: change permission
         run: |
           sudo chown -R ubuntu:ubuntu /home/ubuntu/actions-runner/_work/2024-friendogly 
-      - name: change permission
+      - name: 기존 jar 삭제
         run: |
-          cd ./backend/build/libs
-          rm -rf friendogly-be-develop-jar
+          rm -rf ./backend/build/libsfriendogly-be-develop-jar
       - name: Download build artifact
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -91,7 +91,6 @@ jobs:
       - name: Start server
         run: |
           cd backend/build/libs
-          cd backend/build/libs
           ls -l friendogly-0.0.1-SNAPSHOT.jar
           sudo nohup java -jar friendogly-0.0.1-SNAPSHOT.jar &
           echo "Lastest Backend API Server started."

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -1,10 +1,10 @@
 name: deploy
 
 on:
-  pull_request:
-    branches: [ "develop", "fix/be/swagger-connection" ]
   push:
     branches: ['develop']
+    paths: 
+      - 'backend/**'
      
 jobs:
   build:

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -32,7 +32,7 @@ jobs:
         
       - name: Build project using Gradle
         working-directory: ./backend
-        run: ./gradlew clean build
+        run: ./gradlew bootJar
 
 
       - name: 디렉토리 경로 확인
@@ -42,6 +42,14 @@ jobs:
       - name: 파일 경로 찾기
         working-directory: ./backend
         run: find . -name "friendogly-0.0.1-SNAPSHOT.jar"
+
+      - name: 경로 이동
+        working-directory: ./backend
+        run: |
+          cd build/libs
+          pwd
+          ls
+          ls -l friendogly-0.0.1-SNAPSHOT.jar
         
       - name: Upload build artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -92,7 +92,7 @@ jobs:
         if: env.server_running == 'true'
         run: |
           echo "Stopping server running on port 8080..."
-          kill -9 $PID
+          kill -9 ${{ env.PID }}
           echo "Preivous running Server stopped."
       - name: Start server
         run: |

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -77,22 +77,29 @@ jobs:
           name: friendogly-be-develop-jar
           path: ./backend/build/libs
 
-      - name: Check if room-esc server is running on port 8080
-        id: check-server-on-port
+      - name: Check if port 8080 is in use
+        id: check-port
         run: |
-          echo "Checking if port 8080 is in use..."
+          # Find the PID of the process using port 8080
           PID=$(lsof -t -i:8080 || true)
+          
+          # Check if PID is non-empty
           if [ -n "$PID" ]; then
-            echo "server_running=true" >> $GITHUB_ENV
-            echo "PID=$PID" >> $GITHUB_ENV
+            echo "PORT_8080_PID=$PID" >> $GITHUB_ENV
           else
-            echo "server_running=false" >> $GITHUB_ENV
+            echo "PORT_8080_PID=none" >> $GITHUB_ENV
           fi
+
+      - name: Debug environment variables
+        run: |
+          echo "PORT_8080_PID=${{ env.PORT_8080_PID }}"
+          
       - name: Stop server if running
         run: |
           echo "Stopping server running on port 8080..."
-          kill -9 ${{ env.PID }}
+          kill -9 ${{ env.PORT_8080_PID }}
           echo "Preivous running Server stopped."
+          
       - name: Start server
         run: |
           cd backend/build/libs

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -43,6 +43,9 @@ jobs:
         working-directory: ./backend
         run: find . -name "friendogly-0.0.1-SNAPSHOT.jar"
 
+      - name: GlobalExceptionHandler 내용 확인
+        run: cat ./backend/src/main/java/com/woowacourse/friendogly/GlobalExceptionHandler.java
+        
       - name: 경로 이동
         working-directory: ./backend
         run: |

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Find Java Application PID
         id: find_pid
         run: |
-          pgrep -f friendogly-0.0.1-SNAPSHOT.jar | xargs kill -9
+          sudo pgrep -f friendogly-0.0.1-SNAPSHOT.jar | xargs sudo kill -9
           
       - name: Check if room-esc server is running on port 8080
         id: check-server-on-port

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -62,6 +62,15 @@ jobs:
         id: find_pid
         run: |
           pgrep -f friendogly-0.0.1-SNAPSHOT.jar
+          lsof -Pan -p 20012 | grep LISTEN
+          lsof -Pan -p 20013 | grep LISTEN
+          lsof -Pan -p 20014 | grep LISTEN
+          
+      - name: Find Java Application PID
+        run: |
+          lsof -Pan -p 20012 | grep LISTEN
+          lsof -Pan -p 20013 | grep LISTEN
+          lsof -Pan -p 20014 | grep LISTEN
           
       - name: Check if room-esc server is running on port 8080
         id: check-server-on-port

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -58,6 +58,30 @@ jobs:
           echo "Listing all running processes..."
           ps aux
 
+      - name: Find Java Application PID
+        id: find_pid
+        run: |
+          echo "Finding Java application PID..."
+          PIDS=$(pgrep -f friendogly-0.0.1-SNAPSHOT.jar)
+          if [ -z "$PIDS" ]; then
+            echo "ERROR: Java application is not running."
+            exit 1
+          fi
+          echo "PIDS=$PIDS" >> $GITHUB_ENV
+
+      - name: Check ports for each PID
+        run: |
+          echo "Checking ports for PIDs..."
+          for PID in ${{ env.PIDS }}; do
+            echo "Checking PID $PID..."
+            PORTS=$(sudo lsof -Pan -p $PID -i | grep LISTEN | awk '{print $9}' | cut -d: -f2)
+            if [ -z "$PORTS" ]; then
+              echo "PID $PID: No ports found."
+            else
+              echo "PID $PID: Ports - $PORTS"
+            fi
+          done
+          
       - name: Check if room-esc server is running on port 8080
         id: check-server-on-port
         run: |

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -74,6 +74,5 @@ jobs:
       - name: Start server
         run: |
           cd backend/build/libs
-          cd backend/build/libs
           sudo nohup java -jar friendogly-0.0.1-SNAPSHOT.jar &
           echo "Lastest Backend API Server started."

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -61,26 +61,7 @@ jobs:
       - name: Find Java Application PID
         id: find_pid
         run: |
-          echo "Finding Java application PID..."
-          PIDS=$(pgrep -f friendogly-0.0.1-SNAPSHOT.jar)
-          if [ -z "$PIDS" ]; then
-            echo "ERROR: Java application is not running."
-            exit 1
-          fi
-          echo "PIDS=$PIDS" >> $GITHUB_ENV
-
-      - name: Check ports for each PID
-        run: |
-          echo "Checking ports for PIDs..."
-          for PID in ${{ env.PIDS }}; do
-            echo "Checking PID $PID..."
-            PORTS=$(sudo lsof -Pan -p $PID -i | grep LISTEN | awk '{print $9}' | cut -d: -f2)
-            if [ -z "$PORTS" ]; then
-              echo "PID $PID: No ports found."
-            else
-              echo "PID $PID: Ports - $PORTS"
-            fi
-          done
+          pgrep -f friendogly-0.0.1-SNAPSHOT.jar
           
       - name: Check if room-esc server is running on port 8080
         id: check-server-on-port

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -71,5 +71,7 @@ jobs:
       - name: Start server
         run: |
           cd backend/build/libs
+          echo "File creation time(KR-09:00):"
+          ls -l --time=ctime friendogly-0.0.1-SNAPSHOT.jar
           sudo nohup java -jar friendogly-0.0.1-SNAPSHOT.jar &
           echo "start backend server"

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches: ['develop']
      
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -32,89 +31,51 @@ jobs:
         
       - name: Build project using Gradle
         working-directory: ./backend
-        run: ./gradlew bootJar
+        run: ./gradlew build
 
-
-      - name: 디렉토리 경로 확인
-        working-directory: ./backend
-        run: pwd
-
-      - name: 파일 경로 찾기
-        working-directory: ./backend
-        run: find . -name "friendogly-0.0.1-SNAPSHOT.jar"
-
-      - name: GlobalExceptionHandler 내용 확인
-        run: cat ./backend/src/main/java/com/woowacourse/friendogly/GlobalExceptionHandler.java
-        
-      - name: 경로 이동
-        working-directory: ./backend
-        run: |
-          cd build/libs
-          pwd
-          ls
-          ls -l friendogly-0.0.1-SNAPSHOT.jar
-        
       - name: Upload build artifact
         uses: actions/upload-artifact@v3
         with:
           working-directory: ./backend
           name: friendogly-be-develop-jar
-          path: ./backend/build/libs/friendogly-0.0.1-SNAPSHOT.jar
+          path: ./**/friendogly-0.0.1-SNAPSHOT.jar
           
   deploy:
     needs: build
     runs-on: self-hosted
     steps:
-      - name: change permission
+      - name: Change permission
         run: |
           sudo chown -R ubuntu:ubuntu /home/ubuntu/actions-runner/_work/2024-friendogly 
-      - name: 기존 jar 삭제
-        run: |
-          rm -rf ./backend/build/libsfriendogly-be-develop-jar
+
       - name: Download build artifact
         uses: actions/download-artifact@v3
         with:
           name: friendogly-be-develop-jar
           path: ./backend/build/libs
 
-      - name: Check if port 8080 
+      - name: Check if room-esc server is running on port 8080
+        id: check-server-on-port
         run: |
-          lsof -t -i:8080 | true
-
-      - name: Check if port 80
-        run: |
-          lsof -t -i:80 | true
-
-      - name: Check java jar port
-        run: |
-          lsof -c java | grep friendogly-0.0.1-SNAPSHOT.jar
-          
-      - name: Check if port 8080 is in use
-        id: check-port
-        run: |
-          # Find the PID of the process using port 8080
+          echo "Checking if port 8080 is in use..."
           PID=$(lsof -t -i:8080 || true)
-          
-          # Check if PID is non-empty
           if [ -n "$PID" ]; then
-            echo "PORT_8080_PID=$PID" >> $GITHUB_ENV
+            echo "server_running=true" >> $GITHUB_ENV
+            echo "PID=$PID" >> $GITHUB_ENV
           else
-            echo "PORT_8080_PID=none" >> $GITHUB_ENV
+            echo "server_running=false" >> $GITHUB_ENV
           fi
 
-      - name: Debug environment variables
-        run: |
-          echo "PORT_8080_PID=${{ env.PORT_8080_PID }}"
-          
       - name: Stop server if running
+        if: env.server_running == 'true'
         run: |
           echo "Stopping server running on port 8080..."
-          kill -9 ${{ env.PORT_8080_PID }} | true
-          echo "Preivous running Server stopped."
-          
+          kill -9 ${{ env.PID }}
+          echo "Previous running Server stopped."
+
       - name: Start server
         run: |
           cd backend/build/libs
           ls -l friendogly-0.0.1-SNAPSHOT.jar
-          sudo nohup java -jar friendogly-0.0.1-SNAPSHOT.jar &
-          echo "Lastest Backend API Server started."
+          sudo nohup java -jar friendogly-0.0.1-SNAPSHOT.jar > /dev/null 2>&1 &
+          echo "Latest Backend API Server started."

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -84,6 +84,10 @@ jobs:
       - name: Check if port 80
         run: |
           lsof -t -i:80 | true
+
+      - name: Check java jar port
+        run: |
+          lsof -c java | grep friendogly-0.0.1-SNAPSHOT.jar
           
       - name: Check if port 8080 is in use
         id: check-port

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -1,10 +1,11 @@
 name: deploy
 
 on:
+  pull_request:
+    branches: [ "develop","fix/be/swagger-connection" ]
   push:
     branches: ['develop']
-    paths:
-     - 'backend/**'
+     
 
 jobs:
   build:

--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -77,6 +77,14 @@ jobs:
           name: friendogly-be-develop-jar
           path: ./backend/build/libs
 
+      - name: Check if port 8080 
+        run: |
+          lsof -t -i:8080
+
+      - name: Check if port 80
+        run: |
+          lsof -t -i:80
+          
       - name: Check if port 8080 is in use
         id: check-port
         run: |

--- a/backend/src/main/java/com/woowacourse/friendogly/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/GlobalExceptionHandler.java
@@ -40,6 +40,6 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<String> handle(Exception exception) {
-        return new ResponseEntity<>("예기치 못한 예외가 발생하였습니다. 다시 실행해주세요.", HttpStatus.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(exception.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }


### PR DESCRIPTION
## 이슈
- #139 

## 개발 사항
- 8080 port를 종료 못하는 버그 수정
  - 8080종료가 아닌 friendogly-0.0.1-SNAPSHOT.jar를 가진 프로세스를 종료하도록 변경
- friendogly 자바 어플리케이션이 여러개 실행중이던 버그 수정 
- 500에러를 전역핸들러에서 exception.getMessage()를 반환하도록 임시변경(캠퍼스가 아닌 밖에서도 이유를 보기위함)

