### PR TITLE
[BE] feat: 강아지가 없으면 발자국 추가 못하도록 검증 추가, 일부 명세 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
@@ -30,8 +30,8 @@ public class FootprintController {
     private final FootprintQueryService footprintQueryService;
 
     public FootprintController(
-        FootprintCommandService footprintCommandService,
-        FootprintQueryService footprintQueryService
+            FootprintCommandService footprintCommandService,
+            FootprintQueryService footprintQueryService
     ) {
         this.footprintCommandService = footprintCommandService;
         this.footprintQueryService = footprintQueryService;
@@ -41,7 +41,7 @@ public class FootprintController {
     public ResponseEntity<Void> save(@Valid @RequestBody SaveFootprintRequest request) {
         Long id = footprintCommandService.save(request);
         return ResponseEntity.created(URI.create("/footprints/" + id))
-            .build();
+                .build();
     }
 
     @GetMapping("/{footprintId}")
@@ -69,8 +69,8 @@ public class FootprintController {
 
     @PatchMapping("/image/{footprintId}")
     public ResponseEntity<UpdateFootprintImageResponse> updateFootprintImage(
-        @PathVariable Long footprintId,
-        @ModelAttribute UpdateFootprintImageRequest request
+            @PathVariable Long footprintId,
+            @ModelAttribute UpdateFootprintImageRequest request
     ) {
         UpdateFootprintImageResponse response = footprintCommandService.updateFootprintImage(footprintId, request);
         return ResponseEntity.ok(response);

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
@@ -39,7 +39,7 @@ public class FootprintController {
 
     @PostMapping
     public ResponseEntity<Void> save(@Valid @RequestBody SaveFootprintRequest request) {
-        Long id = footprintCommandService.save(request);
+        Long id = footprintCommandService.save(1L, request);
         return ResponseEntity.created(URI.create("/footprints/" + id))
                 .build();
     }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
@@ -46,7 +46,8 @@ public class FootprintController {
 
     @GetMapping("/{footprintId}")
     public ResponseEntity<FindOneFootprintResponse> findOne(@PathVariable Long footprintId) {
-        FindOneFootprintResponse response = footprintQueryService.findOne(footprintId);
+        // TODO: 추후 토큰에서 memberId를 가져오도록 변경
+        FindOneFootprintResponse response = footprintQueryService.findOne(1L, footprintId);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
@@ -6,6 +6,7 @@ import com.woowacourse.friendogly.footprint.dto.request.UpdateFootprintImageRequ
 import com.woowacourse.friendogly.footprint.dto.response.FindMyLatestFootprintTimeResponse;
 import com.woowacourse.friendogly.footprint.dto.response.FindNearFootprintResponse;
 import com.woowacourse.friendogly.footprint.dto.response.FindOneFootprintResponse;
+import com.woowacourse.friendogly.footprint.dto.response.SaveFootprintResponse;
 import com.woowacourse.friendogly.footprint.dto.response.UpdateFootprintImageResponse;
 import com.woowacourse.friendogly.footprint.service.FootprintCommandService;
 import com.woowacourse.friendogly.footprint.service.FootprintQueryService;
@@ -38,10 +39,10 @@ public class FootprintController {
     }
 
     @PostMapping
-    public ResponseEntity<Void> save(@Valid @RequestBody SaveFootprintRequest request) {
-        Long id = footprintCommandService.save(1L, request);
-        return ResponseEntity.created(URI.create("/footprints/" + id))
-                .build();
+    public ResponseEntity<SaveFootprintResponse> save(@Valid @RequestBody SaveFootprintRequest request) {
+        SaveFootprintResponse response = footprintCommandService.save(1L, request);
+        return ResponseEntity.created(URI.create("/footprints/" + response.id()))
+                .body(response);
     }
 
     @GetMapping("/{footprintId}")

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
@@ -72,6 +72,7 @@ public class FootprintController {
             @PathVariable Long footprintId,
             @ModelAttribute UpdateFootprintImageRequest request
     ) {
+        // TODO: S3가 구현되고 명세가 확정되면 그 때 문서화하기
         UpdateFootprintImageResponse response = footprintCommandService.updateFootprintImage(footprintId, request);
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/domain/Footprint.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/domain/Footprint.java
@@ -58,7 +58,7 @@ public class Footprint {
 
     public boolean isCreatedBy(Long memberId) {
         return this.member.getId()
-            .equals(memberId);
+                .equals(memberId);
     }
 
     public void updateImageUrl(String imageUrl) {

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/domain/Footprint.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/domain/Footprint.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -26,18 +27,20 @@ public class Footprint {
     private Long id;
 
     @ManyToOne(optional = false)
+    @JoinColumn(name = "member_id")
     private Member member;
 
     @Embedded
     @Column(nullable = false)
     private Location location;
 
+    @Column(name = "image_url")
     private String imageUrl;
 
-    @Column(nullable = false)
+    @Column(nullable = false, name = "created_at")
     private LocalDateTime createdAt;
 
-    @Column(nullable = false)
+    @Column(nullable = false, name = "is_deleted")
     private boolean isDeleted;
 
     @Builder

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/domain/Location.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/domain/Location.java
@@ -8,6 +8,7 @@ import static java.lang.Math.toDegrees;
 import static java.lang.Math.toRadians;
 
 import com.woowacourse.friendogly.exception.FriendoglyException;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -24,7 +25,10 @@ public class Location {
     private static final double MIN_LONGITUDE = -180.0;
     private static final double MAX_LONGITUDE = 180.0;
 
+    @Column(name = "latitude")
     private double latitude;
+
+    @Column(name = "longitude")
     private double longitude;
 
     public Location(double latitude, double longitude) {

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/domain/Location.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/domain/Location.java
@@ -25,10 +25,10 @@ public class Location {
     private static final double MIN_LONGITUDE = -180.0;
     private static final double MAX_LONGITUDE = 180.0;
 
-    @Column(name = "latitude")
+    @Column(name = "latitude", nullable = false)
     private double latitude;
 
-    @Column(name = "longitude")
+    @Column(name = "longitude", nullable = false)
     private double longitude;
 
     public Location(double latitude, double longitude) {

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/request/FindNearFootprintRequest.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/request/FindNearFootprintRequest.java
@@ -5,15 +5,15 @@ import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
 
 public record FindNearFootprintRequest(
-    @NotNull
-    @DecimalMin(value = "-90.0", message = "위도는 -90도 이상 90도 이하로 입력해 주세요.")
-    @DecimalMax(value = "90.0", message = "위도는 -90도 이상 90도 이하로 입력해 주세요.")
-    double latitude,
+        @NotNull
+        @DecimalMin(value = "-90.0", message = "위도는 -90도 이상 90도 이하로 입력해 주세요.")
+        @DecimalMax(value = "90.0", message = "위도는 -90도 이상 90도 이하로 입력해 주세요.")
+        double latitude,
 
-    @NotNull
-    @DecimalMin(value = "-180.0", message = "경도는 -180도 이상 180도 이하로 입력해 주세요.")
-    @DecimalMax(value = "180.0", message = "경도는 -180도 이상 180도 이하로 입력해 주세요.")
-    double longitude
+        @NotNull
+        @DecimalMin(value = "-180.0", message = "경도는 -180도 이상 180도 이하로 입력해 주세요.")
+        @DecimalMax(value = "180.0", message = "경도는 -180도 이상 180도 이하로 입력해 주세요.")
+        double longitude
 ) {
 
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/request/SaveFootprintRequest.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/request/SaveFootprintRequest.java
@@ -3,13 +3,8 @@ package com.woowacourse.friendogly.footprint.dto.request;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
 
 public record SaveFootprintRequest(
-        @NotNull
-        @Positive(message = "memberId는 1 이상이어야 합니다.")
-        Long memberId,
-
         @NotNull
         @DecimalMin(value = "-90.0", message = "위도는 -90도 이상 90도 이하로 입력해 주세요.")
         @DecimalMax(value = "90.0", message = "위도는 -90도 이상 90도 이하로 입력해 주세요.")

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/request/SaveFootprintRequest.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/request/SaveFootprintRequest.java
@@ -6,19 +6,19 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
 public record SaveFootprintRequest(
-    @NotNull
-    @Positive(message = "memberId는 1 이상이어야 합니다.")
-    Long memberId,
+        @NotNull
+        @Positive(message = "memberId는 1 이상이어야 합니다.")
+        Long memberId,
 
-    @NotNull
-    @DecimalMin(value = "-90.0", message = "위도는 -90도 이상 90도 이하로 입력해 주세요.")
-    @DecimalMax(value = "90.0", message = "위도는 -90도 이상 90도 이하로 입력해 주세요.")
-    double latitude,
+        @NotNull
+        @DecimalMin(value = "-90.0", message = "위도는 -90도 이상 90도 이하로 입력해 주세요.")
+        @DecimalMax(value = "90.0", message = "위도는 -90도 이상 90도 이하로 입력해 주세요.")
+        double latitude,
 
-    @NotNull
-    @DecimalMin(value = "-180.0", message = "경도는 -180도 이상 180도 이하로 입력해 주세요.")
-    @DecimalMax(value = "180.0", message = "경도는 -180도 이상 180도 이하로 입력해 주세요.")
-    double longitude
+        @NotNull
+        @DecimalMin(value = "-180.0", message = "경도는 -180도 이상 180도 이하로 입력해 주세요.")
+        @DecimalMax(value = "180.0", message = "경도는 -180도 이상 180도 이하로 입력해 주세요.")
+        double longitude
 ) {
 
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindMyLatestFootprintTimeResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindMyLatestFootprintTimeResponse.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 
 public record FindMyLatestFootprintTimeResponse(
-    // TODO: 패턴을 통일시키고 나서 어노테이션 지우기
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt
+        // TODO: 패턴을 통일시키고 나서 어노테이션 지우기
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt
 ) {
 
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindNearFootprintResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindNearFootprintResponse.java
@@ -5,23 +5,23 @@ import com.woowacourse.friendogly.footprint.domain.Footprint;
 import java.time.LocalDateTime;
 
 public record FindNearFootprintResponse(
-    Long footprintId,
-    double latitude,
-    double longitude,
-    // TODO: 패턴을 통일시키고 나서 어노테이션 지우기
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
-    boolean isMine,
-    String imageUrl
+        Long footprintId,
+        double latitude,
+        double longitude,
+        // TODO: 패턴을 통일시키고 나서 어노테이션 지우기
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
+        boolean isMine,
+        String imageUrl
 ) {
 
     public FindNearFootprintResponse(Footprint footprint, boolean isMine) {
         this(
-            footprint.getId(),
-            footprint.getLocation().getLatitude(),
-            footprint.getLocation().getLongitude(),
-            footprint.getCreatedAt(),
-            isMine,
-            footprint.getImageUrl()
+                footprint.getId(),
+                footprint.getLocation().getLatitude(),
+                footprint.getLocation().getLongitude(),
+                footprint.getCreatedAt(),
+                isMine,
+                footprint.getImageUrl()
         );
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindOneFootprintResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindOneFootprintResponse.java
@@ -8,39 +8,39 @@ import com.woowacourse.friendogly.pet.domain.SizeType;
 import java.time.LocalDate;
 
 public record FindOneFootprintResponse(
-    String memberName,
-    String petName,
-    String petDescription,
-    LocalDate petBirthDate,
-    SizeType petSizeType,
-    Gender petGender,
-    String footprintImageUrl,
-    boolean isMine
+        String memberName,
+        String petName,
+        String petDescription,
+        LocalDate petBirthDate,
+        SizeType petSizeType,
+        Gender petGender,
+        String footprintImageUrl,
+        boolean isMine
 ) {
 
     public FindOneFootprintResponse(Member member, Footprint footprint, boolean isMine) {
         this(
-            member.getName().getValue(),
-            null,
-            null,
-            null,
-            null,
-            null,
-            footprint.getImageUrl(),
-            isMine
+                member.getName().getValue(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                footprint.getImageUrl(),
+                isMine
         );
     }
 
     public FindOneFootprintResponse(Member member, Pet mainPet, Footprint footprint, boolean isMine) {
         this(
-            member.getName().getValue(),
-            mainPet.getName().getValue(),
-            mainPet.getDescription().getValue(),
-            mainPet.getBirthDate().getValue(),
-            mainPet.getSizeType(),
-            mainPet.getGender(),
-            footprint.getImageUrl(),
-            isMine
+                member.getName().getValue(),
+                mainPet.getName().getValue(),
+                mainPet.getDescription().getValue(),
+                mainPet.getBirthDate().getValue(),
+                mainPet.getSizeType(),
+                mainPet.getGender(),
+                footprint.getImageUrl(),
+                isMine
         );
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindOneFootprintResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindOneFootprintResponse.java
@@ -18,19 +18,6 @@ public record FindOneFootprintResponse(
         boolean isMine
 ) {
 
-    public FindOneFootprintResponse(Member member, Footprint footprint, boolean isMine) {
-        this(
-                member.getName().getValue(),
-                null,
-                null,
-                null,
-                null,
-                null,
-                footprint.getImageUrl(),
-                isMine
-        );
-    }
-
     public FindOneFootprintResponse(Member member, Pet mainPet, Footprint footprint, boolean isMine) {
         this(
                 member.getName().getValue(),

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindOneFootprintResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindOneFootprintResponse.java
@@ -14,10 +14,11 @@ public record FindOneFootprintResponse(
     LocalDate petBirthDate,
     SizeType petSizeType,
     Gender petGender,
-    String footprintImageUrl
+    String footprintImageUrl,
+    boolean isMine
 ) {
 
-    public FindOneFootprintResponse(Member member, Footprint footprint) {
+    public FindOneFootprintResponse(Member member, Footprint footprint, boolean isMine) {
         this(
             member.getName().getValue(),
             null,
@@ -25,11 +26,12 @@ public record FindOneFootprintResponse(
             null,
             null,
             null,
-            footprint.getImageUrl()
+            footprint.getImageUrl(),
+            isMine
         );
     }
 
-    public FindOneFootprintResponse(Member member, Pet mainPet, Footprint footprint) {
+    public FindOneFootprintResponse(Member member, Pet mainPet, Footprint footprint, boolean isMine) {
         this(
             member.getName().getValue(),
             mainPet.getName().getValue(),
@@ -37,7 +39,8 @@ public record FindOneFootprintResponse(
             mainPet.getBirthDate().getValue(),
             mainPet.getSizeType(),
             mainPet.getGender(),
-            footprint.getImageUrl()
+            footprint.getImageUrl(),
+            isMine
         );
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/SaveFootprintResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/SaveFootprintResponse.java
@@ -1,0 +1,9 @@
+package com.woowacourse.friendogly.footprint.dto.response;
+
+public record SaveFootprintResponse(
+        Long id,
+        double latitude,
+        double longitude
+) {
+
+}

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintCommandService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintCommandService.java
@@ -30,15 +30,15 @@ public class FootprintCommandService {
 
     public Long save(SaveFootprintRequest request) {
         Member member = memberRepository.findById(request.memberId())
-            .orElseThrow(() -> new FriendoglyException("존재하지 않는 사용자 ID입니다."));
+                .orElseThrow(() -> new FriendoglyException("존재하지 않는 사용자 ID입니다."));
 
         validateRecentFootprintExists(request.memberId());
 
         Footprint footprint = footprintRepository.save(
-            Footprint.builder()
-                .member(member)
-                .location(new Location(request.latitude(), request.longitude()))
-                .build()
+                Footprint.builder()
+                        .member(member)
+                        .location(new Location(request.latitude(), request.longitude()))
+                        .build()
         );
 
         return footprint.getId();
@@ -46,8 +46,8 @@ public class FootprintCommandService {
 
     private void validateRecentFootprintExists(Long memberId) {
         boolean exists = footprintRepository.existsByMemberIdAndCreatedAtAfter(
-            memberId,
-            LocalDateTime.now().minusSeconds(FOOTPRINT_COOLDOWN)
+                memberId,
+                LocalDateTime.now().minusSeconds(FOOTPRINT_COOLDOWN)
         );
 
         if (exists) {
@@ -57,7 +57,7 @@ public class FootprintCommandService {
 
     public UpdateFootprintImageResponse updateFootprintImage(Long footprintId, UpdateFootprintImageRequest request) {
         Footprint footprint = footprintRepository.findById(footprintId)
-            .orElseThrow(() -> new FriendoglyException("존재하지 않는 Footprint ID입니다."));
+                .orElseThrow(() -> new FriendoglyException("존재하지 않는 Footprint ID입니다."));
 
         MultipartFile multipartFile = request.imageFile();
         // TODO: 더미 데이터 URL입니다. 나중에 이미지 저장소(AWS S3)와 연동 필요 !!!

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintCommandService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintCommandService.java
@@ -73,7 +73,7 @@ public class FootprintCommandService {
         );
 
         if (exists) {
-            throw new FriendoglyException("마지막 발자국을 찍은 뒤 30초가 경과되지 않았습니다.");
+            throw new FriendoglyException(String.format("마지막 발자국을 찍은 뒤 %d초가 경과되지 않았습니다.", FOOTPRINT_COOLDOWN_SECOND));
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintCommandService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintCommandService.java
@@ -37,12 +37,12 @@ public class FootprintCommandService {
         this.petRepository = petRepository;
     }
 
-    public Long save(SaveFootprintRequest request) {
-        Member member = memberRepository.findById(request.memberId())
+    public Long save(Long memberId, SaveFootprintRequest request) {
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new FriendoglyException("존재하지 않는 사용자 ID입니다."));
 
         validatePetExistence(member);
-        validateRecentFootprintExists(request.memberId());
+        validateRecentFootprintExists(memberId);
 
         Footprint footprint = footprintRepository.save(
                 Footprint.builder()

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintCommandService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintCommandService.java
@@ -22,7 +22,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Transactional
 public class FootprintCommandService {
 
-    private static final int FOOTPRINT_COOLDOWN = 30;
+    private static final int FOOTPRINT_COOLDOWN_SECOND = 30;
 
     private final FootprintRepository footprintRepository;
     private final MemberRepository memberRepository;
@@ -69,7 +69,7 @@ public class FootprintCommandService {
     private void validateRecentFootprintExists(Long memberId) {
         boolean exists = footprintRepository.existsByMemberIdAndCreatedAtAfter(
                 memberId,
-                LocalDateTime.now().minusSeconds(FOOTPRINT_COOLDOWN)
+                LocalDateTime.now().minusSeconds(FOOTPRINT_COOLDOWN_SECOND)
         );
 
         if (exists) {

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintCommandService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintCommandService.java
@@ -5,6 +5,7 @@ import com.woowacourse.friendogly.footprint.domain.Footprint;
 import com.woowacourse.friendogly.footprint.domain.Location;
 import com.woowacourse.friendogly.footprint.dto.request.SaveFootprintRequest;
 import com.woowacourse.friendogly.footprint.dto.request.UpdateFootprintImageRequest;
+import com.woowacourse.friendogly.footprint.dto.response.SaveFootprintResponse;
 import com.woowacourse.friendogly.footprint.dto.response.UpdateFootprintImageResponse;
 import com.woowacourse.friendogly.footprint.repository.FootprintRepository;
 import com.woowacourse.friendogly.member.domain.Member;
@@ -37,7 +38,7 @@ public class FootprintCommandService {
         this.petRepository = petRepository;
     }
 
-    public Long save(Long memberId, SaveFootprintRequest request) {
+    public SaveFootprintResponse save(Long memberId, SaveFootprintRequest request) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new FriendoglyException("존재하지 않는 사용자 ID입니다."));
 
@@ -51,7 +52,11 @@ public class FootprintCommandService {
                         .build()
         );
 
-        return footprint.getId();
+        return new SaveFootprintResponse(
+                footprint.getId(),
+                footprint.getLocation().getLatitude(),
+                footprint.getLocation().getLongitude()
+        );
     }
 
     private void validatePetExistence(Member member) {

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintQueryService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintQueryService.java
@@ -33,18 +33,19 @@ public class FootprintQueryService {
         this.petRepository = petRepository;
     }
 
-    public FindOneFootprintResponse findOne(Long footprintId) {
+    public FindOneFootprintResponse findOne(Long memberId, Long footprintId) {
         Footprint footprint = footprintRepository.findById(footprintId)
             .orElseThrow(() -> new FriendoglyException("존재하지 않는 Footprint ID입니다."));
         Member member = footprint.getMember();
         List<Pet> pets = petRepository.findByMemberId(member.getId());
+        boolean isMine = footprint.isCreatedBy(memberId);
 
         if (pets.isEmpty()) {
-            return new FindOneFootprintResponse(member, footprint);
+            return new FindOneFootprintResponse(member, footprint, isMine);
         }
 
         // TODO: 대표 펫을 지정하는 기능이 없어서, 임시로 0번째 index의 pet 리턴
-        return new FindOneFootprintResponse(member, pets.get(0), footprint);
+        return new FindOneFootprintResponse(member, pets.get(0), footprint, isMine);
     }
 
     public List<FindNearFootprintResponse> findNear(Long memberId, FindNearFootprintRequest request) {

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintQueryService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintQueryService.java
@@ -36,13 +36,10 @@ public class FootprintQueryService {
     public FindOneFootprintResponse findOne(Long memberId, Long footprintId) {
         Footprint footprint = footprintRepository.findById(footprintId)
                 .orElseThrow(() -> new FriendoglyException("존재하지 않는 Footprint ID입니다."));
+
         Member member = footprint.getMember();
         List<Pet> pets = petRepository.findByMemberId(member.getId());
         boolean isMine = footprint.isCreatedBy(memberId);
-
-        if (pets.isEmpty()) {
-            return new FindOneFootprintResponse(member, footprint, isMine);
-        }
 
         // TODO: 대표 펫을 지정하는 기능이 없어서, 임시로 0번째 index의 pet 리턴
         return new FindOneFootprintResponse(member, pets.get(0), footprint, isMine);

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintQueryService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintQueryService.java
@@ -26,8 +26,8 @@ public class FootprintQueryService {
     private final PetRepository petRepository;
 
     public FootprintQueryService(
-        FootprintRepository footprintRepository,
-        PetRepository petRepository
+            FootprintRepository footprintRepository,
+            PetRepository petRepository
     ) {
         this.footprintRepository = footprintRepository;
         this.petRepository = petRepository;
@@ -35,7 +35,7 @@ public class FootprintQueryService {
 
     public FindOneFootprintResponse findOne(Long memberId, Long footprintId) {
         Footprint footprint = footprintRepository.findById(footprintId)
-            .orElseThrow(() -> new FriendoglyException("존재하지 않는 Footprint ID입니다."));
+                .orElseThrow(() -> new FriendoglyException("존재하지 않는 Footprint ID입니다."));
         Member member = footprint.getMember();
         List<Pet> pets = petRepository.findByMemberId(member.getId());
         boolean isMine = footprint.isCreatedBy(memberId);
@@ -55,14 +55,14 @@ public class FootprintQueryService {
         Location currentLocation = new Location(request.latitude(), request.longitude());
 
         return recentFootprints.stream()
-            .filter(footprint -> footprint.isNear(currentLocation))
-            .map(footprint -> new FindNearFootprintResponse(footprint, footprint.isCreatedBy(memberId)))
-            .toList();
+                .filter(footprint -> footprint.isNear(currentLocation))
+                .map(footprint -> new FindNearFootprintResponse(footprint, footprint.isCreatedBy(memberId)))
+                .toList();
     }
 
     public FindMyLatestFootprintTimeResponse findMyLatestFootprintTime(Long memberId) {
         return footprintRepository.findTopOneByMemberIdOrderByCreatedAtDesc(memberId)
-            .map(footprint -> new FindMyLatestFootprintTimeResponse(footprint.getCreatedAt()))
-            .orElse(new FindMyLatestFootprintTimeResponse(null));
+                .map(footprint -> new FindMyLatestFootprintTimeResponse(footprint.getCreatedAt()))
+                .orElse(new FindMyLatestFootprintTimeResponse(null));
     }
 }

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -8,14 +8,14 @@ VALUES ('도도', '4e52d416', 'dodo@test.com'),
        ('채드', '114d8979', 'ched@test.com'),
        ('에디', 'c065a053', 'edy@test.com');
 
-INSERT INTO footprint(member_id, latitude, longitude, created_at, is_deleted)
-VALUES (1, 37.5173316, 127.1011661, TIMESTAMPADD(MINUTE, -10, NOW()), FALSE),
-       (2, 37.5185122, 127.098778, TIMESTAMPADD(MINUTE, -20, NOW()), FALSE),
-       (3, 37.5191964, 127.1055562, TIMESTAMPADD(MINUTE, -30, NOW()), FALSE),
-       (4, 37.5136533, 127.0983182, TIMESTAMPADD(MINUTE, -40, NOW()), FALSE),
-       (5, 37.5131474, 127.1042528, TIMESTAMPADD(MINUTE, -50, NOW()), FALSE),
-       (6, 37.5171728, 127.1047797, TIMESTAMPADD(MINUTE, -60, NOW()), FALSE),
-       (7, 37.516183, 127.1068874, TIMESTAMPADD(MINUTE, -70, NOW()), FALSE);
+INSERT INTO footprint(member_id, latitude, longitude, image_url, created_at, is_deleted)
+VALUES (1, 37.5173316, 127.1011661, 'https://picsum.photos/100', TIMESTAMPADD(MINUTE, -10, NOW()), FALSE),
+       (2, 37.5185122, 127.098778, 'https://picsum.photos/150', TIMESTAMPADD(MINUTE, -20, NOW()), FALSE),
+       (3, 37.5191964, 127.1055562, 'https://picsum.photos/200', TIMESTAMPADD(MINUTE, -30, NOW()), FALSE),
+       (4, 37.5136533, 127.0983182, 'https://picsum.photos/250', TIMESTAMPADD(MINUTE, -40, NOW()), FALSE),
+       (5, 37.5131474, 127.1042528, 'https://picsum.photos/300', TIMESTAMPADD(MINUTE, -50, NOW()), FALSE),
+       (6, 37.5171728, 127.1047797, 'https://picsum.photos/350', TIMESTAMPADD(MINUTE, -60, NOW()), FALSE),
+       (7, 37.516183, 127.1068874, 'https://picsum.photos/400', TIMESTAMPADD(MINUTE, -70, NOW()), FALSE);
 
 INSERT INTO pet(member_id, name, description, birth_date, size_type, gender, image_url)
 VALUES (1, '귀요미', '제 이름은 귀요미입니다', '2010-04-01', 'SMALL', 'MALE_NEUTERED', 'https://pds.joongang.co.kr/news/component/htmlphoto_mmdata/201901/20/28017477-0365-4a43-b546-008b603da621.jpg'),

--- a/backend/src/test/java/com/woowacourse/friendogly/docs/FootprintApiDocsTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/docs/FootprintApiDocsTest.java
@@ -22,8 +22,12 @@ import com.woowacourse.friendogly.footprint.controller.FootprintController;
 import com.woowacourse.friendogly.footprint.dto.request.FindNearFootprintRequest;
 import com.woowacourse.friendogly.footprint.dto.request.SaveFootprintRequest;
 import com.woowacourse.friendogly.footprint.dto.response.FindNearFootprintResponse;
+import com.woowacourse.friendogly.footprint.dto.response.FindOneFootprintResponse;
 import com.woowacourse.friendogly.footprint.service.FootprintCommandService;
 import com.woowacourse.friendogly.footprint.service.FootprintQueryService;
+import com.woowacourse.friendogly.pet.domain.Gender;
+import com.woowacourse.friendogly.pet.domain.SizeType;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -73,6 +77,53 @@ public class FootprintApiDocsTest extends RestDocsTest {
             ))
             .andExpect(status().isCreated())
             .andExpect(header().string(LOCATION, "/footprints/1"));
+    }
+
+    @DisplayName("발자국 세부정보 단건 조회")
+    @Test
+    void findOne() throws Exception {
+        FindOneFootprintResponse response = new FindOneFootprintResponse(
+            "최강지호",
+            "땡이",
+            "우리 귀여운 땡이입니다",
+            LocalDate.now().minusYears(1),
+            SizeType.MEDIUM,
+            Gender.FEMALE_NEUTERED,
+            "https://picsum.photos/200",
+            true
+        );
+
+        given(footprintQueryService.findOne(any(Long.class), any(Long.class)))
+            .willReturn(response);
+
+        mockMvc
+            .perform(get("/footprints/{footprintId}", 1L))
+            .andDo(print())
+            .andDo(document("footprints/findOne",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                resource(ResourceSnippetParameters.builder()
+                    .tag("발자국 세부정보 단건 조회 API")
+                    .summary("발자국 세부정보 단건 조회 API")
+                    .pathParameters(
+                        parameterWithName("footprintId").description("발자국 ID")
+                    )
+                    .responseFields(
+                        fieldWithPath("memberName").description("발자국을 찍은 회원의 Member ID"),
+                        fieldWithPath("petName").description("발자국을 회원의 강아지 이름"),
+                        fieldWithPath("petDescription").description("발자국을 회원의 강아지 설명"),
+                        fieldWithPath("petBirthDate").description("발자국을 찍은 회원의 강아지 생일"),
+                        fieldWithPath("petSizeType").description("발자국을 찍은 회원의 강아지 사이즈"),
+                        fieldWithPath("petGender").description("발자국을 찍은 회원의 강아지 성별(중성화 포함)"),
+                        fieldWithPath("footprintImageUrl").description("발자국의 이미지 URL"),
+                        fieldWithPath("isMine").description("내 발자국인지 여부 (내 발자국이면 true)")
+                    )
+                    .requestSchema(Schema.schema("FindOneFootprintRequest"))
+                    .responseSchema(Schema.schema("FindOneFootprintResponse"))
+                    .build()
+                )
+            ))
+            .andExpect(status().isOk());
     }
 
     @DisplayName("주변 발자국 조회")

--- a/backend/src/test/java/com/woowacourse/friendogly/docs/FootprintApiDocsTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/docs/FootprintApiDocsTest.java
@@ -24,6 +24,7 @@ import com.woowacourse.friendogly.footprint.dto.request.SaveFootprintRequest;
 import com.woowacourse.friendogly.footprint.dto.response.FindMyLatestFootprintTimeResponse;
 import com.woowacourse.friendogly.footprint.dto.response.FindNearFootprintResponse;
 import com.woowacourse.friendogly.footprint.dto.response.FindOneFootprintResponse;
+import com.woowacourse.friendogly.footprint.dto.response.SaveFootprintResponse;
 import com.woowacourse.friendogly.footprint.service.FootprintCommandService;
 import com.woowacourse.friendogly.footprint.service.FootprintQueryService;
 import com.woowacourse.friendogly.pet.domain.Gender;
@@ -49,9 +50,10 @@ public class FootprintApiDocsTest extends RestDocsTest {
     @Test
     void save() throws Exception {
         SaveFootprintRequest request = new SaveFootprintRequest(37.5173316, 127.1011661);
+        SaveFootprintResponse response = new SaveFootprintResponse(1L, 37.5173316, 127.1011661);
 
         given(footprintCommandService.save(any(Long.class), eq(request)))
-                .willReturn(1L);
+                .willReturn(response);
 
         mockMvc
                 .perform(post("/footprints")
@@ -70,6 +72,11 @@ public class FootprintApiDocsTest extends RestDocsTest {
                                 )
                                 .responseHeaders(
                                         headerWithName(LOCATION).description("Location")
+                                )
+                                .responseFields(
+                                        fieldWithPath("id").description("생성된 발자국 ID"),
+                                        fieldWithPath("latitude").description("생성된 발자국의 위도"),
+                                        fieldWithPath("longitude").description("생성된 발자국의 경도")
                                 )
                                 .requestSchema(Schema.schema("FindNearFootprintRequest"))
                                 .build()

--- a/backend/src/test/java/com/woowacourse/friendogly/docs/FootprintApiDocsTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/docs/FootprintApiDocsTest.java
@@ -78,7 +78,8 @@ public class FootprintApiDocsTest extends RestDocsTest {
                                         fieldWithPath("latitude").description("생성된 발자국의 위도"),
                                         fieldWithPath("longitude").description("생성된 발자국의 경도")
                                 )
-                                .requestSchema(Schema.schema("FindNearFootprintRequest"))
+                                .requestSchema(Schema.schema("SaveFootprintRequest"))
+                                .responseSchema(Schema.schema("SaveFootprintResponse"))
                                 .build()
                         )
                 ))
@@ -177,6 +178,7 @@ public class FootprintApiDocsTest extends RestDocsTest {
                                         fieldWithPath("[].isMine").description("나의 발자국인지 여부"),
                                         fieldWithPath("[].imageUrl").description("발자국에 할당된 이미지 URL")
                                 )
+                                .responseSchema(Schema.schema("FindNearFootprintResponse"))
                                 .build()
                         )
                 ))

--- a/backend/src/test/java/com/woowacourse/friendogly/docs/FootprintApiDocsTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/docs/FootprintApiDocsTest.java
@@ -21,6 +21,7 @@ import com.epages.restdocs.apispec.Schema;
 import com.woowacourse.friendogly.footprint.controller.FootprintController;
 import com.woowacourse.friendogly.footprint.dto.request.FindNearFootprintRequest;
 import com.woowacourse.friendogly.footprint.dto.request.SaveFootprintRequest;
+import com.woowacourse.friendogly.footprint.dto.response.FindMyLatestFootprintTimeResponse;
 import com.woowacourse.friendogly.footprint.dto.response.FindNearFootprintResponse;
 import com.woowacourse.friendogly.footprint.dto.response.FindOneFootprintResponse;
 import com.woowacourse.friendogly.footprint.service.FootprintCommandService;
@@ -167,6 +168,35 @@ public class FootprintApiDocsTest extends RestDocsTest {
                         fieldWithPath("[].isMine").description("나의 발자국인지 여부"),
                         fieldWithPath("[].imageUrl").description("발자국에 할당된 이미지 URL")
                     )
+                    .build()
+                )
+            ))
+            .andExpect(status().isOk());
+    }
+
+    @DisplayName("자신의 마지막 발자국 시간 조회")
+    @Test
+    void findMyLatestFootprintTime() throws Exception {
+        FindMyLatestFootprintTimeResponse response = new FindMyLatestFootprintTimeResponse(
+            LocalDateTime.now().minusHours(1)
+        );
+
+        given(footprintQueryService.findMyLatestFootprintTime(any(Long.class)))
+            .willReturn(response);
+
+        mockMvc
+            .perform(get("/footprints/mine/latest"))
+            .andDo(print())
+            .andDo(document("footprints/findMyLatestFootprintTime",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                resource(ResourceSnippetParameters.builder()
+                    .tag("자신의 마지막 발자국 시간 조회 API")
+                    .summary("자신의 마지막 발자국 시간 조회 API")
+                    .responseFields(
+                        fieldWithPath("createdAt").description("자신의 가장 최근 발자국 생성 시간")
+                    )
+                    .responseSchema(Schema.schema("FindMyLatestFootprintTimeResponse"))
                     .build()
                 )
             ))

--- a/backend/src/test/java/com/woowacourse/friendogly/docs/FootprintApiDocsTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/docs/FootprintApiDocsTest.java
@@ -51,80 +51,80 @@ public class FootprintApiDocsTest extends RestDocsTest {
         SaveFootprintRequest request = new SaveFootprintRequest(1L, 37.5173316, 127.1011661);
 
         given(footprintCommandService.save(request))
-            .willReturn(1L);
+                .willReturn(1L);
 
         mockMvc
-            .perform(post("/footprints")
-                .content(objectMapper.writeValueAsString(request))
-                .contentType(APPLICATION_JSON))
-            .andDo(print())
-            .andDo(document("footprints/save",
-                getDocumentRequest(),
-                getDocumentResponse(),
-                resource(ResourceSnippetParameters.builder()
-                    .tag("발자국 저장 API")
-                    .summary("발자국 저장 API")
-                    .requestFields(
-                        fieldWithPath("memberId").description("사용자 ID"),
-                        fieldWithPath("latitude").description("현재 위치의 위도"),
-                        fieldWithPath("longitude").description("현재 위치의 경도")
-                    )
-                    .responseHeaders(
-                        headerWithName(LOCATION).description("Location")
-                    )
-                    .requestSchema(Schema.schema("FindNearFootprintRequest"))
-                    .build()
-                )
-            ))
-            .andExpect(status().isCreated())
-            .andExpect(header().string(LOCATION, "/footprints/1"));
+                .perform(post("/footprints")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON))
+                .andDo(print())
+                .andDo(document("footprints/save",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("발자국 저장 API")
+                                .summary("발자국 저장 API")
+                                .requestFields(
+                                        fieldWithPath("memberId").description("사용자 ID"),
+                                        fieldWithPath("latitude").description("현재 위치의 위도"),
+                                        fieldWithPath("longitude").description("현재 위치의 경도")
+                                )
+                                .responseHeaders(
+                                        headerWithName(LOCATION).description("Location")
+                                )
+                                .requestSchema(Schema.schema("FindNearFootprintRequest"))
+                                .build()
+                        )
+                ))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(LOCATION, "/footprints/1"));
     }
 
     @DisplayName("발자국 세부정보 단건 조회")
     @Test
     void findOne() throws Exception {
         FindOneFootprintResponse response = new FindOneFootprintResponse(
-            "최강지호",
-            "땡이",
-            "우리 귀여운 땡이입니다",
-            LocalDate.now().minusYears(1),
-            SizeType.MEDIUM,
-            Gender.FEMALE_NEUTERED,
-            "https://picsum.photos/200",
-            true
+                "최강지호",
+                "땡이",
+                "우리 귀여운 땡이입니다",
+                LocalDate.now().minusYears(1),
+                SizeType.MEDIUM,
+                Gender.FEMALE_NEUTERED,
+                "https://picsum.photos/200",
+                true
         );
 
         given(footprintQueryService.findOne(any(Long.class), any(Long.class)))
-            .willReturn(response);
+                .willReturn(response);
 
         mockMvc
-            .perform(get("/footprints/{footprintId}", 1L))
-            .andDo(print())
-            .andDo(document("footprints/findOne",
-                getDocumentRequest(),
-                getDocumentResponse(),
-                resource(ResourceSnippetParameters.builder()
-                    .tag("발자국 세부정보 단건 조회 API")
-                    .summary("발자국 세부정보 단건 조회 API")
-                    .pathParameters(
-                        parameterWithName("footprintId").description("발자국 ID")
-                    )
-                    .responseFields(
-                        fieldWithPath("memberName").description("발자국을 찍은 회원의 Member ID"),
-                        fieldWithPath("petName").description("발자국을 회원의 강아지 이름"),
-                        fieldWithPath("petDescription").description("발자국을 회원의 강아지 설명"),
-                        fieldWithPath("petBirthDate").description("발자국을 찍은 회원의 강아지 생일"),
-                        fieldWithPath("petSizeType").description("발자국을 찍은 회원의 강아지 사이즈"),
-                        fieldWithPath("petGender").description("발자국을 찍은 회원의 강아지 성별(중성화 포함)"),
-                        fieldWithPath("footprintImageUrl").description("발자국의 이미지 URL"),
-                        fieldWithPath("isMine").description("내 발자국인지 여부 (내 발자국이면 true)")
-                    )
-                    .requestSchema(Schema.schema("FindOneFootprintRequest"))
-                    .responseSchema(Schema.schema("FindOneFootprintResponse"))
-                    .build()
-                )
-            ))
-            .andExpect(status().isOk());
+                .perform(get("/footprints/{footprintId}", 1L))
+                .andDo(print())
+                .andDo(document("footprints/findOne",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("발자국 세부정보 단건 조회 API")
+                                .summary("발자국 세부정보 단건 조회 API")
+                                .pathParameters(
+                                        parameterWithName("footprintId").description("발자국 ID")
+                                )
+                                .responseFields(
+                                        fieldWithPath("memberName").description("발자국을 찍은 회원의 Member ID"),
+                                        fieldWithPath("petName").description("발자국을 회원의 강아지 이름"),
+                                        fieldWithPath("petDescription").description("발자국을 회원의 강아지 설명"),
+                                        fieldWithPath("petBirthDate").description("발자국을 찍은 회원의 강아지 생일"),
+                                        fieldWithPath("petSizeType").description("발자국을 찍은 회원의 강아지 사이즈"),
+                                        fieldWithPath("petGender").description("발자국을 찍은 회원의 강아지 성별(중성화 포함)"),
+                                        fieldWithPath("footprintImageUrl").description("발자국의 이미지 URL"),
+                                        fieldWithPath("isMine").description("내 발자국인지 여부 (내 발자국이면 true)")
+                                )
+                                .requestSchema(Schema.schema("FindOneFootprintRequest"))
+                                .responseSchema(Schema.schema("FindOneFootprintResponse"))
+                                .build()
+                        )
+                ))
+                .andExpect(status().isOk());
     }
 
     @DisplayName("주변 발자국 조회")
@@ -132,75 +132,78 @@ public class FootprintApiDocsTest extends RestDocsTest {
     void findNear() throws Exception {
         FindNearFootprintRequest request = new FindNearFootprintRequest(37.5173316, 127.1011661);
         List<FindNearFootprintResponse> response = List.of(
-            new FindNearFootprintResponse(
-                1L, 37.5136533, 127.0983182, LocalDateTime.now().minusMinutes(10), true, "https://picsum.photos/200"),
-            new FindNearFootprintResponse(
-                3L, 37.5131474, 127.1042528, LocalDateTime.now().minusMinutes(20), false, ""),
-            new FindNearFootprintResponse(
-                6L, 37.5171728, 127.1047797, LocalDateTime.now().minusMinutes(30), false, "https://picsum.photos/300"),
-            new FindNearFootprintResponse(
-                11L, 37.516183, 127.1068874, LocalDateTime.now().minusMinutes(40), true, "https://picsum.photos/250")
+                new FindNearFootprintResponse(
+                        1L, 37.5136533, 127.0983182, LocalDateTime.now().minusMinutes(10), true,
+                        "https://picsum.photos/200"),
+                new FindNearFootprintResponse(
+                        3L, 37.5131474, 127.1042528, LocalDateTime.now().minusMinutes(20), false, ""),
+                new FindNearFootprintResponse(
+                        6L, 37.5171728, 127.1047797, LocalDateTime.now().minusMinutes(30), false,
+                        "https://picsum.photos/300"),
+                new FindNearFootprintResponse(
+                        11L, 37.516183, 127.1068874, LocalDateTime.now().minusMinutes(40), true,
+                        "https://picsum.photos/250")
         );
 
         given(footprintQueryService.findNear(any(Long.class), eq(request)))
-            .willReturn(response);
+                .willReturn(response);
 
         mockMvc
-            .perform(get("/footprints/near")
-                .param("latitude", "37.5173316")
-                .param("longitude", "127.1011661"))
-            .andDo(print())
-            .andDo(document("footprints/near",
-                getDocumentRequest(),
-                getDocumentResponse(),
-                resource(ResourceSnippetParameters.builder()
-                    .tag("주변 발자국 조회 API")
-                    .summary("주변 발자국 조회 API")
-                    .queryParameters(
-                        parameterWithName("latitude").description("현재 위치의 위도"),
-                        parameterWithName("longitude").description("현재 위치의 경도")
-                    )
-                    .responseFields(
-                        fieldWithPath("[].footprintId").description("발자국 ID"),
-                        fieldWithPath("[].latitude").description("발자국 위치의 위도"),
-                        fieldWithPath("[].longitude").description("발자국 위치의 경도"),
-                        fieldWithPath("[].createdAt").description("발자국 생성 시간"),
-                        fieldWithPath("[].isMine").description("나의 발자국인지 여부"),
-                        fieldWithPath("[].imageUrl").description("발자국에 할당된 이미지 URL")
-                    )
-                    .build()
-                )
-            ))
-            .andExpect(status().isOk());
+                .perform(get("/footprints/near")
+                        .param("latitude", "37.5173316")
+                        .param("longitude", "127.1011661"))
+                .andDo(print())
+                .andDo(document("footprints/near",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("주변 발자국 조회 API")
+                                .summary("주변 발자국 조회 API")
+                                .queryParameters(
+                                        parameterWithName("latitude").description("현재 위치의 위도"),
+                                        parameterWithName("longitude").description("현재 위치의 경도")
+                                )
+                                .responseFields(
+                                        fieldWithPath("[].footprintId").description("발자국 ID"),
+                                        fieldWithPath("[].latitude").description("발자국 위치의 위도"),
+                                        fieldWithPath("[].longitude").description("발자국 위치의 경도"),
+                                        fieldWithPath("[].createdAt").description("발자국 생성 시간"),
+                                        fieldWithPath("[].isMine").description("나의 발자국인지 여부"),
+                                        fieldWithPath("[].imageUrl").description("발자국에 할당된 이미지 URL")
+                                )
+                                .build()
+                        )
+                ))
+                .andExpect(status().isOk());
     }
 
     @DisplayName("자신의 마지막 발자국 시간 조회")
     @Test
     void findMyLatestFootprintTime() throws Exception {
         FindMyLatestFootprintTimeResponse response = new FindMyLatestFootprintTimeResponse(
-            LocalDateTime.now().minusHours(1)
+                LocalDateTime.now().minusHours(1)
         );
 
         given(footprintQueryService.findMyLatestFootprintTime(any(Long.class)))
-            .willReturn(response);
+                .willReturn(response);
 
         mockMvc
-            .perform(get("/footprints/mine/latest"))
-            .andDo(print())
-            .andDo(document("footprints/findMyLatestFootprintTime",
-                getDocumentRequest(),
-                getDocumentResponse(),
-                resource(ResourceSnippetParameters.builder()
-                    .tag("자신의 마지막 발자국 시간 조회 API")
-                    .summary("자신의 마지막 발자국 시간 조회 API")
-                    .responseFields(
-                        fieldWithPath("createdAt").description("자신의 가장 최근 발자국 생성 시간")
-                    )
-                    .responseSchema(Schema.schema("FindMyLatestFootprintTimeResponse"))
-                    .build()
-                )
-            ))
-            .andExpect(status().isOk());
+                .perform(get("/footprints/mine/latest"))
+                .andDo(print())
+                .andDo(document("footprints/findMyLatestFootprintTime",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("자신의 마지막 발자국 시간 조회 API")
+                                .summary("자신의 마지막 발자국 시간 조회 API")
+                                .responseFields(
+                                        fieldWithPath("createdAt").description("자신의 가장 최근 발자국 생성 시간")
+                                )
+                                .responseSchema(Schema.schema("FindMyLatestFootprintTimeResponse"))
+                                .build()
+                        )
+                ))
+                .andExpect(status().isOk());
     }
 
     @Override

--- a/backend/src/test/java/com/woowacourse/friendogly/docs/FootprintApiDocsTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/docs/FootprintApiDocsTest.java
@@ -48,9 +48,9 @@ public class FootprintApiDocsTest extends RestDocsTest {
     @DisplayName("발자국 저장")
     @Test
     void save() throws Exception {
-        SaveFootprintRequest request = new SaveFootprintRequest(1L, 37.5173316, 127.1011661);
+        SaveFootprintRequest request = new SaveFootprintRequest(37.5173316, 127.1011661);
 
-        given(footprintCommandService.save(request))
+        given(footprintCommandService.save(any(Long.class), eq(request)))
                 .willReturn(1L);
 
         mockMvc
@@ -65,7 +65,6 @@ public class FootprintApiDocsTest extends RestDocsTest {
                                 .tag("발자국 저장 API")
                                 .summary("발자국 저장 API")
                                 .requestFields(
-                                        fieldWithPath("memberId").description("사용자 ID"),
                                         fieldWithPath("latitude").description("현재 위치의 위도"),
                                         fieldWithPath("longitude").description("현재 위치의 경도")
                                 )

--- a/backend/src/test/java/com/woowacourse/friendogly/footprint/domain/LocationTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/footprint/domain/LocationTest.java
@@ -18,7 +18,7 @@ class LocationTest {
     @CsvSource(value = {"90.000, 180.000", "-90.000, -180.000", "0.000, 0.000"})
     void constructor_Success(double latitude, double longitude) {
         assertThatCode(() -> new Location(latitude, longitude))
-            .doesNotThrowAnyException();
+                .doesNotThrowAnyException();
     }
 
     @DisplayName("올바르지 않은 위도 범위로 생성하면 예외가 발생한다.")
@@ -26,8 +26,8 @@ class LocationTest {
     @ValueSource(doubles = {-90.001, 90.001})
     void constructor_Fail_IllegalLatitude(double latitude) {
         assertThatThrownBy(() -> new Location(latitude, 0.0))
-            .isInstanceOf(FriendoglyException.class)
-            .hasMessage("위도 범위가 올바르지 않습니다.");
+                .isInstanceOf(FriendoglyException.class)
+                .hasMessage("위도 범위가 올바르지 않습니다.");
     }
 
     @DisplayName("올바르지 않은 경도 범위로 생성하면 예외가 발생한다.")
@@ -35,8 +35,8 @@ class LocationTest {
     @ValueSource(doubles = {-180.001, 180.001})
     void constructor_Fail_IllegalLongitude(double longitude) {
         assertThatThrownBy(() -> new Location(0.0, longitude))
-            .isInstanceOf(FriendoglyException.class)
-            .hasMessage("경도 범위가 올바르지 않습니다.");
+                .isInstanceOf(FriendoglyException.class)
+                .hasMessage("경도 범위가 올바르지 않습니다.");
     }
 
     @DisplayName("약 999m 차이 나는 두 위치는 주변에 있다.")

--- a/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintCommandServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintCommandServiceTest.java
@@ -14,10 +14,8 @@ import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 
-@SpringBootTest
 class FootprintCommandServiceTest extends ServiceTest {
 
     @Autowired

--- a/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintCommandServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintCommandServiceTest.java
@@ -5,15 +5,23 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woowacourse.friendogly.exception.FriendoglyException;
 import com.woowacourse.friendogly.footprint.dto.request.SaveFootprintRequest;
+import com.woowacourse.friendogly.footprint.repository.FootprintRepository;
 import com.woowacourse.friendogly.member.domain.Member;
-import com.woowacourse.friendogly.support.ServiceTest;
+import com.woowacourse.friendogly.member.repository.MemberRepository;
+import com.woowacourse.friendogly.pet.domain.Gender;
+import com.woowacourse.friendogly.pet.domain.Pet;
+import com.woowacourse.friendogly.pet.domain.SizeType;
+import com.woowacourse.friendogly.pet.repository.PetRepository;
+import java.time.LocalDate;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 
-
-class FootprintCommandServiceTest extends ServiceTest {
+@SpringBootTest
+class FootprintCommandServiceTest {
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
@@ -21,9 +29,26 @@ class FootprintCommandServiceTest extends ServiceTest {
     @Autowired
     private FootprintCommandService footprintCommandService;
 
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private FootprintRepository footprintRepository;
+
+    @Autowired
+    private PetRepository petRepository;
+
+    @AfterEach
+    void cleanUp() {
+        footprintRepository.deleteAll();
+        petRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
     @DisplayName("발자국 저장")
     @Test
     void save() {
+        // given
         Member member = memberRepository.save(
                 Member.builder()
                         .name("name")
@@ -31,8 +56,43 @@ class FootprintCommandServiceTest extends ServiceTest {
                         .build()
         );
 
+        petRepository.save(
+                Pet.builder()
+                        .member(member)
+                        .name("땡이")
+                        .description("귀여운 땡이")
+                        .birthDate(LocalDate.now().minusYears(1))
+                        .sizeType(SizeType.MEDIUM)
+                        .gender(Gender.MALE_NEUTERED)
+                        .imageUrl("https://picsum.photos/200")
+                        .build()
+        );
+
+        // when
         footprintCommandService.save(new SaveFootprintRequest(member.getId(), 30.0, 30.0));
+
+        // then
         assertThat(footprintRepository.findAll()).hasSize(1);
+    }
+
+    @DisplayName("강아지를 등록하지 않은 사용자는 발자국을 남길 수 없다.")
+    @Test
+    void save_Fail_NoPets() {
+        // given
+        Member member = memberRepository.save(
+                Member.builder()
+                        .name("name")
+                        .email("test@test.com")
+                        .build()
+        );
+
+        // when - then
+        assertThatThrownBy(() -> footprintCommandService.save(new SaveFootprintRequest(
+                member.getId(),
+                90.000,
+                90.000
+        ))).isInstanceOf(FriendoglyException.class)
+                .hasMessage("펫을 등록해야만 발자국을 생성할 수 있습니다.");
     }
 
     @DisplayName("발자국 저장 실패 - 존재하지 않는 Member ID")
@@ -51,6 +111,18 @@ class FootprintCommandServiceTest extends ServiceTest {
                 Member.builder()
                         .name("name")
                         .email("test@test.com")
+                        .build()
+        );
+
+        petRepository.save(
+                Pet.builder()
+                        .member(member)
+                        .name("땡이")
+                        .description("귀여운 땡이")
+                        .birthDate(LocalDate.now().minusYears(1))
+                        .sizeType(SizeType.MEDIUM)
+                        .gender(Gender.MALE_NEUTERED)
+                        .imageUrl("https://picsum.photos/200")
                         .build()
         );
 

--- a/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintCommandServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintCommandServiceTest.java
@@ -5,15 +5,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woowacourse.friendogly.exception.FriendoglyException;
 import com.woowacourse.friendogly.footprint.dto.request.SaveFootprintRequest;
-import com.woowacourse.friendogly.footprint.repository.FootprintRepository;
 import com.woowacourse.friendogly.member.domain.Member;
-import com.woowacourse.friendogly.member.repository.MemberRepository;
 import com.woowacourse.friendogly.pet.domain.Gender;
 import com.woowacourse.friendogly.pet.domain.Pet;
 import com.woowacourse.friendogly.pet.domain.SizeType;
-import com.woowacourse.friendogly.pet.repository.PetRepository;
+import com.woowacourse.friendogly.support.ServiceTest;
 import java.time.LocalDate;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,29 +18,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 @SpringBootTest
-class FootprintCommandServiceTest {
+class FootprintCommandServiceTest extends ServiceTest {
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
     @Autowired
     private FootprintCommandService footprintCommandService;
-
-    @Autowired
-    private MemberRepository memberRepository;
-
-    @Autowired
-    private FootprintRepository footprintRepository;
-
-    @Autowired
-    private PetRepository petRepository;
-
-    @AfterEach
-    void cleanUp() {
-        footprintRepository.deleteAll();
-        petRepository.deleteAll();
-        memberRepository.deleteAll();
-    }
 
     @DisplayName("발자국 저장")
     @Test

--- a/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintCommandServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintCommandServiceTest.java
@@ -69,7 +69,7 @@ class FootprintCommandServiceTest {
         );
 
         // when
-        footprintCommandService.save(new SaveFootprintRequest(member.getId(), 30.0, 30.0));
+        footprintCommandService.save(member.getId(), new SaveFootprintRequest(30.0, 30.0));
 
         // then
         assertThat(footprintRepository.findAll()).hasSize(1);
@@ -87,11 +87,12 @@ class FootprintCommandServiceTest {
         );
 
         // when - then
-        assertThatThrownBy(() -> footprintCommandService.save(new SaveFootprintRequest(
-                member.getId(),
-                90.000,
-                90.000
-        ))).isInstanceOf(FriendoglyException.class)
+        assertThatThrownBy(
+                () -> footprintCommandService.save(
+                        member.getId(),
+                        new SaveFootprintRequest(90.000, 90.000)
+                )
+        ).isInstanceOf(FriendoglyException.class)
                 .hasMessage("펫을 등록해야만 발자국을 생성할 수 있습니다.");
     }
 
@@ -99,7 +100,10 @@ class FootprintCommandServiceTest {
     @Test
     void save_Fail_IllegalMemberId() {
         assertThatThrownBy(
-                () -> footprintCommandService.save(new SaveFootprintRequest(1L, 30.0, 30.0))
+                () -> footprintCommandService.save(
+                        -1L,
+                        new SaveFootprintRequest(30.0, 30.0)
+                )
         ).isInstanceOf(FriendoglyException.class)
                 .hasMessage("존재하지 않는 사용자 ID입니다.");
     }
@@ -133,7 +137,10 @@ class FootprintCommandServiceTest {
                 """, member.getId());
 
         assertThatThrownBy(
-                () -> footprintCommandService.save(new SaveFootprintRequest(member.getId(), 30.0, 30.0))
+                () -> footprintCommandService.save(
+                        member.getId(),
+                        new SaveFootprintRequest(30.0, 30.0)
+                )
         ).isInstanceOf(FriendoglyException.class)
                 .hasMessage("마지막 발자국을 찍은 뒤 30초가 경과되지 않았습니다.");
     }

--- a/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintQueryServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintQueryServiceTest.java
@@ -145,10 +145,16 @@ class FootprintQueryServiceTest {
         double farLongitude = 0.009001209;
 
         // 999m 떨어진 발자국 저장
-        footprintCommandService.save(new SaveFootprintRequest(member1.getId(), 0.0, nearLongitude));
+        footprintCommandService.save(
+                member1.getId(),
+                new SaveFootprintRequest(0.0, nearLongitude)
+        );
 
         // 1001m 떨어진 발자국 저장
-        footprintCommandService.save(new SaveFootprintRequest(member2.getId(), 0.0, farLongitude));
+        footprintCommandService.save(
+                member2.getId(),
+                new SaveFootprintRequest(0.0, farLongitude)
+        );
 
         List<FindNearFootprintResponse> nearFootprints = footprintQueryService.findNear(
                 member1.getId(), new FindNearFootprintRequest(0.0, 0.0));

--- a/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintQueryServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintQueryServiceTest.java
@@ -21,10 +21,8 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 
-@SpringBootTest
 class FootprintQueryServiceTest extends ServiceTest {
 
     @Autowired

--- a/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintQueryServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintQueryServiceTest.java
@@ -117,6 +117,30 @@ class FootprintQueryServiceTest {
                         .build()
         );
 
+        petRepository.save(
+                Pet.builder()
+                        .member(member1)
+                        .name("땡이")
+                        .description("귀여운 땡이")
+                        .birthDate(LocalDate.now().minusYears(1))
+                        .sizeType(SizeType.MEDIUM)
+                        .gender(Gender.MALE_NEUTERED)
+                        .imageUrl("https://picsum.photos/200")
+                        .build()
+        );
+
+        petRepository.save(
+                Pet.builder()
+                        .member(member2)
+                        .name("땡이")
+                        .description("귀여운 땡이")
+                        .birthDate(LocalDate.now().minusYears(1))
+                        .sizeType(SizeType.MEDIUM)
+                        .gender(Gender.MALE_NEUTERED)
+                        .imageUrl("https://picsum.photos/200")
+                        .build()
+        );
+
         double nearLongitude = 0.008993216;
         double farLongitude = 0.009001209;
 

--- a/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintQueryServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintQueryServiceTest.java
@@ -10,17 +10,14 @@ import com.woowacourse.friendogly.footprint.dto.request.SaveFootprintRequest;
 import com.woowacourse.friendogly.footprint.dto.response.FindMyLatestFootprintTimeResponse;
 import com.woowacourse.friendogly.footprint.dto.response.FindNearFootprintResponse;
 import com.woowacourse.friendogly.footprint.dto.response.FindOneFootprintResponse;
-import com.woowacourse.friendogly.footprint.repository.FootprintRepository;
 import com.woowacourse.friendogly.member.domain.Member;
-import com.woowacourse.friendogly.member.repository.MemberRepository;
 import com.woowacourse.friendogly.pet.domain.Gender;
 import com.woowacourse.friendogly.pet.domain.Pet;
 import com.woowacourse.friendogly.pet.domain.SizeType;
-import com.woowacourse.friendogly.pet.repository.PetRepository;
+import com.woowacourse.friendogly.support.ServiceTest;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,7 +25,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 @SpringBootTest
-class FootprintQueryServiceTest {
+class FootprintQueryServiceTest extends ServiceTest {
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
@@ -38,22 +35,6 @@ class FootprintQueryServiceTest {
 
     @Autowired
     private FootprintCommandService footprintCommandService;
-
-    @Autowired
-    private MemberRepository memberRepository;
-
-    @Autowired
-    private FootprintRepository footprintRepository;
-
-    @Autowired
-    private PetRepository petRepository;
-
-    @AfterEach
-    void cleanUp() {
-        footprintRepository.deleteAll();
-        petRepository.deleteAll();
-        memberRepository.deleteAll();
-    }
 
     @DisplayName("Footprint ID를 통해 발자국의 정보를 조회할 수 있다.")
     @Test

--- a/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintQueryServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintQueryServiceTest.java
@@ -60,29 +60,29 @@ class FootprintQueryServiceTest {
     void findOne() {
         // given
         Member member = memberRepository.save(
-            Member.builder()
-                .name("name1")
-                .email("test@test.com")
-                .build()
+                Member.builder()
+                        .name("name1")
+                        .email("test@test.com")
+                        .build()
         );
 
         petRepository.save(
-            Pet.builder()
-                .member(member)
-                .name("petname1")
-                .description("petdescription1")
-                .birthDate(LocalDate.now().minusYears(1))
-                .sizeType(SizeType.MEDIUM)
-                .gender(Gender.MALE_NEUTERED)
-                .imageUrl("https://picsum.photos/200")
-                .build()
+                Pet.builder()
+                        .member(member)
+                        .name("petname1")
+                        .description("petdescription1")
+                        .birthDate(LocalDate.now().minusYears(1))
+                        .sizeType(SizeType.MEDIUM)
+                        .gender(Gender.MALE_NEUTERED)
+                        .imageUrl("https://picsum.photos/200")
+                        .build()
         );
 
         Footprint footprint = footprintRepository.save(
-            Footprint.builder()
-                .member(member)
-                .location(new Location(0.0, 0.0))
-                .build()
+                Footprint.builder()
+                        .member(member)
+                        .location(new Location(0.0, 0.0))
+                        .build()
         );
 
         // when
@@ -90,13 +90,13 @@ class FootprintQueryServiceTest {
 
         // then
         assertAll(
-            () -> assertThat(response.memberName()).isEqualTo("name1"),
-            () -> assertThat(response.petName()).isEqualTo("petname1"),
-            () -> assertThat(response.petDescription()).isEqualTo("petdescription1"),
-            () -> assertThat(response.petBirthDate()).isEqualTo(LocalDate.now().minusYears(1)),
-            () -> assertThat(response.petSizeType()).isEqualTo(SizeType.MEDIUM),
-            () -> assertThat(response.petGender()).isEqualTo(Gender.MALE_NEUTERED),
-            () -> assertThat(response.isMine()).isTrue()
+                () -> assertThat(response.memberName()).isEqualTo("name1"),
+                () -> assertThat(response.petName()).isEqualTo("petname1"),
+                () -> assertThat(response.petDescription()).isEqualTo("petdescription1"),
+                () -> assertThat(response.petBirthDate()).isEqualTo(LocalDate.now().minusYears(1)),
+                () -> assertThat(response.petSizeType()).isEqualTo(SizeType.MEDIUM),
+                () -> assertThat(response.petGender()).isEqualTo(Gender.MALE_NEUTERED),
+                () -> assertThat(response.isMine()).isTrue()
         );
     }
 
@@ -104,17 +104,17 @@ class FootprintQueryServiceTest {
     @Test
     void findNear() {
         Member member1 = memberRepository.save(
-            Member.builder()
-                .name("name1")
-                .email("test@test.com")
-                .build()
+                Member.builder()
+                        .name("name1")
+                        .email("test@test.com")
+                        .build()
         );
 
         Member member2 = memberRepository.save(
-            Member.builder()
-                .name("name2")
-                .email("test@test.com")
-                .build()
+                Member.builder()
+                        .name("name2")
+                        .email("test@test.com")
+                        .build()
         );
 
         double nearLongitude = 0.008993216;
@@ -127,13 +127,13 @@ class FootprintQueryServiceTest {
         footprintCommandService.save(new SaveFootprintRequest(member2.getId(), 0.0, farLongitude));
 
         List<FindNearFootprintResponse> nearFootprints = footprintQueryService.findNear(
-            member1.getId(), new FindNearFootprintRequest(0.0, 0.0));
+                member1.getId(), new FindNearFootprintRequest(0.0, 0.0));
 
         assertAll(
-            () -> assertThat(nearFootprints).extracting(FindNearFootprintResponse::latitude)
-                .containsExactly(0.0),
-            () -> assertThat(nearFootprints).extracting(FindNearFootprintResponse::longitude)
-                .containsExactly(nearLongitude)
+                () -> assertThat(nearFootprints).extracting(FindNearFootprintResponse::latitude)
+                        .containsExactly(0.0),
+                () -> assertThat(nearFootprints).extracting(FindNearFootprintResponse::longitude)
+                        .containsExactly(nearLongitude)
         );
     }
 
@@ -141,28 +141,28 @@ class FootprintQueryServiceTest {
     @Test
     void findNear24Hours() {
         Member member = memberRepository.save(
-            Member.builder()
-                .name("name")
-                .email("test@test.com")
-                .build()
+                Member.builder()
+                        .name("name")
+                        .email("test@test.com")
+                        .build()
         );
 
         jdbcTemplate.update("""
-            INSERT INTO footprint (member_id, latitude, longitude, created_at, is_deleted)
-            VALUES
-            (?, 0.00000, 0.00000, TIMESTAMPADD(HOUR, -25, NOW()), FALSE),
-            (?, 0.00000, 0.00000, TIMESTAMPADD(HOUR, -23, NOW()), FALSE),
-            (?, 0.00000, 0.00000, TIMESTAMPADD(HOUR, -22, NOW()), FALSE);
-            """, member.getId(), member.getId(), member.getId());
+                INSERT INTO footprint (member_id, latitude, longitude, created_at, is_deleted)
+                VALUES
+                (?, 0.00000, 0.00000, TIMESTAMPADD(HOUR, -25, NOW()), FALSE),
+                (?, 0.00000, 0.00000, TIMESTAMPADD(HOUR, -23, NOW()), FALSE),
+                (?, 0.00000, 0.00000, TIMESTAMPADD(HOUR, -22, NOW()), FALSE);
+                """, member.getId(), member.getId(), member.getId());
 
         List<FindNearFootprintResponse> nearFootprints = footprintQueryService.findNear(
-            member.getId(), new FindNearFootprintRequest(0.0, 0.0));
+                member.getId(), new FindNearFootprintRequest(0.0, 0.0));
 
         assertAll(
-            () -> assertThat(nearFootprints).extracting(FindNearFootprintResponse::latitude)
-                .containsExactly(0.00000, 0.00000),
-            () -> assertThat(nearFootprints).extracting(FindNearFootprintResponse::longitude)
-                .containsExactly(0.00000, 0.00000)
+                () -> assertThat(nearFootprints).extracting(FindNearFootprintResponse::latitude)
+                        .containsExactly(0.00000, 0.00000),
+                () -> assertThat(nearFootprints).extracting(FindNearFootprintResponse::longitude)
+                        .containsExactly(0.00000, 0.00000)
         );
     }
 
@@ -170,28 +170,28 @@ class FootprintQueryServiceTest {
     @Test
     void findMyLatestFootprintTime_MyFootprintExists() {
         Member member = memberRepository.save(
-            Member.builder()
-                .name("name")
-                .email("test@test.com")
-                .build()
+                Member.builder()
+                        .name("name")
+                        .email("test@test.com")
+                        .build()
         );
 
         LocalDateTime oneMinuteAgo = LocalDateTime.now().minusMinutes(1);
 
         jdbcTemplate.update("""
-            INSERT INTO footprint (member_id, latitude, longitude, created_at, is_deleted)
-            VALUES
-            (?, 0.00000, 0.00000, TIMESTAMPADD(HOUR, -25, NOW()), FALSE),
-            (?, 0.11111, 0.11111, TIMESTAMPADD(HOUR, -23, NOW()), FALSE),
-            (?, 0.22222, 0.22222, ?, FALSE);
-            """, member.getId(), member.getId(), member.getId(), oneMinuteAgo);
+                INSERT INTO footprint (member_id, latitude, longitude, created_at, is_deleted)
+                VALUES
+                (?, 0.00000, 0.00000, TIMESTAMPADD(HOUR, -25, NOW()), FALSE),
+                (?, 0.11111, 0.11111, TIMESTAMPADD(HOUR, -23, NOW()), FALSE),
+                (?, 0.22222, 0.22222, ?, FALSE);
+                """, member.getId(), member.getId(), member.getId(), oneMinuteAgo);
 
         LocalDateTime time = footprintQueryService.findMyLatestFootprintTime(member.getId()).createdAt();
 
         assertAll(
-            () -> assertThat(time.getHour()).isEqualTo(oneMinuteAgo.getHour()),
-            () -> assertThat(time.getMinute()).isEqualTo(oneMinuteAgo.getMinute()),
-            () -> assertThat(time.getSecond()).isEqualTo(oneMinuteAgo.getSecond())
+                () -> assertThat(time.getHour()).isEqualTo(oneMinuteAgo.getHour()),
+                () -> assertThat(time.getMinute()).isEqualTo(oneMinuteAgo.getMinute()),
+                () -> assertThat(time.getSecond()).isEqualTo(oneMinuteAgo.getSecond())
         );
     }
 
@@ -199,14 +199,14 @@ class FootprintQueryServiceTest {
     @Test
     void findMyLatestFootprintTime_MyFootprintDoesNotExist() {
         Member member = memberRepository.save(
-            Member.builder()
-                .name("name")
-                .email("test@test.com")
-                .build()
+                Member.builder()
+                        .name("name")
+                        .email("test@test.com")
+                        .build()
         );
 
         assertThat(footprintQueryService.findMyLatestFootprintTime(member.getId()))
-            .extracting(FindMyLatestFootprintTimeResponse::createdAt)
-            .isNull();
+                .extracting(FindMyLatestFootprintTimeResponse::createdAt)
+                .isNull();
     }
 }


### PR DESCRIPTION
## 이슈
- #164 

## 개발 사항
- 강아지가 없는 사용자는 발자국을 추가할 수 없도록 검증 추가
- 발자국 상세정보 조회에서, 강아지가 없는 경우에 대한 response를 삭제 (정책 변경에 따라 불필요해짐)
- 구현 완료된 API에 대한 문서화 완료
- 발자국 단건 조회 응답 body에 `isMine` 필드 추가
- 발자국 저장 시 응답 body 추가 - 발자국 id, 위도, 경도 응답
