### PR TITLE
[BE] feat: 시간대 설정, 날짜 응답 포맷 일괄 지정

### DIFF
--- a/backend/src/main/java/com/woowacourse/friendogly/FriendoglyApplication.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/FriendoglyApplication.java
@@ -1,10 +1,17 @@
 package com.woowacourse.friendogly;
 
+import jakarta.annotation.PostConstruct;
+import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class FriendoglyApplication {
+
+    @PostConstruct
+    void setTimeZone() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
 
     public static void main(String[] args) {
         SpringApplication.run(FriendoglyApplication.class, args);

--- a/backend/src/main/java/com/woowacourse/friendogly/config/TimeFormatConfig.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/config/TimeFormatConfig.java
@@ -1,0 +1,27 @@
+package com.woowacourse.friendogly.config;
+
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
+import java.time.format.DateTimeFormatter;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeFormatConfig {
+
+    private static final String DATE_FORMAT = "yyyy-MM-dd";
+    private static final String TIME_FORMAT = "HH:mm:ss.SSS";
+    private static final String DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS";
+
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer customizeTimeFormat() {
+        return builder -> {
+            builder.simpleDateFormat(DATE_TIME_FORMAT);
+            builder.serializers(new LocalDateSerializer(DateTimeFormatter.ofPattern(DATE_FORMAT)));
+            builder.serializers(new LocalTimeSerializer(DateTimeFormatter.ofPattern(TIME_FORMAT)));
+            builder.serializers(new LocalDateTimeSerializer(DateTimeFormatter.ofPattern(DATE_TIME_FORMAT)));
+        };
+    }
+}

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindMyLatestFootprintTimeResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindMyLatestFootprintTimeResponse.java
@@ -1,11 +1,9 @@
 package com.woowacourse.friendogly.footprint.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 
 public record FindMyLatestFootprintTimeResponse(
-        // TODO: 패턴을 통일시키고 나서 어노테이션 지우기
-        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt
+        LocalDateTime createdAt
 ) {
 
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindNearFootprintResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindNearFootprintResponse.java
@@ -1,6 +1,5 @@
 package com.woowacourse.friendogly.footprint.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.woowacourse.friendogly.footprint.domain.Footprint;
 import java.time.LocalDateTime;
 

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindNearFootprintResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindNearFootprintResponse.java
@@ -8,8 +8,7 @@ public record FindNearFootprintResponse(
         Long footprintId,
         double latitude,
         double longitude,
-        // TODO: 패턴을 통일시키고 나서 어노테이션 지우기
-        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
+        LocalDateTime createdAt,
         boolean isMine,
         String imageUrl
 ) {

--- a/backend/src/test/java/com/woowacourse/friendogly/docs/RestDocsTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/docs/RestDocsTest.java
@@ -28,6 +28,10 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 @ExtendWith(RestDocumentationExtension.class)
 abstract class RestDocsTest {
+
+    private static final String DATE_FORMAT = "yyyy-MM-dd";
+    private static final String TIME_FORMAT = "HH:mm:ss.SSS";
+    private static final String DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS";
     protected static ObjectMapper objectMapper;
 
     protected MockMvc mockMvc;
@@ -36,9 +40,10 @@ abstract class RestDocsTest {
     static void beforeAll() {
         objectMapper = new ObjectMapper();
         JavaTimeModule module = new JavaTimeModule();
-        module.addSerializer(LocalTime.class, new LocalTimeSerializer(DateTimeFormatter.ISO_LOCAL_TIME));
-        module.addSerializer(LocalDate.class, new LocalDateSerializer(DateTimeFormatter.ISO_LOCAL_DATE));
-        module.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer(DateTimeFormatter.ISO_LOCAL_DATE));
+        module.addSerializer(LocalDate.class, new LocalDateSerializer(DateTimeFormatter.ofPattern(DATE_FORMAT)));
+        module.addSerializer(LocalTime.class, new LocalTimeSerializer(DateTimeFormatter.ofPattern(TIME_FORMAT)));
+        module.addSerializer(
+                LocalDateTime.class, new LocalDateTimeSerializer(DateTimeFormatter.ofPattern(DATE_TIME_FORMAT)));
         objectMapper.registerModule(module);
     }
 

--- a/backend/src/test/java/com/woowacourse/friendogly/support/ServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/support/ServiceTest.java
@@ -6,6 +6,8 @@ import com.woowacourse.friendogly.club.repository.ClubRepository;
 import com.woowacourse.friendogly.footprint.repository.FootprintRepository;
 import com.woowacourse.friendogly.member.repository.MemberRepository;
 import com.woowacourse.friendogly.pet.repository.PetRepository;
+import java.util.TimeZone;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -30,6 +32,11 @@ public abstract class ServiceTest {
 
     @Autowired
     protected FootprintRepository footprintRepository;
+
+    @BeforeAll
+    static void setTimeZone() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
 
     @BeforeEach
     void clearDB() {


### PR DESCRIPTION
## 이슈
- #174 

## 개발 사항
- 시간대를 대한민국 표준시인 `Asia/Seoul` 으로 지정
- 프로덕션 코드와 문서화 테스트 코드에서, 날짜 응답 포맷을 다음과 같이 지정
  - `LocalDate`: `yyyy-MM-dd`
  - `LocalTime`: `HH:mm:ss.SSS`
  - `LocalDateTime`: `yyyy-MM-dd HH:mm:ss.SSS`
- `RestDocsTest`에서 `LocalDateTime`을 제대로 문서화하지 못하였던 오류 수정
- `Footprint` DTO 에서 불필요한 `@JsonFormat` 제거

## 전달 사항
- AWS EC2에 배포 후 시간이 GMT+9 (한국 시간)으로 잘 설정되어있는지 확인 필요
- **앞으로 시간을 사용하는 테스트를 작성할 때는 TimeZone을 꼭 명시해야 합니다! Service가 아닌 다른 layer에서도 추상 클래스를 적용시키면 더 안전하게 할 수 있을 것 같네요.**