### PR TITLE
[BE] `Authorization` 헤더 사용하도록 리팩토링

### DIFF
--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
@@ -1,5 +1,6 @@
 package com.woowacourse.friendogly.footprint.controller;
 
+import com.woowacourse.friendogly.auth.Auth;
 import com.woowacourse.friendogly.footprint.dto.request.FindNearFootprintRequest;
 import com.woowacourse.friendogly.footprint.dto.request.SaveFootprintRequest;
 import com.woowacourse.friendogly.footprint.dto.request.UpdateFootprintImageRequest;
@@ -39,37 +40,45 @@ public class FootprintController {
     }
 
     @PostMapping
-    public ResponseEntity<SaveFootprintResponse> save(@Valid @RequestBody SaveFootprintRequest request) {
-        SaveFootprintResponse response = footprintCommandService.save(1L, request);
+    public ResponseEntity<SaveFootprintResponse> save(
+            @Auth Long memberId,
+            @Valid @RequestBody SaveFootprintRequest request
+    ) {
+        SaveFootprintResponse response = footprintCommandService.save(memberId, request);
         return ResponseEntity.created(URI.create("/footprints/" + response.id()))
                 .body(response);
     }
 
     @GetMapping("/{footprintId}")
-    public ResponseEntity<FindOneFootprintResponse> findOne(@PathVariable Long footprintId) {
+    public ResponseEntity<FindOneFootprintResponse> findOne(
+            @Auth Long memberId,
+            @PathVariable Long footprintId
+    ) {
         // TODO: 추후 토큰에서 memberId를 가져오도록 변경
-        FindOneFootprintResponse response = footprintQueryService.findOne(1L, footprintId);
+        FindOneFootprintResponse response = footprintQueryService.findOne(memberId, footprintId);
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/near")
-    public ResponseEntity<List<FindNearFootprintResponse>> findNear(@Valid FindNearFootprintRequest request) {
-        // memberId == 1L 로 dummy data 사용
+    public ResponseEntity<List<FindNearFootprintResponse>> findNear(
+            @Auth Long memberId,
+            @Valid FindNearFootprintRequest request
+    ) {
         // TODO: 추후 토큰에서 memberId를 가져오도록 변경
-        List<FindNearFootprintResponse> response = footprintQueryService.findNear(1L, request);
+        List<FindNearFootprintResponse> response = footprintQueryService.findNear(memberId, request);
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/mine/latest")
-    public ResponseEntity<FindMyLatestFootprintTimeResponse> findMyLatestFootprintTime() {
-        // memberId == 1L 로 dummy data 사용
+    public ResponseEntity<FindMyLatestFootprintTimeResponse> findMyLatestFootprintTime(@Auth Long memberId) {
         // TODO: 추후 토큰에서 memberId를 가져오도록 변경
-        FindMyLatestFootprintTimeResponse response = footprintQueryService.findMyLatestFootprintTime(1L);
+        FindMyLatestFootprintTimeResponse response = footprintQueryService.findMyLatestFootprintTime(memberId);
         return ResponseEntity.ok(response);
     }
 
     @PatchMapping("/image/{footprintId}")
     public ResponseEntity<UpdateFootprintImageResponse> updateFootprintImage(
+            @Auth Long memberId,
             @PathVariable Long footprintId,
             @ModelAttribute UpdateFootprintImageRequest request
     ) {

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/controller/FootprintController.java
@@ -83,7 +83,8 @@ public class FootprintController {
             @ModelAttribute UpdateFootprintImageRequest request
     ) {
         // TODO: S3가 구현되고 명세가 확정되면 그 때 문서화하기
-        UpdateFootprintImageResponse response = footprintCommandService.updateFootprintImage(footprintId, request);
+        UpdateFootprintImageResponse response =
+                footprintCommandService.updateFootprintImage(memberId, footprintId, request);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindOneFootprintResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindOneFootprintResponse.java
@@ -6,6 +6,7 @@ import com.woowacourse.friendogly.pet.domain.Gender;
 import com.woowacourse.friendogly.pet.domain.Pet;
 import com.woowacourse.friendogly.pet.domain.SizeType;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public record FindOneFootprintResponse(
         String memberName,
@@ -15,6 +16,7 @@ public record FindOneFootprintResponse(
         SizeType petSizeType,
         Gender petGender,
         String footprintImageUrl,
+        LocalDateTime createdAt,
         boolean isMine
 ) {
 
@@ -27,6 +29,7 @@ public record FindOneFootprintResponse(
                 mainPet.getSizeType(),
                 mainPet.getGender(),
                 footprint.getImageUrl(),
+                footprint.getCreatedAt(),
                 isMine
         );
     }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintCommandService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintCommandService.java
@@ -81,6 +81,7 @@ public class FootprintCommandService {
         Footprint footprint = footprintRepository.findById(footprintId)
                 .orElseThrow(() -> new FriendoglyException("존재하지 않는 Footprint ID입니다."));
 
+        // TODO: 자신의 발자국이 아니면 사진을 업데이트할 수 없다. 검증 추가하기!
         MultipartFile multipartFile = request.imageFile();
         // TODO: 더미 데이터 URL입니다. 나중에 이미지 저장소(AWS S3)와 연동 필요 !!!
         // TODO: 연동 완료되면 테스트도 작성 필요합니다.

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintCommandService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintCommandService.java
@@ -77,11 +77,21 @@ public class FootprintCommandService {
         }
     }
 
-    public UpdateFootprintImageResponse updateFootprintImage(Long footprintId, UpdateFootprintImageRequest request) {
+    public UpdateFootprintImageResponse updateFootprintImage(
+            Long memberId,
+            Long footprintId,
+            UpdateFootprintImageRequest request
+    ) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new FriendoglyException("존재하지 않는 사용자 ID입니다."));
+
         Footprint footprint = footprintRepository.findById(footprintId)
                 .orElseThrow(() -> new FriendoglyException("존재하지 않는 Footprint ID입니다."));
 
-        // TODO: 자신의 발자국이 아니면 사진을 업데이트할 수 없다. 검증 추가하기!
+        if (!footprint.isCreatedBy(memberId)) {
+            throw new FriendoglyException("자신의 발자국만 수정할 수 있습니다.");
+        }
+
         MultipartFile multipartFile = request.imageFile();
         // TODO: 더미 데이터 URL입니다. 나중에 이미지 저장소(AWS S3)와 연동 필요 !!!
         // TODO: 연동 완료되면 테스트도 작성 필요합니다.

--- a/backend/src/test/java/com/woowacourse/friendogly/docs/FootprintApiDocsTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/docs/FootprintApiDocsTest.java
@@ -5,6 +5,7 @@ import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.LOCATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
@@ -52,13 +53,14 @@ public class FootprintApiDocsTest extends RestDocsTest {
         SaveFootprintRequest request = new SaveFootprintRequest(37.5173316, 127.1011661);
         SaveFootprintResponse response = new SaveFootprintResponse(1L, 37.5173316, 127.1011661);
 
-        given(footprintCommandService.save(any(Long.class), eq(request)))
+        given(footprintCommandService.save(any(), eq(request)))
                 .willReturn(response);
 
         mockMvc
                 .perform(post("/footprints")
                         .content(objectMapper.writeValueAsString(request))
-                        .contentType(APPLICATION_JSON))
+                        .contentType(APPLICATION_JSON)
+                        .header(AUTHORIZATION, "1"))
                 .andDo(print())
                 .andDo(document("footprints/save",
                         getDocumentRequest(),
@@ -66,6 +68,9 @@ public class FootprintApiDocsTest extends RestDocsTest {
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Footprint API")
                                 .summary("발자국 저장 API")
+                                .requestHeaders(
+                                        headerWithName(AUTHORIZATION).description("로그인한 회원 ID")
+                                )
                                 .requestFields(
                                         fieldWithPath("latitude").description("현재 위치의 위도"),
                                         fieldWithPath("longitude").description("현재 위치의 경도")
@@ -102,11 +107,12 @@ public class FootprintApiDocsTest extends RestDocsTest {
                 true
         );
 
-        given(footprintQueryService.findOne(any(Long.class), any(Long.class)))
+        given(footprintQueryService.findOne(any(), any()))
                 .willReturn(response);
 
         mockMvc
-                .perform(get("/footprints/{footprintId}", 1L))
+                .perform(get("/footprints/{footprintId}", 1L)
+                        .header(AUTHORIZATION, 1L))
                 .andDo(print())
                 .andDo(document("footprints/findOne",
                         getDocumentRequest(),
@@ -114,6 +120,9 @@ public class FootprintApiDocsTest extends RestDocsTest {
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Footprint API")
                                 .summary("발자국 세부정보 단건 조회 API")
+                                .requestHeaders(
+                                        headerWithName(AUTHORIZATION).description("로그인한 회원 ID")
+                                )
                                 .pathParameters(
                                         parameterWithName("footprintId").description("발자국 ID")
                                 )
@@ -154,13 +163,14 @@ public class FootprintApiDocsTest extends RestDocsTest {
                         "https://picsum.photos/250")
         );
 
-        given(footprintQueryService.findNear(any(Long.class), eq(request)))
+        given(footprintQueryService.findNear(any(), any()))
                 .willReturn(response);
 
         mockMvc
                 .perform(get("/footprints/near")
                         .param("latitude", "37.5173316")
-                        .param("longitude", "127.1011661"))
+                        .param("longitude", "127.1011661")
+                        .header(AUTHORIZATION, 1L))
                 .andDo(print())
                 .andDo(document("footprints/near",
                         getDocumentRequest(),
@@ -168,6 +178,9 @@ public class FootprintApiDocsTest extends RestDocsTest {
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Footprint API")
                                 .summary("주변 발자국 조회 API")
+                                .requestHeaders(
+                                        headerWithName(AUTHORIZATION).description("로그인한 회원 ID")
+                                )
                                 .queryParameters(
                                         parameterWithName("latitude").description("현재 위치의 위도"),
                                         parameterWithName("longitude").description("현재 위치의 경도")
@@ -194,11 +207,12 @@ public class FootprintApiDocsTest extends RestDocsTest {
                 LocalDateTime.now().minusHours(1)
         );
 
-        given(footprintQueryService.findMyLatestFootprintTime(any(Long.class)))
+        given(footprintQueryService.findMyLatestFootprintTime(any()))
                 .willReturn(response);
 
         mockMvc
-                .perform(get("/footprints/mine/latest"))
+                .perform(get("/footprints/mine/latest")
+                        .header(AUTHORIZATION, 1L))
                 .andDo(print())
                 .andDo(document("footprints/findMyLatestFootprintTime",
                         getDocumentRequest(),
@@ -206,6 +220,9 @@ public class FootprintApiDocsTest extends RestDocsTest {
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Footprint API")
                                 .summary("자신의 마지막 발자국 시간 조회 API")
+                                .requestHeaders(
+                                        headerWithName(AUTHORIZATION).description("로그인한 회원 ID")
+                                )
                                 .responseFields(
                                         fieldWithPath("createdAt").description("자신의 가장 최근 발자국 생성 시간")
                                 )

--- a/backend/src/test/java/com/woowacourse/friendogly/docs/FootprintApiDocsTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/docs/FootprintApiDocsTest.java
@@ -64,7 +64,7 @@ public class FootprintApiDocsTest extends RestDocsTest {
                         getDocumentRequest(),
                         getDocumentResponse(),
                         resource(ResourceSnippetParameters.builder()
-                                .tag("발자국 저장 API")
+                                .tag("Footprint API")
                                 .summary("발자국 저장 API")
                                 .requestFields(
                                         fieldWithPath("latitude").description("현재 위치의 위도"),
@@ -112,7 +112,7 @@ public class FootprintApiDocsTest extends RestDocsTest {
                         getDocumentRequest(),
                         getDocumentResponse(),
                         resource(ResourceSnippetParameters.builder()
-                                .tag("발자국 세부정보 단건 조회 API")
+                                .tag("Footprint API")
                                 .summary("발자국 세부정보 단건 조회 API")
                                 .pathParameters(
                                         parameterWithName("footprintId").description("발자국 ID")
@@ -166,7 +166,7 @@ public class FootprintApiDocsTest extends RestDocsTest {
                         getDocumentRequest(),
                         getDocumentResponse(),
                         resource(ResourceSnippetParameters.builder()
-                                .tag("주변 발자국 조회 API")
+                                .tag("Footprint API")
                                 .summary("주변 발자국 조회 API")
                                 .queryParameters(
                                         parameterWithName("latitude").description("현재 위치의 위도"),
@@ -204,7 +204,7 @@ public class FootprintApiDocsTest extends RestDocsTest {
                         getDocumentRequest(),
                         getDocumentResponse(),
                         resource(ResourceSnippetParameters.builder()
-                                .tag("자신의 마지막 발자국 시간 조회 API")
+                                .tag("Footprint API")
                                 .summary("자신의 마지막 발자국 시간 조회 API")
                                 .responseFields(
                                         fieldWithPath("createdAt").description("자신의 가장 최근 발자국 생성 시간")

--- a/backend/src/test/java/com/woowacourse/friendogly/docs/FootprintApiDocsTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/docs/FootprintApiDocsTest.java
@@ -98,6 +98,7 @@ public class FootprintApiDocsTest extends RestDocsTest {
                 SizeType.MEDIUM,
                 Gender.FEMALE_NEUTERED,
                 "https://picsum.photos/200",
+                LocalDateTime.now(),
                 true
         );
 
@@ -124,6 +125,7 @@ public class FootprintApiDocsTest extends RestDocsTest {
                                         fieldWithPath("petSizeType").description("발자국을 찍은 회원의 강아지 사이즈"),
                                         fieldWithPath("petGender").description("발자국을 찍은 회원의 강아지 성별(중성화 포함)"),
                                         fieldWithPath("footprintImageUrl").description("발자국의 이미지 URL"),
+                                        fieldWithPath("createdAt").description("발자국이 생성된 시간"),
                                         fieldWithPath("isMine").description("내 발자국인지 여부 (내 발자국이면 true)")
                                 )
                                 .requestSchema(Schema.schema("FindOneFootprintRequest"))


### PR DESCRIPTION
## 이슈
- #170 

## 개발 사항
- `Authorization` 헤더에서 Member ID를 가져와서 사용하도록 수정
- 발자국 단건 조회 응답에 `createdAt` 헤더 추가 (안드로이드 팀 요청)
- 다른 사람의 발자국을 수정할 수 없도록 검증 로직 추가
- API 문서 정리

## 리뷰 요청 사항
- 빠르게 리뷰 부탁드립니다! 나머지 부분은 너무 사소해서, [Service 클래스만 봐주시면 될 것 같아요.](https://github.com/woowacourse-teams/2024-friendogly/pull/171/commits/49b1330e0a9ae7939c3fcefe04cc0c865b234198)