### PR TITLE
[BE] feat: 인증 ArgumentResolver 구현 및 API 문서화

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -72,8 +72,25 @@ tasks.withType(Test) {
     systemProperty 'file.encoding', 'UTF-8'
 }
 
+//tasks.withType(GenerateSwaggerUI) {
+//    dependsOn 'openapi3'
+//}
+
 tasks.withType(GenerateSwaggerUI) {
     dependsOn 'openapi3'
+    doFirst {
+        def swaggerUIFile = file("${openapi3.outputDirectory}/openapi3.yaml")
+
+        def securitySchemesContent = "  securitySchemes:\n" +   \
+                                       "    APIKey:\n" +   \
+                                       "      type: apiKey\n" +   \
+                                       "      name: Authorization\n" +   \
+                                       "      in: header\n" +  \
+                                       "security:\n" +
+                "  - APIKey: []  # Apply the security scheme here"
+
+        swaggerUIFile.append securitySchemesContent
+    }
 }
 
 // 생성된 SwaggerUI 를 jar 에 포함시키기 위해 build/resources 경로로 로 복사

--- a/backend/src/main/java/com/woowacourse/friendogly/auth/Auth.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/auth/Auth.java
@@ -1,0 +1,11 @@
+package com.woowacourse.friendogly.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface Auth {
+}

--- a/backend/src/main/java/com/woowacourse/friendogly/auth/AuthArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/auth/AuthArgumentResolver.java
@@ -30,10 +30,6 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
 
         String authorizationValue = request.getHeader(HttpHeaders.AUTHORIZATION);
 
-        System.out.println("==========================");
-        System.out.println(authorizationValue);
-        System.out.println("==========================");
-
         if (authorizationValue == null) {
             throw new FriendoglyException("로그인 후에 사용할 수 있습니다.");
         }

--- a/backend/src/main/java/com/woowacourse/friendogly/auth/AuthArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/auth/AuthArgumentResolver.java
@@ -3,14 +3,15 @@ package com.woowacourse.friendogly.auth;
 import com.woowacourse.friendogly.exception.FriendoglyException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+@Component
 public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
-
-    private static final String AUTHORIZATION = "Authorization";
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -27,7 +28,12 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
         // TODO: token에서 추출하도록 변경
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
 
-        String authorizationValue = request.getHeader(AUTHORIZATION);
+        String authorizationValue = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        System.out.println("==========================");
+        System.out.println(authorizationValue);
+        System.out.println("==========================");
+
         if (authorizationValue == null) {
             throw new FriendoglyException("로그인 후에 사용할 수 있습니다.");
         }

--- a/backend/src/main/java/com/woowacourse/friendogly/auth/AuthArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/auth/AuthArgumentResolver.java
@@ -1,0 +1,37 @@
+package com.woowacourse.friendogly.auth;
+
+import com.woowacourse.friendogly.exception.FriendoglyException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final String AUTHORIZATION = "Authorization";
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(Auth.class);
+    }
+
+    @Override
+    public Long resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) throws Exception {
+        // TODO: token에서 추출하도록 변경
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+
+        String authorizationValue = request.getHeader(AUTHORIZATION);
+        if (authorizationValue == null) {
+            throw new FriendoglyException("로그인 후에 사용할 수 있습니다.");
+        }
+
+        return Long.parseLong(authorizationValue);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/friendogly/config/WebConfig.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/config/WebConfig.java
@@ -1,8 +1,12 @@
 package com.woowacourse.friendogly.config;
 
+import com.woowacourse.friendogly.auth.AuthArgumentResolver;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
@@ -14,5 +18,10 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE")
                 .allowedHeaders("*")
                 .allowCredentials(true);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new AuthArgumentResolver());
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/pet/controller/PetController.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/pet/controller/PetController.java
@@ -1,13 +1,12 @@
 package com.woowacourse.friendogly.pet.controller;
 
