### PR TITLE
[BE] feat: 공통 응답 포맷 구현

### DIFF
--- a/backend/src/main/java/com/woowacourse/friendogly/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/GlobalExceptionHandler.java
@@ -1,6 +1,12 @@
 package com.woowacourse.friendogly;
 
+import com.woowacourse.friendogly.common.ApiResponse;
+import com.woowacourse.friendogly.common.ErrorCode;
+import com.woowacourse.friendogly.common.ErrorResponse;
 import com.woowacourse.friendogly.exception.FriendoglyException;
+import java.util.Collections;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -10,36 +16,92 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
+// TODO: 적절한 로그 레벨 설정
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(FriendoglyException.class)
-    public ResponseEntity<String> handle(FriendoglyException exception) {
-        return new ResponseEntity<>(exception.getMessage(), HttpStatus.BAD_REQUEST);
+    public ResponseEntity<ApiResponse<ErrorResponse>> handle(FriendoglyException exception) {
+        log.warn(exception.getMessage(), exception);
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                exception.getErrorCode(),
+                exception.getMessage(),
+                Collections.emptyList()
+        );
+
+        return new ResponseEntity(ApiResponse.ofError(errorResponse), exception.getHttpStatus());
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<String> handle(MethodArgumentNotValidException exception) {
-        return new ResponseEntity<>("유효하지 않은 요청 값입니다.", HttpStatus.BAD_REQUEST);
+    public ResponseEntity<ApiResponse<ErrorResponse>> handle(MethodArgumentNotValidException exception) {
+        log.warn(exception.getMessage(), exception);
+
+        List<String> detail = exception.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(fieldError -> fieldError.getDefaultMessage())
+                .toList();
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                ErrorCode.DEFAULT_ERROR_CODE,
+                "유효하지 않은 요청 값입니다.",
+                detail
+        );
+
+        return new ResponseEntity(ApiResponse.ofError(errorResponse), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<String> handle(HttpMessageNotReadableException exception) {
-        return new ResponseEntity<>("읽을 수 없는 HTTP 메세지입니다.", HttpStatus.BAD_REQUEST);
+        log.warn(exception.getMessage(), exception);
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                ErrorCode.DEFAULT_ERROR_CODE,
+                "읽을 수 없는 HTTP 메세지입니다.",
+                Collections.emptyList()
+        );
+
+        return new ResponseEntity(ApiResponse.ofError(errorResponse), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<String> handle(HttpRequestMethodNotSupportedException exception) {
-        return new ResponseEntity<>("지원하지 않는 HTTP 메서드입니다.", HttpStatus.METHOD_NOT_ALLOWED);
+        log.warn(exception.getMessage(), exception);
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                ErrorCode.DEFAULT_ERROR_CODE,
+                "지원하지 않는 HTTP 메서드입니다.",
+                Collections.emptyList()
+        );
+
+        return new ResponseEntity(ApiResponse.ofError(errorResponse), HttpStatus.METHOD_NOT_ALLOWED);
     }
 
     @ExceptionHandler(NoResourceFoundException.class)
     public ResponseEntity<String> handle(NoResourceFoundException exception) {
-        return new ResponseEntity<>("존재하지 않는 요청 경로입니다.", HttpStatus.NOT_FOUND);
+        log.warn(exception.getMessage(), exception);
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                ErrorCode.DEFAULT_ERROR_CODE,
+                "존재하지 않는 요청 경로입니다.",
+                Collections.emptyList()
+        );
+
+        return new ResponseEntity(ApiResponse.ofError(errorResponse), HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<String> handle(Exception exception) {
-        return new ResponseEntity<>(exception.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        log.error(exception.getMessage(), exception);
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                ErrorCode.DEFAULT_ERROR_CODE,
+                exception.getMessage(), // TODO: 처리 필요
+                Collections.emptyList()
+        );
+
+        return new ResponseEntity(ApiResponse.ofError(errorResponse), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/auth/AuthArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/auth/AuthArgumentResolver.java
@@ -4,6 +4,7 @@ import com.woowacourse.friendogly.exception.FriendoglyException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -31,7 +32,7 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
         String authorizationValue = request.getHeader(HttpHeaders.AUTHORIZATION);
 
         if (authorizationValue == null) {
-            throw new FriendoglyException("로그인 후에 사용할 수 있습니다.");
+            throw new FriendoglyException("로그인 후에 사용할 수 있습니다.", HttpStatus.UNAUTHORIZED);
         }
 
         return Long.parseLong(authorizationValue);

--- a/backend/src/main/java/com/woowacourse/friendogly/common/ApiResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/common/ApiResponse.java
@@ -1,0 +1,12 @@
+package com.woowacourse.friendogly.common;
+
+public record ApiResponse<T>(boolean isSuccess, T data) {
+
+    public static <T> ApiResponse<T> ofSuccess(T data) {
+        return new ApiResponse(true, data);
+    }
+
+    public static <T> ApiResponse<T> ofError(T data) {
+        return new ApiResponse(false, data);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/friendogly/common/ErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/common/ErrorCode.java
@@ -1,0 +1,8 @@
+package com.woowacourse.friendogly.common;
+
+public enum ErrorCode {
+
+    // TODO: 추가 필요
+    DEFAULT_ERROR_CODE
+    ;
+}

--- a/backend/src/main/java/com/woowacourse/friendogly/common/ErrorResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/common/ErrorResponse.java
@@ -1,0 +1,7 @@
+package com.woowacourse.friendogly.common;
+
+import java.util.List;
+
+public record ErrorResponse(ErrorCode errorCode, String errorMessage, List<String> detail) {
+
+}

--- a/backend/src/main/java/com/woowacourse/friendogly/exception/FriendoglyException.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/exception/FriendoglyException.java
@@ -1,8 +1,32 @@
 package com.woowacourse.friendogly.exception;
 
+import com.woowacourse.friendogly.common.ErrorCode;
+import org.springframework.http.HttpStatus;
+
 public class FriendoglyException extends RuntimeException {
 
+    private ErrorCode errorCode;
+    private HttpStatus httpStatus;
+
     public FriendoglyException(String message) {
+        this(message, HttpStatus.BAD_REQUEST);
+    }
+
+    public FriendoglyException(String message, HttpStatus httpStatus) {
+        this(message, ErrorCode.DEFAULT_ERROR_CODE, httpStatus);
+    }
+
+    public FriendoglyException(String message, ErrorCode errorCode, HttpStatus httpStatus) {
         super(message);
+        this.errorCode = errorCode;
+        this.httpStatus = httpStatus;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/member/controller/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.woowacourse.friendogly.member.controller;
 
+import com.woowacourse.friendogly.common.ApiResponse;
 import com.woowacourse.friendogly.member.dto.request.SaveMemberRequest;
 import com.woowacourse.friendogly.member.dto.response.SaveMemberResponse;
 import com.woowacourse.friendogly.member.service.MemberCommandService;
@@ -22,9 +23,9 @@ public class MemberController {
     }
 
     @PostMapping
-    public ResponseEntity<SaveMemberResponse> saveMember(@RequestBody @Valid SaveMemberRequest request) {
+    public ResponseEntity<ApiResponse<SaveMemberResponse>> saveMember(@RequestBody @Valid SaveMemberRequest request) {
         SaveMemberResponse response = memberCommandService.saveMember(request);
         return ResponseEntity.created(URI.create("/members/" + response.id()))
-                .body(response);
+                .body(ApiResponse.ofSuccess(response));
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/pet/controller/PetController.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/pet/controller/PetController.java
@@ -1,6 +1,7 @@
 package com.woowacourse.friendogly.pet.controller;
 
 import com.woowacourse.friendogly.auth.Auth;
+import com.woowacourse.friendogly.common.ApiResponse;
 import com.woowacourse.friendogly.pet.dto.request.SavePetRequest;
 import com.woowacourse.friendogly.pet.dto.response.FindPetResponse;
 import com.woowacourse.friendogly.pet.dto.response.SavePetResponse;
@@ -31,28 +32,30 @@ public class PetController {
     }
 
     @PostMapping
-    public ResponseEntity<SavePetResponse> savePet(
+    public ResponseEntity<ApiResponse<SavePetResponse>> savePet(
             @Auth Long memberId,
             @RequestBody @Valid SavePetRequest savePetRequest
     ) {
         SavePetResponse response = petCommandService.savePet(memberId, savePetRequest);
         return ResponseEntity.created(URI.create("/pets/" + response.id()))
-                .body(response);
+                .body(ApiResponse.ofSuccess(response));
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<FindPetResponse> findById(@PathVariable Long id) {
+    public ApiResponse<FindPetResponse> findById(@PathVariable Long id) {
         FindPetResponse response = petQueryService.findById(id);
-        return ResponseEntity.ok(response);
+        return ApiResponse.ofSuccess(response);
     }
 
     @GetMapping("/mine")
-    public List<FindPetResponse> findMine(@Auth Long memberId) {
-        return petQueryService.findByMemberId(memberId);
+    public ApiResponse<List<FindPetResponse>> findMine(@Auth Long memberId) {
+        List<FindPetResponse> response = petQueryService.findByMemberId(memberId);
+        return ApiResponse.ofSuccess(response);
     }
 
     @GetMapping
-    public List<FindPetResponse> findByMemberId(@RequestParam Long memberId) {
-        return petQueryService.findByMemberId(memberId);
+    public ApiResponse<List<FindPetResponse>> findByMemberId(@RequestParam Long memberId) {
+        List<FindPetResponse> response = petQueryService.findByMemberId(memberId);
+        return ApiResponse.ofSuccess(response);
     }
 }

--- a/backend/src/test/java/com/woowacourse/friendogly/docs/MemberApiDocsTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/docs/MemberApiDocsTest.java
@@ -1,5 +1,9 @@
 package com.woowacourse.friendogly.docs;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
@@ -16,10 +20,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
-
-import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(MemberController.class)
 public class MemberApiDocsTest extends RestDocsTest {
@@ -54,10 +54,12 @@ public class MemberApiDocsTest extends RestDocsTest {
                                         fieldWithPath("name").type(JsonFieldType.STRING).description("회원 이름"),
                                         fieldWithPath("email").type(JsonFieldType.STRING).description("회원 이메일"))
                                 .responseFields(
-                                        fieldWithPath("id").type(JsonFieldType.NUMBER).description("회원 id"),
-                                        fieldWithPath("name").type(JsonFieldType.STRING).description("회원 이름"),
-                                        fieldWithPath("tag").type(JsonFieldType.STRING).description("중복된 회원 이름을 식별하기 위한 고유한 문자열"),
-                                        fieldWithPath("email").type(JsonFieldType.STRING).description("회원 이메일"))
+                                        fieldWithPath("isSuccess").type(JsonFieldType.BOOLEAN).description("요청 성공 여부"),
+                                        fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("회원 id"),
+                                        fieldWithPath("data.name").type(JsonFieldType.STRING).description("회원 이름"),
+                                        fieldWithPath("data.tag").type(JsonFieldType.STRING)
+                                                .description("중복된 회원 이름을 식별하기 위한 고유한 문자열"),
+                                        fieldWithPath("data.email").type(JsonFieldType.STRING).description("회원 이메일"))
                                 .requestSchema(Schema.schema("saveMemberRequest"))
                                 .responseSchema(Schema.schema("응답DTO 이름"))
                                 .build()))

--- a/backend/src/test/java/com/woowacourse/friendogly/docs/PetApiDocsTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/docs/PetApiDocsTest.java
@@ -94,18 +94,15 @@ public class PetApiDocsTest extends RestDocsTest {
                                         fieldWithPath("imageUrl").type(JsonFieldType.STRING).description("반려견 이미지 URL")
                                 )
                                 .responseFields(
-                                        fieldWithPath("id").type(JsonFieldType.NUMBER).description("반려견 id"),
-                                        fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("반려견의 주인 id"),
-                                        fieldWithPath("name").type(JsonFieldType.STRING).description("반려견 이름"),
-                                        fieldWithPath("description").type(JsonFieldType.STRING)
-                                                .description("반려견 한 줄 소개"),
-                                        fieldWithPath("birthDate").type(JsonFieldType.STRING)
-                                                .description("반려견 생년월일: yyyy-MM-dd"),
-                                        fieldWithPath("sizeType").type(JsonFieldType.STRING)
-                                                .description("반려견 크기: SMALL, MEDIUM, LARGE"),
-                                        fieldWithPath("gender").type(JsonFieldType.STRING)
-                                                .description("반려견 성별: MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED"),
-                                        fieldWithPath("imageUrl").type(JsonFieldType.STRING).description("반려견 이미지 URL")
+                                        fieldWithPath("isSuccess").type(JsonFieldType.BOOLEAN).description("요청 성공 여부"),
+                                        fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("반려견 id"),
+                                        fieldWithPath("data.memberId").type(JsonFieldType.NUMBER).description("반려견의 주인 id"),
+                                        fieldWithPath("data.name").type(JsonFieldType.STRING).description("반려견 이름"),
+                                        fieldWithPath("data.description").type(JsonFieldType.STRING).description("반려견 한 줄 소개"),
+                                        fieldWithPath("data.birthDate").type(JsonFieldType.STRING).description("반려견 생년월일: yyyy-MM-dd"),
+                                        fieldWithPath("data.sizeType").type(JsonFieldType.STRING).description("반려견 크기: SMALL, MEDIUM, LARGE"),
+                                        fieldWithPath("data.gender").type(JsonFieldType.STRING).description("반려견 성별: MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED"),
+                                        fieldWithPath("data.imageUrl").type(JsonFieldType.STRING).description("반려견 이미지 URL")
                                 )
                                 .requestSchema(Schema.schema("SavePetRequest"))
                                 .responseSchema(Schema.schema("SavePetResponse"))
@@ -144,14 +141,15 @@ public class PetApiDocsTest extends RestDocsTest {
                                         parameterWithName("id").description("조회하려는 반려견 id")
                                 )
                                 .responseFields(
-                                        fieldWithPath("id").type(JsonFieldType.NUMBER).description("반려견 id"),
-                                        fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("반려견의 주인 id"),
-                                        fieldWithPath("name").type(JsonFieldType.STRING).description("반려견 이름"),
-                                        fieldWithPath("description").type(JsonFieldType.STRING).description("반려견 한 줄 소개"),
-                                        fieldWithPath("birthDate").type(JsonFieldType.STRING).description("반려견 생년월일: yyyy-MM-dd"),
-                                        fieldWithPath("sizeType").type(JsonFieldType.STRING).description("반려견 크기: SMALL, MEDIUM, LARGE"),
-                                        fieldWithPath("gender").type(JsonFieldType.STRING).description("반려견 성별: MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED"),
-                                        fieldWithPath("imageUrl").type(JsonFieldType.STRING).description("반려견 이미지 URL")
+                                        fieldWithPath("isSuccess").type(JsonFieldType.BOOLEAN).description("요청 성공 여부"),
+                                        fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("반려견 id"),
+                                        fieldWithPath("data.memberId").type(JsonFieldType.NUMBER).description("반려견의 주인 id"),
+                                        fieldWithPath("data.name").type(JsonFieldType.STRING).description("반려견 이름"),
+                                        fieldWithPath("data.description").type(JsonFieldType.STRING).description("반려견 한 줄 소개"),
+                                        fieldWithPath("data.birthDate").type(JsonFieldType.STRING).description("반려견 생년월일: yyyy-MM-dd"),
+                                        fieldWithPath("data.sizeType").type(JsonFieldType.STRING).description("반려견 크기: SMALL, MEDIUM, LARGE"),
+                                        fieldWithPath("data.gender").type(JsonFieldType.STRING).description("반려견 성별: MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED"),
+                                        fieldWithPath("data.imageUrl").type(JsonFieldType.STRING).description("반려견 이미지 URL")
                                 )
                                 .requestSchema(Schema.schema("FindPetByIdRequest"))
                                 .responseSchema(Schema.schema("FindPetByIdResponse"))
@@ -202,14 +200,15 @@ public class PetApiDocsTest extends RestDocsTest {
                                         headerWithName("Authorization").description("로그인한 회원 id")
                                 )
                                 .responseFields(
-                                        fieldWithPath("[].id").type(JsonFieldType.NUMBER).description("반려견 id"),
-                                        fieldWithPath("[].memberId").type(JsonFieldType.NUMBER).description("반려견의 주인 id"),
-                                        fieldWithPath("[].name").type(JsonFieldType.STRING).description("반려견 이름"),
-                                        fieldWithPath("[].description").type(JsonFieldType.STRING).description("반려견 한 줄 소개"),
-                                        fieldWithPath("[].birthDate").type(JsonFieldType.STRING).description("반려견 생년월일: yyyy-MM-dd"),
-                                        fieldWithPath("[].sizeType").type(JsonFieldType.STRING).description("반려견 크기: SMALL, MEDIUM, LARGE"),
-                                        fieldWithPath("[].gender").type(JsonFieldType.STRING).description("반려견 성별: MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED"),
-                                        fieldWithPath("[].imageUrl").type(JsonFieldType.STRING).description("반려견 이미지 URL")
+                                        fieldWithPath("isSuccess").type(JsonFieldType.BOOLEAN).description("요청 성공 여부"),
+                                        fieldWithPath("data.[].id").type(JsonFieldType.NUMBER).description("반려견 id"),
+                                        fieldWithPath("data.[].memberId").type(JsonFieldType.NUMBER).description("반려견의 주인 id"),
+                                        fieldWithPath("data.[].name").type(JsonFieldType.STRING).description("반려견 이름"),
+                                        fieldWithPath("data.[].description").type(JsonFieldType.STRING).description("반려견 한 줄 소개"),
+                                        fieldWithPath("data.[].birthDate").type(JsonFieldType.STRING).description("반려견 생년월일: yyyy-MM-dd"),
+                                        fieldWithPath("data.[].sizeType").type(JsonFieldType.STRING).description("반려견 크기: SMALL, MEDIUM, LARGE"),
+                                        fieldWithPath("data.[].gender").type(JsonFieldType.STRING).description("반려견 성별: MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED"),
+                                        fieldWithPath("data.[].imageUrl").type(JsonFieldType.STRING).description("반려견 이미지 URL")
                                 )
                                 .responseSchema(Schema.schema("FindPetResponse"))
                                 .build()))
@@ -259,14 +258,15 @@ public class PetApiDocsTest extends RestDocsTest {
                                         parameterWithName("memberId").description("조회하려는 회원의 id")
                                 )
                                 .responseFields(
-                                        fieldWithPath("[].id").type(JsonFieldType.NUMBER).description("반려견 id"),
-                                        fieldWithPath("[].memberId").type(JsonFieldType.NUMBER).description("반려견의 주인 id"),
-                                        fieldWithPath("[].name").type(JsonFieldType.STRING).description("반려견 이름"),
-                                        fieldWithPath("[].description").type(JsonFieldType.STRING).description("반려견 한 줄 소개"),
-                                        fieldWithPath("[].birthDate").type(JsonFieldType.STRING).description("반려견 생년월일: yyyy-MM-dd"),
-                                        fieldWithPath("[].sizeType").type(JsonFieldType.STRING).description("반려견 크기: SMALL, MEDIUM, LARGE"),
-                                        fieldWithPath("[].gender").type(JsonFieldType.STRING).description("반려견 성별: MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED"),
-                                        fieldWithPath("[].imageUrl").type(JsonFieldType.STRING).description("반려견 이미지 URL")
+                                        fieldWithPath("isSuccess").type(JsonFieldType.BOOLEAN).description("요청 성공 여부"),
+                                        fieldWithPath("data.[].id").type(JsonFieldType.NUMBER).description("반려견 id"),
+                                        fieldWithPath("data.[].memberId").type(JsonFieldType.NUMBER).description("반려견의 주인 id"),
+                                        fieldWithPath("data.[].name").type(JsonFieldType.STRING).description("반려견 이름"),
+                                        fieldWithPath("data.[].description").type(JsonFieldType.STRING).description("반려견 한 줄 소개"),
+                                        fieldWithPath("data.[].birthDate").type(JsonFieldType.STRING).description("반려견 생년월일: yyyy-MM-dd"),
+                                        fieldWithPath("data.[].sizeType").type(JsonFieldType.STRING).description("반려견 크기: SMALL, MEDIUM, LARGE"),
+                                        fieldWithPath("data.[].gender").type(JsonFieldType.STRING).description("반려견 성별: MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED"),
+                                        fieldWithPath("data.[].imageUrl").type(JsonFieldType.STRING).description("반려견 이미지 URL")
                                 )
                                 .responseSchema(Schema.schema("FindPetResponse"))
                                 .build()))

--- a/backend/src/test/java/com/woowacourse/friendogly/pet/controller/PetControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/pet/controller/PetControllerTest.java
@@ -1,20 +1,20 @@
 package com.woowacourse.friendogly.pet.controller;
 
 import com.woowacourse.friendogly.member.domain.Member;
-import com.woowacourse.friendogly.member.dto.request.SaveMemberRequest;
+import com.woowacourse.friendogly.member.repository.MemberRepository;
 import com.woowacourse.friendogly.pet.dto.request.SavePetRequest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
-
-import java.time.LocalDate;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext
@@ -23,22 +23,18 @@ class PetControllerTest {
     @LocalServerPort
     private int port;
 
+    @Autowired
+    private MemberRepository memberRepository;
+
     private Member member;
 
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
-
-        SaveMemberRequest request = new SaveMemberRequest("견주", "ddang@email.com");
-
-        member = RestAssured.given().log().all()
-                .contentType(ContentType.JSON)
-                .body(request)
-                .when().post("/members")
-                .then().log().all()
-                .statusCode(HttpStatus.CREATED.value())
-                .extract()
-                .as(Member.class);
+        member = memberRepository.save(Member.builder()
+                .name("견주")
+                .email("ddang@email.com")
+                .build());
     }
 
     @DisplayName("정상적으로 반려견을 생성하면 201을 반환한다.")


### PR DESCRIPTION
## 이슈
- close #94 
- close #97

## 개발 사항
- 공통 응답 포맷 구현
- 회원 및 반려견 도메인 API 문서 공통 응답 포맷 포함하도록 수정

# 전달 사항
- `ApiResponse.ofError()` 와 `ApiResponse.ofSuccess()` 를 사용해 공통 응답 객체를 생성할 수 있습니다.
- 자세한 사용법은 `GlobalExceptionHandler` 와 `PetController` 참고해주세요!
