### PR TITLE
[BE] 발자국 단건 조회 API 구현, 주변 발자국 조회 API 명세 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
@@ -5,6 +5,7 @@ import com.woowacourse.friendogly.footprint.dto.request.SaveFootprintRequest;
 import com.woowacourse.friendogly.footprint.dto.request.UpdateFootprintImageRequest;
 import com.woowacourse.friendogly.footprint.dto.response.FindMyLatestFootprintTimeResponse;
 import com.woowacourse.friendogly.footprint.dto.response.FindNearFootprintResponse;
+import com.woowacourse.friendogly.footprint.dto.response.FindOneFootprintResponse;
 import com.woowacourse.friendogly.footprint.dto.response.UpdateFootprintImageResponse;
 import com.woowacourse.friendogly.footprint.service.FootprintCommandService;
 import com.woowacourse.friendogly.footprint.service.FootprintQueryService;
@@ -41,6 +42,12 @@ public class FootprintController {
         Long id = footprintCommandService.save(request);
         return ResponseEntity.created(URI.create("/footprints/" + id))
             .build();
+    }
+
+    @GetMapping("/{footprintId}")
+    public ResponseEntity<FindOneFootprintResponse> findOne(@PathVariable Long footprintId) {
+        FindOneFootprintResponse response = footprintQueryService.findOne(footprintId);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/near")

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindNearFootprintResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindNearFootprintResponse.java
@@ -10,7 +10,8 @@ public record FindNearFootprintResponse(
     double longitude,
     // TODO: 패턴을 통일시키고 나서 어노테이션 지우기
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
-    boolean isMine
+    boolean isMine,
+    String imageUrl
 ) {
 
     public FindNearFootprintResponse(Footprint footprint, boolean isMine) {
@@ -19,7 +20,8 @@ public record FindNearFootprintResponse(
             footprint.getLocation().getLatitude(),
             footprint.getLocation().getLongitude(),
             footprint.getCreatedAt(),
-            isMine
+            isMine,
+            footprint.getImageUrl()
         );
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindOneFootprintResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindOneFootprintResponse.java
@@ -1,0 +1,43 @@
+package com.woowacourse.friendogly.footprint.dto.response;
+
+import com.woowacourse.friendogly.footprint.domain.Footprint;
+import com.woowacourse.friendogly.member.domain.Member;
+import com.woowacourse.friendogly.pet.domain.Gender;
+import com.woowacourse.friendogly.pet.domain.Pet;
+import com.woowacourse.friendogly.pet.domain.SizeType;
+import java.time.LocalDate;
+
+public record FindOneFootprintResponse(
+    String memberName,
+    String petName,
+    String petDescription,
+    LocalDate petBirthDate,
+    SizeType petSizeType,
+    Gender petGender,
+    String footprintImageUrl
+) {
+
+    public FindOneFootprintResponse(Member member, Footprint footprint) {
+        this(
+            member.getName(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            footprint.getImageUrl()
+        );
+    }
+
+    public FindOneFootprintResponse(Member member, Pet mainPet, Footprint footprint) {
+        this(
+            member.getName(),
+            mainPet.getName().getValue(),
+            mainPet.getDescription().getValue(),
+            mainPet.getBirthDate().getValue(),
+            mainPet.getSizeType(),
+            mainPet.getGender(),
+            footprint.getImageUrl()
+        );
+    }
+}

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintQueryService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintQueryService.java
@@ -1,11 +1,16 @@
 package com.woowacourse.friendogly.footprint.service;
 
+import com.woowacourse.friendogly.exception.FriendoglyException;
 import com.woowacourse.friendogly.footprint.domain.Footprint;
 import com.woowacourse.friendogly.footprint.domain.Location;
 import com.woowacourse.friendogly.footprint.dto.request.FindNearFootprintRequest;
 import com.woowacourse.friendogly.footprint.dto.response.FindMyLatestFootprintTimeResponse;
 import com.woowacourse.friendogly.footprint.dto.response.FindNearFootprintResponse;
+import com.woowacourse.friendogly.footprint.dto.response.FindOneFootprintResponse;
 import com.woowacourse.friendogly.footprint.repository.FootprintRepository;
+import com.woowacourse.friendogly.member.domain.Member;
+import com.woowacourse.friendogly.pet.domain.Pet;
+import com.woowacourse.friendogly.pet.repository.PetRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -18,9 +23,28 @@ public class FootprintQueryService {
     private static final int FOOTPRINT_DURATION_HOURS = 24;
 
     private final FootprintRepository footprintRepository;
+    private final PetRepository petRepository;
 
-    public FootprintQueryService(FootprintRepository footprintRepository) {
+    public FootprintQueryService(
+        FootprintRepository footprintRepository,
+        PetRepository petRepository
+    ) {
         this.footprintRepository = footprintRepository;
+        this.petRepository = petRepository;
+    }
+
+    public FindOneFootprintResponse findOne(Long footprintId) {
+        Footprint footprint = footprintRepository.findById(footprintId)
+            .orElseThrow(() -> new FriendoglyException("존재하지 않는 Footprint ID입니다."));
+        Member member = footprint.getMember();
+        List<Pet> pets = petRepository.findByMemberId(member.getId());
+
+        if (pets.isEmpty()) {
+            return new FindOneFootprintResponse(member, footprint);
+        }
+
+        // TODO: 대표 펫을 지정하는 기능이 없어서, 임시로 0번째 index의 pet 리턴
+        return new FindOneFootprintResponse(member, pets.get(0), footprint);
     }
 
     public List<FindNearFootprintResponse> findNear(Long memberId, FindNearFootprintRequest request) {

--- a/backend/src/test/java/com/woowacourse/friendogly/docs/FootprintApiDocsTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/docs/FootprintApiDocsTest.java
@@ -81,13 +81,13 @@ public class FootprintApiDocsTest extends RestDocsTest {
         FindNearFootprintRequest request = new FindNearFootprintRequest(37.5173316, 127.1011661);
         List<FindNearFootprintResponse> response = List.of(
             new FindNearFootprintResponse(
-                1L, 37.5136533, 127.0983182, LocalDateTime.now().minusMinutes(10), true),
+                1L, 37.5136533, 127.0983182, LocalDateTime.now().minusMinutes(10), true, "https://picsum.photos/200"),
             new FindNearFootprintResponse(
-                3L, 37.5131474, 127.1042528, LocalDateTime.now().minusMinutes(20), false),
+                3L, 37.5131474, 127.1042528, LocalDateTime.now().minusMinutes(20), false, ""),
             new FindNearFootprintResponse(
-                6L, 37.5171728, 127.1047797, LocalDateTime.now().minusMinutes(30), false),
+                6L, 37.5171728, 127.1047797, LocalDateTime.now().minusMinutes(30), false, "https://picsum.photos/300"),
             new FindNearFootprintResponse(
-                11L, 37.516183, 127.1068874, LocalDateTime.now().minusMinutes(40), true)
+                11L, 37.516183, 127.1068874, LocalDateTime.now().minusMinutes(40), true, "https://picsum.photos/250")
         );
 
         given(footprintQueryService.findNear(any(Long.class), eq(request)))
@@ -113,7 +113,8 @@ public class FootprintApiDocsTest extends RestDocsTest {
                         fieldWithPath("[].latitude").description("발자국 위치의 위도"),
                         fieldWithPath("[].longitude").description("발자국 위치의 경도"),
                         fieldWithPath("[].createdAt").description("발자국 생성 시간"),
-                        fieldWithPath("[].isMine").description("나의 발자국인지 여부")
+                        fieldWithPath("[].isMine").description("나의 발자국인지 여부"),
+                        fieldWithPath("[].imageUrl").description("발자국에 할당된 이미지 URL")
                     )
                     .build()
                 )


### PR DESCRIPTION
## 이슈
- #124
- #125 

## 개발 사항
- 발자국 ID를 통해 발자국 정보를 받는 API 구현
- 주변 발자국 조회 API에서 imageUrl도 같이 받아오도록 수정

## 리뷰 요청 사항
- 키우는 강아지가 없는 경우 강아지에 대한 정보를 null로 반환하도록 했는데요. 더 좋은 방법이 없을까요?