### PR TITLE
[BE] feat: 회원 및 강아지 검증 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/friendogly/member/domain/Email.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/member/domain/Email.java
@@ -1,0 +1,41 @@
+package com.woowacourse.friendogly.member.domain;
+
+import com.woowacourse.friendogly.exception.FriendoglyException;
+import io.micrometer.common.util.StringUtils;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.regex.Pattern;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Email {
+
+    private static final Pattern VALID_EMAIL_ADDRESS_REGEX =
+            Pattern.compile("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$");
+
+    @Column(name = "email", nullable = false)
+    private String value;
+
+    public Email(String value) {
+        validateBlank(value);
+        validateFormat(value);
+        this.value = value;
+    }
+
+    private void validateBlank(String value) {
+        if (StringUtils.isBlank(value)) {
+            throw new FriendoglyException("이메일은 빈 값이나 null일 수 없습니다.");
+        }
+    }
+
+    private void validateFormat(String value) {
+        if (!VALID_EMAIL_ADDRESS_REGEX.matcher(value).matches()) {
+            throw new FriendoglyException("올바른 이메일 형식이 아닙니다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/woowacourse/friendogly/member/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/member/domain/Member.java
@@ -1,14 +1,19 @@
 package com.woowacourse.friendogly.member.domain;
 
+import com.woowacourse.friendogly.pet.domain.Pet;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -19,6 +24,9 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @OneToMany(mappedBy = "member")
+    private List<Pet> pets;
+
     @Embedded
     private Name name;
 
@@ -27,6 +35,7 @@ public class Member {
 
     @Builder
     public Member(String name, String email) {
+        this.pets = new ArrayList<>();
         this.name = new Name(name);
         this.email = new Email(email);
     }

--- a/backend/src/main/java/com/woowacourse/friendogly/member/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.woowacourse.friendogly.member.domain;
 
+import com.woowacourse.friendogly.exception.FriendoglyException;
 import com.woowacourse.friendogly.pet.domain.Pet;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -20,6 +21,8 @@ import java.util.List;
 @Getter
 public class Member {
 
+    private static final int MAX_PET_CAPACITY = 5;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -38,5 +41,12 @@ public class Member {
         this.pets = new ArrayList<>();
         this.name = new Name(name);
         this.email = new Email(email);
+    }
+
+    public void validatePetCapacity() {
+        if (MAX_PET_CAPACITY <= this.pets.size()) {
+            throw new FriendoglyException(String.format(
+                    "강아지는 최대 %d 마리까지만 등록할 수 있습니다.", MAX_PET_CAPACITY));
+        }
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/member/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/member/domain/Member.java
@@ -46,7 +46,13 @@ public class Member {
         this.email = new Email(email);
     }
 
-    public void validatePetCapacity() {
+    public void addPet(Pet pet) {
+        validatePetCapacity();
+        pet.updateMember(this);
+        this.pets.add(pet);
+    }
+
+    private void validatePetCapacity() {
         if (MAX_PET_CAPACITY <= this.pets.size()) {
             throw new FriendoglyException(String.format(
                     "강아지는 최대 %d 마리까지만 등록할 수 있습니다.", MAX_PET_CAPACITY));

--- a/backend/src/main/java/com/woowacourse/friendogly/member/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/member/domain/Member.java
@@ -1,52 +1,33 @@
 package com.woowacourse.friendogly.member.domain;
 
-import com.woowacourse.friendogly.exception.FriendoglyException;
-import io.micrometer.common.util.StringUtils;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class Member {
-
-    private static final int MAX_NAME_LENGTH = 15;
-    private static final Pattern VALID_EMAIL_ADDRESS_REGEX =
-            Pattern.compile("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$");
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String name;
+    @Embedded
+    private Name name;
 
-    private String email;
+    @Embedded
+    private Email email;
 
     @Builder
     public Member(String name, String email) {
-        validateName(name);
-        validateEmail(email);
-
-        this.name = name;
-        this.email = email;
-    }
-
-    private void validateName(String value) {
-        if (StringUtils.isBlank(value) || value.length() > MAX_NAME_LENGTH) {
-            throw new FriendoglyException("올바른 이름 형식이 아닙니다.");
-        }
-    }
-
-    private void validateEmail(String value) {
-        if (StringUtils.isBlank(value) || !VALID_EMAIL_ADDRESS_REGEX.matcher(value).matches()) {
-            throw new FriendoglyException("올바른 이메일 형식이 아닙니다.");
-        }
+        this.name = new Name(name);
+        this.email = new Email(email);
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/member/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/member/domain/Member.java
@@ -33,13 +33,16 @@ public class Member {
     @Embedded
     private Name name;
 
+    private String tag;
+
     @Embedded
     private Email email;
 
     @Builder
-    public Member(String name, String email) {
+    public Member(String name, String tag, String email) {
         this.pets = new ArrayList<>();
         this.name = new Name(name);
+        this.tag = tag;
         this.email = new Email(email);
     }
 

--- a/backend/src/main/java/com/woowacourse/friendogly/member/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/member/domain/Member.java
@@ -1,34 +1,23 @@
 package com.woowacourse.friendogly.member.domain;
 
-import com.woowacourse.friendogly.exception.FriendoglyException;
-import com.woowacourse.friendogly.pet.domain.Pet;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Member {
 
-    private static final int MAX_PET_CAPACITY = 5;
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @OneToMany(mappedBy = "member")
-    private List<Pet> pets;
 
     @Embedded
     private Name name;
@@ -40,22 +29,8 @@ public class Member {
 
     @Builder
     public Member(String name, String tag, String email) {
-        this.pets = new ArrayList<>();
         this.name = new Name(name);
         this.tag = tag;
         this.email = new Email(email);
-    }
-
-    public void addPet(Pet pet) {
-        validatePetCapacity();
-        pet.updateMember(this);
-        this.pets.add(pet);
-    }
-
-    private void validatePetCapacity() {
-        if (MAX_PET_CAPACITY <= this.pets.size()) {
-            throw new FriendoglyException(String.format(
-                    "강아지는 최대 %d 마리까지만 등록할 수 있습니다.", MAX_PET_CAPACITY));
-        }
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/member/domain/Name.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/member/domain/Name.java
@@ -1,0 +1,40 @@
+package com.woowacourse.friendogly.member.domain;
+
+import com.woowacourse.friendogly.exception.FriendoglyException;
+import io.micrometer.common.util.StringUtils;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Name {
+
+    private static final int MIN_NAME_LENGTH = 1;
+    private static final int MAX_NAME_LENGTH = 15;
+
+    @Column(name = "name", nullable = false)
+    private String value;
+
+    public Name(String value) {
+        validateBlank(value);
+        validateNameLength(value);
+        this.value = value;
+    }
+
+    private void validateBlank(String value) {
+        if (StringUtils.isBlank(value)) {
+            throw new FriendoglyException("이름은 빈 값이나 null일 수 없습니다.");
+        }
+    }
+
+    private void validateNameLength(String value) {
+        if (value.length() < MIN_NAME_LENGTH || value.length() > MAX_NAME_LENGTH) {
+            throw new FriendoglyException(String.format(
+                    "이름은 %d자 이상, %d자 이하여야 합니다.", MIN_NAME_LENGTH, MAX_NAME_LENGTH));
+        }
+    }
+}

--- a/backend/src/main/java/com/woowacourse/friendogly/member/dto/response/SaveMemberResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/member/dto/response/SaveMemberResponse.java
@@ -5,6 +5,6 @@ import com.woowacourse.friendogly.member.domain.Member;
 public record SaveMemberResponse(Long id, String name, String email) {
 
     public SaveMemberResponse(Member member) {
-        this(member.getId(), member.getName(), member.getEmail());
+        this(member.getId(), member.getName().getValue(), member.getEmail().getValue());
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/member/dto/response/SaveMemberResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/member/dto/response/SaveMemberResponse.java
@@ -2,9 +2,14 @@ package com.woowacourse.friendogly.member.dto.response;
 
 import com.woowacourse.friendogly.member.domain.Member;
 
-public record SaveMemberResponse(Long id, String name, String email) {
+public record SaveMemberResponse(Long id, String name, String tag, String email) {
 
     public SaveMemberResponse(Member member) {
-        this(member.getId(), member.getName().getValue(), member.getEmail().getValue());
+        this(
+                member.getId(),
+                member.getName().getValue(),
+                member.getTag(),
+                member.getEmail().getValue()
+        );
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/member/service/MemberCommandService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/member/service/MemberCommandService.java
@@ -4,6 +4,7 @@ import com.woowacourse.friendogly.member.domain.Member;
 import com.woowacourse.friendogly.member.dto.request.SaveMemberRequest;
 import com.woowacourse.friendogly.member.dto.response.SaveMemberResponse;
 import com.woowacourse.friendogly.member.repository.MemberRepository;
+import com.woowacourse.friendogly.utils.UuidGenerator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +21,7 @@ public class MemberCommandService {
     public SaveMemberResponse saveMember(SaveMemberRequest request) {
         Member member = Member.builder()
                 .name(request.name())
+                .tag(UuidGenerator.generateUuid())
                 .email(request.email())
                 .build();
         Member savedMember = memberRepository.save(member);

--- a/backend/src/main/java/com/woowacourse/friendogly/pet/domain/Pet.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/pet/domain/Pet.java
@@ -1,5 +1,6 @@
 package com.woowacourse.friendogly.pet.domain;
 
+import com.woowacourse.friendogly.exception.FriendoglyException;
 import com.woowacourse.friendogly.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -61,6 +62,8 @@ public class Pet {
             Gender gender,
             String imageUrl
     ) {
+        validateMember(member);
+        
         this.member = member;
         this.name = new Name(name);
         this.description = new Description(description);
@@ -70,7 +73,9 @@ public class Pet {
         this.imageUrl = new ImageUrl(imageUrl);
     }
 
-    public void updateMember(Member member) {
-        this.member = member;
+    private void validateMember(Member member) {
+        if (member == null) {
+            throw new FriendoglyException("member는 null일 수 없습니다.");
+        }
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/pet/domain/Pet.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/pet/domain/Pet.java
@@ -1,6 +1,5 @@
 package com.woowacourse.friendogly.pet.domain;
 
-import com.woowacourse.friendogly.exception.FriendoglyException;
 import com.woowacourse.friendogly.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -12,11 +11,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
 
 @Entity
 @Getter
@@ -61,8 +61,6 @@ public class Pet {
             Gender gender,
             String imageUrl
     ) {
-        validateMember(member);
-
         this.member = member;
         this.name = new Name(name);
         this.description = new Description(description);
@@ -72,9 +70,7 @@ public class Pet {
         this.imageUrl = new ImageUrl(imageUrl);
     }
 
-    private void validateMember(Member member) {
-        if (member == null) {
-            throw new FriendoglyException("member는 null일 수 없습니다.");
-        }
+    public void updateMember(Member member) {
+        this.member = member;
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/pet/dto/request/SavePetRequest.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/pet/dto/request/SavePetRequest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.friendogly.pet.dto.request;
 
+import com.woowacourse.friendogly.member.domain.Member;
 import com.woowacourse.friendogly.pet.domain.Gender;
 import com.woowacourse.friendogly.pet.domain.Pet;
 import com.woowacourse.friendogly.pet.domain.SizeType;
@@ -39,8 +40,9 @@ public record SavePetRequest(
         String imageUrl
 ) {
 
-    public Pet toEntity() {
+    public Pet toEntity(Member member) {
         return Pet.builder()
+                .member(member)
                 .name(name)
                 .description(description)
                 .birthDate(birthDate)

--- a/backend/src/main/java/com/woowacourse/friendogly/pet/dto/request/SavePetRequest.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/pet/dto/request/SavePetRequest.java
@@ -1,6 +1,5 @@
 package com.woowacourse.friendogly.pet.dto.request;
 
-import com.woowacourse.friendogly.member.domain.Member;
 import com.woowacourse.friendogly.pet.domain.Gender;
 import com.woowacourse.friendogly.pet.domain.Pet;
 import com.woowacourse.friendogly.pet.domain.SizeType;
@@ -9,8 +8,9 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PastOrPresent;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
-import java.time.LocalDate;
 import org.hibernate.validator.constraints.URL;
+
+import java.time.LocalDate;
 
 public record SavePetRequest(
         @NotNull(message = "memberId는 null을 입력할 수 없습니다.")
@@ -38,9 +38,9 @@ public record SavePetRequest(
         @URL
         String imageUrl
 ) {
-    public Pet toEntity(Member member) {
+
+    public Pet toEntity() {
         return Pet.builder()
-                .member(member)
                 .name(name)
                 .description(description)
                 .birthDate(birthDate)

--- a/backend/src/main/java/com/woowacourse/friendogly/pet/repository/PetRepository.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/pet/repository/PetRepository.java
@@ -1,10 +1,14 @@
 package com.woowacourse.friendogly.pet.repository;
 
+import com.woowacourse.friendogly.member.domain.Member;
 import com.woowacourse.friendogly.pet.domain.Pet;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PetRepository extends JpaRepository<Pet, Long> {
+
+    Long countByMember(Member member);
 
     List<Pet> findByMemberId(Long memberId);
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/pet/service/PetCommandService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/pet/service/PetCommandService.java
@@ -26,9 +26,8 @@ public class PetCommandService {
         Member member = memberRepository.findById(request.memberId())
                 .orElseThrow(() -> new FriendoglyException("존재하지 않는 Member 입니다."));
 
-        member.validatePetCapacity();
-
-        Pet pet = request.toEntity(member);
+        Pet pet = request.toEntity();
+        member.addPet(pet);
         Pet savedPet = petRepository.save(pet);
 
         return new SavePetResponse(savedPet);

--- a/backend/src/main/java/com/woowacourse/friendogly/pet/service/PetCommandService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/pet/service/PetCommandService.java
@@ -25,6 +25,9 @@ public class PetCommandService {
     public SavePetResponse savePet(SavePetRequest request) {
         Member member = memberRepository.findById(request.memberId())
                 .orElseThrow(() -> new FriendoglyException("존재하지 않는 Member 입니다."));
+
+        member.validatePetCapacity();
+
         Pet pet = request.toEntity(member);
         Pet savedPet = petRepository.save(pet);
 

--- a/backend/src/main/java/com/woowacourse/friendogly/pet/service/PetCommandService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/pet/service/PetCommandService.java
@@ -14,6 +14,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class PetCommandService {
 
+    private static final int MAX_PET_CAPACITY = 5;
+
     private final PetRepository petRepository;
     private final MemberRepository memberRepository;
 
@@ -26,10 +28,16 @@ public class PetCommandService {
         Member member = memberRepository.findById(request.memberId())
                 .orElseThrow(() -> new FriendoglyException("존재하지 않는 Member 입니다."));
 
-        Pet pet = request.toEntity();
-        member.addPet(pet);
-        Pet savedPet = petRepository.save(pet);
+        validatePetCapacity(petRepository.countByMember(member));
+        Pet savedPet = petRepository.save(request.toEntity(member));
 
         return new SavePetResponse(savedPet);
+    }
+
+    private void validatePetCapacity(Long size) {
+        if (MAX_PET_CAPACITY <= size) {
+            throw new FriendoglyException(String.format(
+                    "강아지는 최대 %d 마리까지만 등록할 수 있습니다.", MAX_PET_CAPACITY));
+        }
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/utils/UuidGenerator.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/utils/UuidGenerator.java
@@ -1,0 +1,12 @@
+package com.woowacourse.friendogly.utils;
+
+import java.util.UUID;
+
+public class UuidGenerator {
+
+    // TODO: 정말 Unique한 UUID를 생성하는 로직으로 갈아끼우기
+    public static String generateUuid() {
+        return UUID.randomUUID().toString()
+                .substring(0, 8);
+    }
+}

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,12 +1,12 @@
-INSERT INTO member(name, email)
-VALUES ('도도', 'dodo@test.com'),
-       ('땡이', 'jiho@test.com'),
-       ('트레', 'tre@test.com'),
-       ('위브', 'wiib@test.com'),
-       ('벼리', 'byeori@test.com'),
-       ('누누', 'nunu@test.com'),
-       ('채드', 'ched@test.com'),
-       ('에디', 'edy@test.com');
+INSERT INTO member(name, tag, email)
+VALUES ('도도', '4e52d416', 'dodo@test.com'),
+       ('땡이', 'a582a275', 'jiho@test.com'),
+       ('트레', '68fc8014', 'tre@test.com'),
+       ('위브', '3dde7373', 'wiib@test.com'),
+       ('벼리', '525ec19f', 'byeori@test.com'),
+       ('누누', '5f0f8307', 'nunu@test.com'),
+       ('채드', '114d8979', 'ched@test.com'),
+       ('에디', 'c065a053', 'edy@test.com');
 
 INSERT INTO footprint(member_id, latitude, longitude, created_at, is_deleted)
 VALUES (1, 37.5173316, 127.1011661, TIMESTAMPADD(MINUTE, -10, NOW()), FALSE),

--- a/backend/src/test/java/com/woowacourse/friendogly/docs/MemberApiDocsTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/docs/MemberApiDocsTest.java
@@ -1,9 +1,5 @@
 package com.woowacourse.friendogly.docs;
 
-import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
@@ -21,6 +17,10 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 @WebMvcTest(MemberController.class)
 public class MemberApiDocsTest extends RestDocsTest {
 
@@ -34,7 +34,7 @@ public class MemberApiDocsTest extends RestDocsTest {
     @Test
     void saveMember_Success() throws Exception {
         SaveMemberRequest request = new SaveMemberRequest("반갑개", "member@email.com");
-        SaveMemberResponse response = new SaveMemberResponse(1L, "반갑개", "member@email.com");
+        SaveMemberResponse response = new SaveMemberResponse(1L, "반갑개", "4e52d416", "member@email.com");
 
         Mockito.when(memberCommandService.saveMember(request))
                 .thenReturn(response);
@@ -57,6 +57,7 @@ public class MemberApiDocsTest extends RestDocsTest {
                                 .responseFields(
                                         fieldWithPath("id").type(JsonFieldType.NUMBER).description("회원 id"),
                                         fieldWithPath("name").type(JsonFieldType.STRING).description("회원 이름"),
+                                        fieldWithPath("tag").type(JsonFieldType.STRING).description("중복된 회원 이름을 식별하기 위한 고유한 문자열"),
                                         fieldWithPath("email").type(JsonFieldType.STRING).description("회원 이메일"))
                                 .requestSchema(Schema.schema("saveMemberRequest"))
                                 .responseSchema(Schema.schema("응답DTO 이름"))

--- a/backend/src/test/java/com/woowacourse/friendogly/pet/controller/PetControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/pet/controller/PetControllerTest.java
@@ -1,10 +1,10 @@
 package com.woowacourse.friendogly.pet.controller;
 
+import com.woowacourse.friendogly.member.domain.Member;
 import com.woowacourse.friendogly.member.dto.request.SaveMemberRequest;
 import com.woowacourse.friendogly.pet.dto.request.SavePetRequest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,6 +15,8 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
 
+import java.time.LocalDate;
+
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext
 class PetControllerTest {
@@ -22,25 +24,29 @@ class PetControllerTest {
     @LocalServerPort
     private int port;
 
+    private Member member;
+
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
 
         SaveMemberRequest request = new SaveMemberRequest("견주", "ddang@email.com");
 
-        RestAssured.given().log().all()
+        member = RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .body(request)
                 .when().post("/members")
                 .then().log().all()
-                .statusCode(HttpStatus.CREATED.value());
+                .statusCode(HttpStatus.CREATED.value())
+                .extract()
+                .as(Member.class);
     }
 
     @DisplayName("정상적으로 반려견을 생성하면 201을 반환한다.")
     @Test
     void savePet() {
         SavePetRequest request = new SavePetRequest(
-                1L,
+                member.getId(),
                 "땡이",
                 "땡이입니다.",
                 LocalDate.now().minusDays(1L),
@@ -83,7 +89,7 @@ class PetControllerTest {
     @Test
     void savePet_Fail_NameLengthOver() {
         SavePetRequest request = new SavePetRequest(
-                1L,
+                member.getId(),
                 "1234567890123456",
                 "땡이입니다.",
                 LocalDate.now().minusDays(1L),
@@ -104,7 +110,7 @@ class PetControllerTest {
     @Test
     void savePet_Fail_DescriptionLengthOver() {
         SavePetRequest request = new SavePetRequest(
-                1L,
+                member.getId(),
                 "땡이",
                 "1234567890123456",
                 LocalDate.now().minusDays(1L),
@@ -125,7 +131,7 @@ class PetControllerTest {
     @Test
     void savePet_Fail_BirthDateFuture() {
         SavePetRequest request = new SavePetRequest(
-                1L,
+                member.getId(),
                 "땡이",
                 "땡이입니다.",
                 LocalDate.now().plusDays(1L),
@@ -146,7 +152,7 @@ class PetControllerTest {
     @Test
     void savePet_Fail_InvalidUrlFormat() {
         SavePetRequest request = new SavePetRequest(
-                1L,
+                member.getId(),
                 "땡이",
                 "땡이입니다.",
                 LocalDate.now().minusDays(1L),
@@ -154,6 +160,62 @@ class PetControllerTest {
                 "FEMALE_NEUTERED",
                 "내맘대로 URL주소 지정하기~"
         );
+
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when().post("/pets")
+                .then().log().all()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @DisplayName("한 회원에 대해 5마리를 초과하는 수의 강아지를 등록하는 경우 400을 반환한다.")
+    @Test
+    void savePet_Fail_OverPetCapacity() {
+        SavePetRequest request = new SavePetRequest(
+                member.getId(),
+                "땡이",
+                "땡이입니다.",
+                LocalDate.now().minusDays(1L),
+                "SMALL",
+                "FEMALE_NEUTERED",
+                "http://www.google.com"
+        );
+
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when().post("/pets")
+                .then().log().all()
+                .statusCode(HttpStatus.CREATED.value());
+
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when().post("/pets")
+                .then().log().all()
+                .statusCode(HttpStatus.CREATED.value());
+
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when().post("/pets")
+                .then().log().all()
+                .statusCode(HttpStatus.CREATED.value());
+
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when().post("/pets")
+                .then().log().all()
+                .statusCode(HttpStatus.CREATED.value());
+
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when().post("/pets")
+                .then().log().all()
+                .statusCode(HttpStatus.CREATED.value());
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)

--- a/backend/src/test/java/com/woowacourse/friendogly/pet/domain/PetTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/pet/domain/PetTest.java
@@ -1,15 +1,16 @@
 package com.woowacourse.friendogly.pet.domain;
 
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import com.woowacourse.friendogly.exception.FriendoglyException;
 import com.woowacourse.friendogly.member.domain.Member;
-import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class PetTest {
 
@@ -32,23 +33,6 @@ class PetTest {
                         .imageUrl("http://www.google.com")
                         .build()
         ).doesNotThrowAnyException();
-    }
-
-    @DisplayName("member가 null인 경우 예외가 발생한다.")
-    @Test
-    void create_Fail_NullMember() {
-        assertThatThrownBy(() ->
-                Pet.builder()
-                        .member(null)
-                        .name("땡이")
-                        .description("땡이입니다.")
-                        .birthDate(LocalDate.now().minusDays(1L))
-                        .sizeType(SizeType.SMALL)
-                        .gender(Gender.FEMALE_NEUTERED)
-                        .imageUrl("http://www.google.com")
-                        .build())
-                .isExactlyInstanceOf(FriendoglyException.class)
-                .hasMessage("member는 null일 수 없습니다.");
     }
 
     @DisplayName("이름이 null인 경우 예외가 발생한다.")

--- a/backend/src/test/java/com/woowacourse/friendogly/pet/domain/PetTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/pet/domain/PetTest.java
@@ -35,6 +35,23 @@ class PetTest {
         ).doesNotThrowAnyException();
     }
 
+    @DisplayName("member가 null인 경우 예외가 발생한다.")
+    @Test
+    void create_Fail_NullMember() {
+        assertThatThrownBy(() ->
+                Pet.builder()
+                        .member(null)
+                        .name("땡이")
+                        .description("땡이입니다.")
+                        .birthDate(LocalDate.now().minusDays(1L))
+                        .sizeType(SizeType.SMALL)
+                        .gender(Gender.FEMALE_NEUTERED)
+                        .imageUrl("http://www.google.com")
+                        .build())
+                .isExactlyInstanceOf(FriendoglyException.class)
+                .hasMessage("member는 null일 수 없습니다.");
+    }
+
     @DisplayName("이름이 null인 경우 예외가 발생한다.")
     @Test
     void create_Fail_NullName() {


### PR DESCRIPTION
## 이슈
- close #134 

## 개발 사항
- 사용자 도메인 리팩토링 (값 객체 분리)
- 강아지 등록 시 5마리 초과하지 못하도록 검증
- 닉네임 중복 처리를 위한 UUID 생성 기능 구현

# 전달 사항
- 닉네임 중복 허용에 따른 tag(UUID) 필드 추가했습니다.
- 이에 따른 schema 변동 있어 data.sql 파일 변경되었습니다.
- 이때 현재 추가한 tag(UUID)는 완전히 unique한 값은 아닙니다. 일단 추후에 로직만 갈아끼울 수 있도록 구성했습니다.
