### PR TITLE
[BE] fix: Member 이름 원시값 포장하면서 발생한 컴파일 에러 fix

### DIFF
--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindOneFootprintResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindOneFootprintResponse.java
@@ -19,7 +19,7 @@ public record FindOneFootprintResponse(
 
     public FindOneFootprintResponse(Member member, Footprint footprint) {
         this(
-            member.getName(),
+            member.getName().getValue(),
             null,
             null,
             null,
@@ -31,7 +31,7 @@ public record FindOneFootprintResponse(
 
     public FindOneFootprintResponse(Member member, Pet mainPet, Footprint footprint) {
         this(
-            member.getName(),
+            member.getName().getValue(),
             mainPet.getName().getValue(),
             mainPet.getDescription().getValue(),
             mainPet.getBirthDate().getValue(),


### PR DESCRIPTION
## 이슈
- #154 

## 개발 사항
- Member의 이름을 원시값 포장함에 따라, Footprint 도메인의 response 부분에서 컴파일 에러 발생.
- 해당 error 수정.

## 리뷰 요청 사항
- 바로 approve 주셔도 됩니다.