+import com.woowacourse.friendogly.auth.Auth;
 import com.woowacourse.friendogly.pet.dto.request.SavePetRequest;
 import com.woowacourse.friendogly.pet.dto.response.FindPetResponse;
 import com.woowacourse.friendogly.pet.dto.response.SavePetResponse;
 import com.woowacourse.friendogly.pet.service.PetCommandService;
 import com.woowacourse.friendogly.pet.service.PetQueryService;
 import jakarta.validation.Valid;
-import java.net.URI;
-import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,6 +14,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.util.List;
 
 @RestController
 @RequestMapping("/pets")
@@ -29,8 +31,11 @@ public class PetController {
     }
 
     @PostMapping
-    public ResponseEntity<SavePetResponse> savePet(@RequestBody @Valid SavePetRequest savePetRequest) {
-        SavePetResponse response = petCommandService.savePet(savePetRequest);
+    public ResponseEntity<SavePetResponse> savePet(
+            @Auth Long memberId,
+            @RequestBody @Valid SavePetRequest savePetRequest
+    ) {
+        SavePetResponse response = petCommandService.savePet(memberId, savePetRequest);
         return ResponseEntity.created(URI.create("/pets/" + response.id()))
                 .body(response);
     }
@@ -41,8 +46,8 @@ public class PetController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/mine/{memberId}")
-    public List<FindPetResponse> findByMemberId(@PathVariable Long memberId) {
+    @GetMapping("/mine")
+    public List<FindPetResponse> findByMemberId(@Auth Long memberId) {
         return petQueryService.findByMemberId(memberId);
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/pet/controller/PetController.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/pet/controller/PetController.java
@@ -7,6 +7,8 @@ import com.woowacourse.friendogly.pet.dto.response.SavePetResponse;
 import com.woowacourse.friendogly.pet.service.PetCommandService;
 import com.woowacourse.friendogly.pet.service.PetQueryService;
 import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -14,9 +16,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.net.URI;
-import java.util.List;
 
 @RestController
 @RequestMapping("/pets")
@@ -47,7 +46,7 @@ public class PetController {
     }
 
     @GetMapping("/mine")
-    public List<FindPetResponse> findByMemberId(@Auth Long memberId) {
+    public List<FindPetResponse> findMine(@Auth Long memberId) {
         return petQueryService.findByMemberId(memberId);
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/pet/controller/PetController.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/pet/controller/PetController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -47,6 +48,11 @@ public class PetController {
 
     @GetMapping("/mine")
     public List<FindPetResponse> findMine(@Auth Long memberId) {
+        return petQueryService.findByMemberId(memberId);
+    }
+
+    @GetMapping
+    public List<FindPetResponse> findByMemberId(@RequestParam Long memberId) {
         return petQueryService.findByMemberId(memberId);
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/pet/dto/request/SavePetRequest.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/pet/dto/request/SavePetRequest.java
@@ -7,16 +7,12 @@ import com.woowacourse.friendogly.pet.domain.SizeType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PastOrPresent;
-import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import org.hibernate.validator.constraints.URL;
 
 import java.time.LocalDate;
 
 public record SavePetRequest(
-        @NotNull(message = "memberId는 null을 입력할 수 없습니다.")
-        @Positive(message = "memberId는 음수일 수 없습니다.")
-        Long memberId,
 
         @NotBlank(message = "name은 빈 문자열이나 null을 입력할 수 없습니다.")
         @Size(max = 15, message = "이름은 1글자 이상 15글자 이하여야 합니다.")

--- a/backend/src/main/java/com/woowacourse/friendogly/pet/service/PetCommandService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/pet/service/PetCommandService.java
@@ -24,8 +24,8 @@ public class PetCommandService {
         this.memberRepository = memberRepository;
     }
 
-    public SavePetResponse savePet(SavePetRequest request) {
-        Member member = memberRepository.findById(request.memberId())
+    public SavePetResponse savePet(Long memberId, SavePetRequest request) {
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new FriendoglyException("존재하지 않는 Member 입니다."));
 
         validatePetCapacity(petRepository.countByMember(member));

--- a/backend/src/test/java/com/woowacourse/friendogly/docs/MemberApiDocsTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/docs/MemberApiDocsTest.java
@@ -25,12 +25,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class MemberApiDocsTest extends RestDocsTest {
 
     @MockBean
-    MemberCommandService memberCommandService;
+    private MemberCommandService memberCommandService;
 
     @MockBean
-    MemberQueryService memberQueryService;
+    private MemberQueryService memberQueryService;
 
-    @DisplayName("회원 생성 문서화 테스트 예시")
+    @DisplayName("회원 생성 문서화")
     @Test
     void saveMember_Success() throws Exception {
         SaveMemberRequest request = new SaveMemberRequest("반갑개", "member@email.com");
@@ -38,13 +38,12 @@ public class MemberApiDocsTest extends RestDocsTest {
 
         Mockito.when(memberCommandService.saveMember(request))
                 .thenReturn(response);
-        // http method() static import 가능, 단 라이브러리 확인 필수
+
         mockMvc.perform(RestDocumentationRequestBuilders.post("/members")
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isCreated())
-                //*** document() static import 가능함, 단 라이브러리 확인 필수
                 .andDo(MockMvcRestDocumentationWrapper.document("member-save-201",
                         getDocumentRequest(),
                         getDocumentResponse(),

--- a/backend/src/test/java/com/woowacourse/friendogly/docs/PetApiDocsTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/docs/PetApiDocsTest.java
@@ -1,5 +1,12 @@
 package com.woowacourse.friendogly.docs;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
@@ -8,9 +15,12 @@ import com.woowacourse.friendogly.pet.controller.PetController;
 import com.woowacourse.friendogly.pet.domain.Gender;
 import com.woowacourse.friendogly.pet.domain.SizeType;
 import com.woowacourse.friendogly.pet.dto.request.SavePetRequest;
+import com.woowacourse.friendogly.pet.dto.response.FindPetResponse;
 import com.woowacourse.friendogly.pet.dto.response.SavePetResponse;
 import com.woowacourse.friendogly.pet.service.PetCommandService;
 import com.woowacourse.friendogly.pet.service.PetQueryService;
+import java.time.LocalDate;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -21,14 +31,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
-
-import java.time.LocalDate;
-
-import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
-import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static org.mockito.ArgumentMatchers.any;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(PetController.class)
 public class PetApiDocsTest extends RestDocsTest {
@@ -95,14 +97,178 @@ public class PetApiDocsTest extends RestDocsTest {
                                         fieldWithPath("id").type(JsonFieldType.NUMBER).description("반려견 id"),
                                         fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("반려견의 주인 id"),
                                         fieldWithPath("name").type(JsonFieldType.STRING).description("반려견 이름"),
+                                        fieldWithPath("description").type(JsonFieldType.STRING)
+                                                .description("반려견 한 줄 소개"),
+                                        fieldWithPath("birthDate").type(JsonFieldType.STRING)
+                                                .description("반려견 생년월일: yyyy-MM-dd"),
+                                        fieldWithPath("sizeType").type(JsonFieldType.STRING)
+                                                .description("반려견 크기: SMALL, MEDIUM, LARGE"),
+                                        fieldWithPath("gender").type(JsonFieldType.STRING)
+                                                .description("반려견 성별: MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED"),
+                                        fieldWithPath("imageUrl").type(JsonFieldType.STRING).description("반려견 이미지 URL")
+                                )
+                                .requestSchema(Schema.schema("SavePetRequest"))
+                                .responseSchema(Schema.schema("SavePetResponse"))
+                                .build()))
+                );
+    }
+
+    @DisplayName("반려견 단건 조회 문서화")
+    @Test
+    void findById_Success() throws Exception {
+        Long petId = 1L;
+        FindPetResponse response = new FindPetResponse(
+                petId,
+                1L,
+                "땡이",
+                "땡이입니다.",
+                LocalDate.now().minusDays(1L),
+                SizeType.SMALL.toString(),
+                Gender.FEMALE.toString(),
+                "https://google.com"
+        );
+
+        Mockito.when(petQueryService.findById(any()))
+                .thenReturn(response);
+
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/pets/{id}", petId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(MockMvcRestDocumentationWrapper.document("pet-findById-200",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Pet API")
+                                .summary("반려견 단건 조회 API")
+                                .pathParameters(
+                                        parameterWithName("id").description("조회하려는 반려견 id")
+                                )
+                                .responseFields(
+                                        fieldWithPath("id").type(JsonFieldType.NUMBER).description("반려견 id"),
+                                        fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("반려견의 주인 id"),
+                                        fieldWithPath("name").type(JsonFieldType.STRING).description("반려견 이름"),
                                         fieldWithPath("description").type(JsonFieldType.STRING).description("반려견 한 줄 소개"),
                                         fieldWithPath("birthDate").type(JsonFieldType.STRING).description("반려견 생년월일: yyyy-MM-dd"),
                                         fieldWithPath("sizeType").type(JsonFieldType.STRING).description("반려견 크기: SMALL, MEDIUM, LARGE"),
                                         fieldWithPath("gender").type(JsonFieldType.STRING).description("반려견 성별: MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED"),
                                         fieldWithPath("imageUrl").type(JsonFieldType.STRING).description("반려견 이미지 URL")
                                 )
-                                .requestSchema(Schema.schema("SavePetRequest"))
-                                .responseSchema(Schema.schema("SavePetResponse"))
+                                .requestSchema(Schema.schema("FindPetByIdRequest"))
+                                .responseSchema(Schema.schema("FindPetByIdResponse"))
+                                .build()))
+                );
+    }
+
+    @DisplayName("내 반려견 목록 조회 문서화")
+    @Test
+    void findMine_Success() throws Exception {
+        Long loginMemberId = 1L;
+        FindPetResponse response1 = new FindPetResponse(
+                1L,
+                loginMemberId,
+                "땡이",
+                "땡이입니다.",
+                LocalDate.now().minusDays(1L),
+                SizeType.SMALL.toString(),
+                Gender.FEMALE.toString(),
+                "https://google.com"
+        );
+        FindPetResponse response2 = new FindPetResponse(
+                2L,
+                loginMemberId,
+                "뚱이",
+                "뚱이입니다.",
+                LocalDate.now().minusDays(2L),
+                SizeType.LARGE.toString(),
+                Gender.MALE_NEUTERED.toString(),
+                "https://google.com"
+        );
+        List<FindPetResponse> response = List.of(response1, response2);
+
+        Mockito.when(petQueryService.findByMemberId(any()))
+                .thenReturn(response);
+
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/pets/mine")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, loginMemberId.toString()))
+                .andExpect(status().isOk())
+                .andDo(MockMvcRestDocumentationWrapper.document("pet-findMine-200",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Pet API")
+                                .summary("내 반려견 목록 조회 API")
+                                .requestHeaders(
+                                        headerWithName("Authorization").description("로그인한 회원 id")
+                                )
+                                .responseFields(
+                                        fieldWithPath("[].id").type(JsonFieldType.NUMBER).description("반려견 id"),
+                                        fieldWithPath("[].memberId").type(JsonFieldType.NUMBER).description("반려견의 주인 id"),
+                                        fieldWithPath("[].name").type(JsonFieldType.STRING).description("반려견 이름"),
+                                        fieldWithPath("[].description").type(JsonFieldType.STRING).description("반려견 한 줄 소개"),
+                                        fieldWithPath("[].birthDate").type(JsonFieldType.STRING).description("반려견 생년월일: yyyy-MM-dd"),
+                                        fieldWithPath("[].sizeType").type(JsonFieldType.STRING).description("반려견 크기: SMALL, MEDIUM, LARGE"),
+                                        fieldWithPath("[].gender").type(JsonFieldType.STRING).description("반려견 성별: MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED"),
+                                        fieldWithPath("[].imageUrl").type(JsonFieldType.STRING).description("반려견 이미지 URL")
+                                )
+                                .responseSchema(Schema.schema("FindPetResponse"))
+                                .build()))
+                );
+    }
+
+    @DisplayName("특정 회원의 반려견 목록 조회 문서화")
+    @Test
+    void findByMemberId_Success() throws Exception {
+        Long memberId = 1L;
+        FindPetResponse response1 = new FindPetResponse(
+                1L,
+                memberId,
+                "땡이",
+                "땡이입니다.",
+                LocalDate.now().minusDays(1L),
+                SizeType.SMALL.toString(),
+                Gender.FEMALE.toString(),
+                "https://google.com"
+        );
+        FindPetResponse response2 = new FindPetResponse(
+                2L,
+                memberId,
+                "뚱이",
+                "뚱이입니다.",
+                LocalDate.now().minusDays(2L),
+                SizeType.LARGE.toString(),
+                Gender.MALE_NEUTERED.toString(),
+                "https://google.com"
+        );
+        List<FindPetResponse> response = List.of(response1, response2);
+
+        Mockito.when(petQueryService.findByMemberId(any()))
+                .thenReturn(response);
+
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/pets")
+                        .param("memberId", memberId.toString())
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(MockMvcRestDocumentationWrapper.document("pet-findByMemberId-200",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Pet API")
+                                .summary("특정 회원의 반려견 목록 조회 API")
+                                .queryParameters(
+                                        parameterWithName("memberId").description("조회하려는 회원의 id")
+                                )
+                                .responseFields(
+                                        fieldWithPath("[].id").type(JsonFieldType.NUMBER).description("반려견 id"),
+                                        fieldWithPath("[].memberId").type(JsonFieldType.NUMBER).description("반려견의 주인 id"),
+                                        fieldWithPath("[].name").type(JsonFieldType.STRING).description("반려견 이름"),
+                                        fieldWithPath("[].description").type(JsonFieldType.STRING).description("반려견 한 줄 소개"),
+                                        fieldWithPath("[].birthDate").type(JsonFieldType.STRING).description("반려견 생년월일: yyyy-MM-dd"),
+                                        fieldWithPath("[].sizeType").type(JsonFieldType.STRING).description("반려견 크기: SMALL, MEDIUM, LARGE"),
+                                        fieldWithPath("[].gender").type(JsonFieldType.STRING).description("반려견 성별: MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED"),
+                                        fieldWithPath("[].imageUrl").type(JsonFieldType.STRING).description("반려견 이미지 URL")
+                                )
+                                .responseSchema(Schema.schema("FindPetResponse"))
                                 .build()))
                 );
     }

--- a/backend/src/test/java/com/woowacourse/friendogly/docs/PetApiDocsTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/docs/PetApiDocsTest.java
@@ -1,0 +1,114 @@
+package com.woowacourse.friendogly.docs;
+
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.woowacourse.friendogly.auth.AuthArgumentResolver;
+import com.woowacourse.friendogly.pet.controller.PetController;
+import com.woowacourse.friendogly.pet.domain.Gender;
+import com.woowacourse.friendogly.pet.domain.SizeType;
+import com.woowacourse.friendogly.pet.dto.request.SavePetRequest;
+import com.woowacourse.friendogly.pet.dto.response.SavePetResponse;
+import com.woowacourse.friendogly.pet.service.PetCommandService;
+import com.woowacourse.friendogly.pet.service.PetQueryService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import java.time.LocalDate;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PetController.class)
+public class PetApiDocsTest extends RestDocsTest {
+
+    @MockBean
+    private PetCommandService petCommandService;
+
+    @MockBean
+    private PetQueryService petQueryService;
+
+    @Autowired
+    private AuthArgumentResolver authArgumentResolver;
+
+    @DisplayName("반려견 등록 문서화")
+    @Test
+    void savePet_Success() throws Exception {
+        Long loginMemberId = 1L;
+        SavePetRequest request = new SavePetRequest(
+                "땡이",
+                "땡이입니다.",
+                LocalDate.now().minusDays(1L),
+                SizeType.SMALL.toString(),
+                Gender.FEMALE.toString(),
+                "https://google.com"
+        );
+        SavePetResponse response = new SavePetResponse(
+                1L,
+                loginMemberId,
+                "땡이",
+                "땡이입니다.",
+                LocalDate.now().minusDays(1L),
+                SizeType.SMALL.toString(),
+                Gender.FEMALE.toString(),
+                "https://google.com"
+        );
+
+        Mockito.when(petCommandService.savePet(any(), any()))
+                .thenReturn(response);
+
+        mockMvc.perform(RestDocumentationRequestBuilders.post("/pets")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, loginMemberId.toString()))
+                .andExpect(status().isCreated())
+                .andDo(MockMvcRestDocumentationWrapper.document("pet-save-201",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Pet API")
+                                .summary("반려견 등록 API")
+                                .requestHeaders(
+                                        headerWithName("Authorization").description("로그인한 회원 id")
+                                )
+                                .requestFields(
+                                        fieldWithPath("name").type(JsonFieldType.STRING).description("반려견 이름"),
+                                        fieldWithPath("description").type(JsonFieldType.STRING).description("반려견 한 줄 소개"),
+                                        fieldWithPath("birthDate").type(JsonFieldType.STRING).description("반려견 생년월일: yyyy-MM-dd"),
+                                        fieldWithPath("sizeType").type(JsonFieldType.STRING).description("반려견 크기: SMALL, MEDIUM, LARGE"),
+                                        fieldWithPath("gender").type(JsonFieldType.STRING).description("반려견 성별: MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED"),
+                                        fieldWithPath("imageUrl").type(JsonFieldType.STRING).description("반려견 이미지 URL")
+                                )
+                                .responseFields(
+                                        fieldWithPath("id").type(JsonFieldType.NUMBER).description("반려견 id"),
+                                        fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("반려견의 주인 id"),
+                                        fieldWithPath("name").type(JsonFieldType.STRING).description("반려견 이름"),
+                                        fieldWithPath("description").type(JsonFieldType.STRING).description("반려견 한 줄 소개"),
+                                        fieldWithPath("birthDate").type(JsonFieldType.STRING).description("반려견 생년월일: yyyy-MM-dd"),
+                                        fieldWithPath("sizeType").type(JsonFieldType.STRING).description("반려견 크기: SMALL, MEDIUM, LARGE"),
+                                        fieldWithPath("gender").type(JsonFieldType.STRING).description("반려견 성별: MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED"),
+                                        fieldWithPath("imageUrl").type(JsonFieldType.STRING).description("반려견 이미지 URL")
+                                )
+                                .requestSchema(Schema.schema("SavePetRequest"))
+                                .responseSchema(Schema.schema("SavePetResponse"))
+                                .build()))
+                );
+    }
+
+    @Override
+    protected Object controller() {
+        return new PetController(petQueryService, petCommandService);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/friendogly/pet/controller/PetControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/pet/controller/PetControllerTest.java
@@ -8,10 +8,9 @@ import io.restassured.http.ContentType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
 
@@ -46,7 +45,6 @@ class PetControllerTest {
     @Test
     void savePet() {
         SavePetRequest request = new SavePetRequest(
-                member.getId(),
                 "땡이",
                 "땡이입니다.",
                 LocalDate.now().minusDays(1L),
@@ -57,39 +55,17 @@ class PetControllerTest {
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, member.getId())
                 .body(request)
                 .when().post("/pets")
                 .then().log().all()
                 .statusCode(HttpStatus.CREATED.value());
     }
 
-    @DisplayName("memberId가 양수가 아닌 경우 400을 반환한다.")
-    @ValueSource(longs = {-1L, 0L})
-    @ParameterizedTest
-    void savePet_Fail_NonPositiveMemberId(Long idInput) {
-        SavePetRequest request = new SavePetRequest(
-                idInput,
-                "1234567890123456",
-                "땡이입니다.",
-                LocalDate.now().minusDays(1L),
-                "SMALL",
-                "FEMALE_NEUTERED",
-                "http://www.google.com"
-        );
-
-        RestAssured.given().log().all()
-                .contentType(ContentType.JSON)
-                .body(request)
-                .when().post("/pets")
-                .then().log().all()
-                .statusCode(HttpStatus.BAD_REQUEST.value());
-    }
-
     @DisplayName("닉네임 길이가 15자를 초과하는 경우 400을 반환한다.")
     @Test
     void savePet_Fail_NameLengthOver() {
         SavePetRequest request = new SavePetRequest(
-                member.getId(),
                 "1234567890123456",
                 "땡이입니다.",
                 LocalDate.now().minusDays(1L),
@@ -100,6 +76,7 @@ class PetControllerTest {
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, member.getId())
                 .body(request)
                 .when().post("/pets")
                 .then().log().all()
@@ -110,7 +87,6 @@ class PetControllerTest {
     @Test
     void savePet_Fail_DescriptionLengthOver() {
         SavePetRequest request = new SavePetRequest(
-                member.getId(),
                 "땡이",
                 "1234567890123456",
                 LocalDate.now().minusDays(1L),
@@ -121,6 +97,7 @@ class PetControllerTest {
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, member.getId())
                 .body(request)
                 .when().post("/pets")
                 .then().log().all()
@@ -131,7 +108,6 @@ class PetControllerTest {
     @Test
     void savePet_Fail_BirthDateFuture() {
         SavePetRequest request = new SavePetRequest(
-                member.getId(),
                 "땡이",
                 "땡이입니다.",
                 LocalDate.now().plusDays(1L),
@@ -142,6 +118,7 @@ class PetControllerTest {
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, member.getId())
                 .body(request)
                 .when().post("/pets")
                 .then().log().all()
@@ -152,7 +129,6 @@ class PetControllerTest {
     @Test
     void savePet_Fail_InvalidUrlFormat() {
         SavePetRequest request = new SavePetRequest(
-                member.getId(),
                 "땡이",
                 "땡이입니다.",
                 LocalDate.now().minusDays(1L),
@@ -163,6 +139,7 @@ class PetControllerTest {
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, member.getId())
                 .body(request)
                 .when().post("/pets")
                 .then().log().all()
@@ -173,7 +150,6 @@ class PetControllerTest {
     @Test
     void savePet_Fail_OverPetCapacity() {
         SavePetRequest request = new SavePetRequest(
-                member.getId(),
                 "땡이",
                 "땡이입니다.",
                 LocalDate.now().minusDays(1L),
@@ -184,6 +160,7 @@ class PetControllerTest {
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, member.getId())
                 .body(request)
                 .when().post("/pets")
                 .then().log().all()
@@ -191,6 +168,7 @@ class PetControllerTest {
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, member.getId())
                 .body(request)
                 .when().post("/pets")
                 .then().log().all()
@@ -198,6 +176,7 @@ class PetControllerTest {
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, member.getId())
                 .body(request)
                 .when().post("/pets")
                 .then().log().all()
@@ -205,6 +184,7 @@ class PetControllerTest {
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, member.getId())
                 .body(request)
                 .when().post("/pets")
                 .then().log().all()
@@ -212,6 +192,7 @@ class PetControllerTest {
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, member.getId())
                 .body(request)
                 .when().post("/pets")
                 .then().log().all()
@@ -219,6 +200,7 @@ class PetControllerTest {
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, member.getId())
                 .body(request)
                 .when().post("/pets")
                 .then().log().all()


### PR DESCRIPTION
## 이슈
- close #161 
- close #162 

## 개발 사항
- Authorization 헤더에서 memberId를 읽어와 인자로 넣어주는 ArgumentResolver 구현
- 회원 및 반려견 도메인 API 문서화

# 전달 사항
- 토큰 관련 정보 없이 임시로 구현한 ArgumentResolver입니다.
- 컨트롤러 메서드 파라미터에 `@Auth` 어노테이션 걸어주시면 ArgumentResolver가 Authorization 헤더에서 값 꺼내서 넣어줍니다.
- swgger 인증 설정 추가했습니다. (build.gradle 변경 있음) 아래 버튼 눌러서 Authorization 헤더에 값 넣어줄 수 있습니다. 로그인 필요한 API의 경우, 항상 해당 헤더에 값 넣어야 정상 동작합니다.

![image](https://github.com/user-attachments/assets/00672a3d-16d8-47bd-9ddd-b6acccd9d065)
