### PR TITLE
[AN] feat: 기본 다이얼로그 추가

### DIFF
--- a/android/app/src/main/java/com/woowacourse/friendogly/presentation/base/BaseDialog.kt
+++ b/android/app/src/main/java/com/woowacourse/friendogly/presentation/base/BaseDialog.kt
@@ -1,0 +1,64 @@
+package com.woowacourse.friendogly.presentation.base
+
+import android.content.Context
+import android.graphics.Color
+import android.graphics.Point
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.Window
+import android.view.WindowManager
+import androidx.annotation.LayoutRes
+import androidx.databinding.DataBindingUtil
+import androidx.databinding.ViewDataBinding
+import androidx.fragment.app.DialogFragment
+
+abstract class BaseDialog<T : ViewDataBinding>(
+    @LayoutRes private val layoutResourceId: Int,
+) : DialogFragment() {
+    private var _binding: T? = null
+    val binding get() = requireNotNull(_binding)
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View? {
+        _binding = DataBindingUtil.inflate(inflater, layoutResourceId, container, false)
+        binding.lifecycleOwner = viewLifecycleOwner
+        dialog?.window?.apply {
+            setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+            requestFeature(Window.FEATURE_NO_TITLE)
+        }
+        return binding.root
+    }
+
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+        initViewCreated()
+    }
+
+    abstract fun initViewCreated()
+
+    override fun onResume() {
+        super.onResume()
+        val windowManager = context?.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+        val display = windowManager.defaultDisplay
+        val size = Point()
+        display.getSize(size)
+        val params: ViewGroup.LayoutParams? = dialog?.window?.attributes
+        val deviceWidth = size.x
+        params?.width = (deviceWidth * 0.9).toInt()
+        dialog?.window?.attributes = params as WindowManager.LayoutParams
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/android/app/src/main/java/com/woowacourse/friendogly/presentation/dialog/AlertDialogModel.kt
+++ b/android/app/src/main/java/com/woowacourse/friendogly/presentation/dialog/AlertDialogModel.kt
@@ -1,0 +1,8 @@
+package com.woowacourse.friendogly.presentation.dialog
+
+data class AlertDialogModel(
+    val title: String?,
+    val description: String?,
+    val negativeContents: String,
+    val positiveContents: String,
+)

--- a/android/app/src/main/java/com/woowacourse/friendogly/presentation/dialog/BaseAlertDialogBindingAdapter.kt
+++ b/android/app/src/main/java/com/woowacourse/friendogly/presentation/dialog/BaseAlertDialogBindingAdapter.kt
@@ -1,0 +1,15 @@
+package com.woowacourse.friendogly.presentation.dialog
+
+import android.view.View
+import android.widget.TextView
+import androidx.databinding.BindingAdapter
+
+@BindingAdapter("textVisibleCheck")
+fun TextView.setTextVisibleCheck(contents: String?) {
+    if (contents == null) {
+        this.visibility = View.GONE
+    } else {
+        this.visibility = View.VISIBLE
+        this.text = contents
+    }
+}

--- a/android/app/src/main/java/com/woowacourse/friendogly/presentation/dialog/DefaultBlueAlertDialog.kt
+++ b/android/app/src/main/java/com/woowacourse/friendogly/presentation/dialog/DefaultBlueAlertDialog.kt
@@ -1,0 +1,39 @@
+package com.woowacourse.friendogly.presentation.dialog
+
+import android.view.View
+import com.woowacourse.friendogly.R
+import com.woowacourse.friendogly.databinding.DialogBlueDefaultAlertBinding
+import com.woowacourse.friendogly.presentation.base.BaseDialog
+
+class DefaultBlueAlertDialog(
+    private val alertDialogModel: AlertDialogModel,
+    private val clickToNegative: () -> Unit,
+    private val clickToPositive: () -> Unit,
+) : BaseDialog<DialogBlueDefaultAlertBinding>(layoutResourceId = R.layout.dialog_blue_default_alert) {
+    override fun initViewCreated() {
+        initDataBinding()
+        initClickListener()
+    }
+
+    private fun initDataBinding() {
+        binding.model = alertDialogModel
+    }
+
+    private fun initClickListener() {
+        if (alertDialogModel.title == null) {
+            binding.tvAlertTitle.visibility = View.GONE
+        }
+        if (alertDialogModel.description == null) {
+            binding.tvAlertDescription.visibility = View.GONE
+        }
+
+        binding.tvNegative.setOnClickListener {
+            clickToNegative()
+            dismiss()
+        }
+        binding.tvPositive.setOnClickListener {
+            clickToPositive()
+            dismiss()
+        }
+    }
+}

--- a/android/app/src/main/java/com/woowacourse/friendogly/presentation/dialog/DefaultGrayAlertDialog.kt
+++ b/android/app/src/main/java/com/woowacourse/friendogly/presentation/dialog/DefaultGrayAlertDialog.kt
@@ -1,0 +1,26 @@
+package com.woowacourse.friendogly.presentation.dialog
+
+import com.woowacourse.friendogly.R
+import com.woowacourse.friendogly.databinding.DialogGrayDefaultAlertBinding
+import com.woowacourse.friendogly.presentation.base.BaseDialog
+
+class DefaultGrayAlertDialog(
+    private val alertDialogModel: AlertDialogModel,
+    private val clickToNegative: () -> Unit,
+) : BaseDialog<DialogGrayDefaultAlertBinding>(layoutResourceId = R.layout.dialog_gray_default_alert) {
+    override fun initViewCreated() {
+        initDataBinding()
+        initClickListener()
+    }
+
+    private fun initDataBinding() {
+        binding.model = alertDialogModel
+    }
+
+    private fun initClickListener() {
+        binding.tvNegative.setOnClickListener {
+            clickToNegative()
+            dismiss()
+        }
+    }
+}

--- a/android/app/src/main/java/com/woowacourse/friendogly/presentation/dialog/DefaultRedAlertDialog.kt
+++ b/android/app/src/main/java/com/woowacourse/friendogly/presentation/dialog/DefaultRedAlertDialog.kt
@@ -1,0 +1,31 @@
+package com.woowacourse.friendogly.presentation.dialog
+
+import com.woowacourse.friendogly.R
+import com.woowacourse.friendogly.databinding.DialogRedDefaultAlertBinding
+import com.woowacourse.friendogly.presentation.base.BaseDialog
+
+class DefaultRedAlertDialog(
+    private val alertDialogModel: AlertDialogModel,
+    private val clickToNegative: () -> Unit,
+    private val clickToPositive: () -> Unit,
+) : BaseDialog<DialogRedDefaultAlertBinding>(layoutResourceId = R.layout.dialog_red_default_alert) {
+    override fun initViewCreated() {
+        initDataBinding()
+        initClickListener()
+    }
+
+    fun initDataBinding() {
+        binding.model = alertDialogModel
+    }
+
+    private fun initClickListener() {
+        binding.tvNegative.setOnClickListener {
+            clickToNegative()
+            dismiss()
+        }
+        binding.tvPositive.setOnClickListener {
+            clickToPositive()
+            dismiss()
+        }
+    }
+}

--- a/android/app/src/main/res/drawable/sel_dialog_blue_fill_16.xml
+++ b/android/app/src/main/res/drawable/sel_dialog_blue_fill_16.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="false" android:state_pressed="false">
+        <shape>
+            <solid android:color="@color/blue" />
+            <corners android:radius="16dp" />
+        </shape>
+    </item>
+</selector>

--- a/android/app/src/main/res/drawable/sel_dialog_gray02_fill_16.xml
+++ b/android/app/src/main/res/drawable/sel_dialog_gray02_fill_16.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="false" android:state_pressed="false">
+        <shape>
+            <solid android:color="@color/gray02" />
+            <corners android:radius="16dp" />
+        </shape>
+    </item>
+</selector>

--- a/android/app/src/main/res/drawable/sel_dialog_line_red_16.xml
+++ b/android/app/src/main/res/drawable/sel_dialog_line_red_16.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="false" android:state_pressed="false">
+        <shape>
+            <corners android:radius="16dp" />
+            <stroke android:width="1dp" android:color="@color/red" />
+        </shape>
+    </item>
+</selector>

--- a/android/app/src/main/res/drawable/sel_dialog_white_fill_20.xml
+++ b/android/app/src/main/res/drawable/sel_dialog_white_fill_20.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="false" android:state_pressed="false">
+        <shape>
+            <solid android:color="@color/white"></solid>
+            <corners android:radius="20dp" />
+        </shape>
+    </item>
+</selector>

--- a/android/app/src/main/res/layout/dialog_blue_default_alert.xml
+++ b/android/app/src/main/res/layout/dialog_blue_default_alert.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="model"
+            type="com.woowacourse.friendogly.presentation.dialog.AlertDialogModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/sel_dialog_white_fill_20"
+        android:padding="24dp">
+
+        <TextView
+            android:id="@+id/tv_alert_title"
+            style="@style/Theme.AppCompat.TextView.Regular.Black.Size18"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:textVisibleCheck="@{model.title}"
+            tools:text="알림 제목" />
+
+        <TextView
+            android:id="@+id/tv_alert_description"
+            style="@style/Theme.AppCompat.TextView.Regular.Black.Size16"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:gravity="center"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tv_alert_title"
+            app:textVisibleCheck="@{model.description}"
+            tools:text="알림 설명" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:orientation="horizontal"
+            app:layout_constraintTop_toBottomOf="@+id/tv_alert_description"
+            tools:layout_editor_absoluteX="24dp">
+
+            <TextView
+                android:id="@+id/tv_negative"
+                style="@style/Theme.AppCompat.blue.Alert.TextView.Button.Negative"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="5dp"
+                android:layout_weight="1"
+                android:text="@{model.negativeContents}"
+                app:layout_constraintTop_toBottomOf="@+id/tv_alert_description"
+                tools:layout_editor_absoluteX="24dp" />
+
+            <TextView
+                android:id="@+id/tv_positive"
+                style="@style/Theme.AppCompat.blue.Alert.TextView.Button.Positive"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="5dp"
+                android:layout_weight="1"
+                android:text="@{model.positiveContents}"
+                app:layout_constraintTop_toBottomOf="@+id/tv_alert_description"
+                tools:layout_editor_absoluteX="24dp" />
+        </LinearLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/layout/dialog_gray_default_alert.xml
+++ b/android/app/src/main/res/layout/dialog_gray_default_alert.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="model"
+            type="com.woowacourse.friendogly.presentation.dialog.AlertDialogModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/sel_dialog_white_fill_20"
+        android:padding="24dp">
+
+        <TextView
+            android:id="@+id/tv_alert_title"
+            style="@style/Theme.AppCompat.TextView.Regular.Black.Size18"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:textVisibleCheck="@{model.title}" />
+
+        <TextView
+            android:id="@+id/tv_alert_description"
+            style="@style/Theme.AppCompat.TextView.Regular.Black.Size16"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:gravity="center"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tv_alert_title"
+            app:textVisibleCheck="@{model.description}" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:orientation="horizontal"
+            app:layout_constraintTop_toBottomOf="@+id/tv_alert_description"
+            tools:layout_editor_absoluteX="24dp">
+
+            <TextView
+                android:id="@+id/tv_negative"
+                style="@style/Theme.AppCompat.blue.Alert.TextView.Button.Negative"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="5dp"
+                android:layout_weight="1"
+                android:text="@{model.negativeContents}"
+                app:layout_constraintTop_toBottomOf="@+id/tv_alert_description"
+                tools:layout_editor_absoluteX="24dp" />
+
+        </LinearLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/layout/dialog_red_default_alert.xml
+++ b/android/app/src/main/res/layout/dialog_red_default_alert.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="model"
+            type="com.woowacourse.friendogly.presentation.dialog.AlertDialogModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/sel_dialog_white_fill_20"
+        android:padding="24dp">
+
+        <TextView
+            android:id="@+id/tv_alert_title"
+            style="@style/Theme.AppCompat.TextView.Regular.Black.Size18"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:textVisibleCheck="@{model.title}" />
+
+        <TextView
+            android:id="@+id/tv_alert_description"
+            style="@style/Theme.AppCompat.TextView.Regular.Black.Size16"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:gravity="center"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tv_alert_title"
+            app:textVisibleCheck="@{model.description}" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:orientation="horizontal"
+            app:layout_constraintTop_toBottomOf="@+id/tv_alert_description"
+            tools:layout_editor_absoluteX="24dp">
+
+            <TextView
+                android:id="@+id/tv_negative"
+                style="@style/Theme.AppCompat.Red.Alert.TextView.Button.Negative"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="5dp"
+                android:layout_weight="1"
+                android:text="@{model.negativeContents}"
+                app:layout_constraintTop_toBottomOf="@+id/tv_alert_description"
+                tools:layout_editor_absoluteX="24dp" />
+
+            <TextView
+                android:id="@+id/tv_positive"
+                style="@style/Theme.AppCompat.Red.Alert.TextView.Button.Positive"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="5dp"
+                android:layout_weight="1"
+                android:text="@{model.positiveContents}"
+                app:layout_constraintTop_toBottomOf="@+id/tv_alert_description"
+                tools:layout_editor_absoluteX="24dp" />
+        </LinearLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/layout/fragment_my_page.xml
+++ b/android/app/src/main/res/layout/fragment_my_page.xml
@@ -101,8 +101,7 @@
                         android:gravity="center"
                         android:paddingTop="15dp"
                         android:paddingBottom="15dp"
-                        android:text="@string/edit_profile_title"
-                        app:layout_constraintTop_toBottomOf="@+id/alert_description" />
+                        android:text="@string/edit_profile_title" />
 
                     <TextView
                         android:id="@+id/tv_register_dog_btn"
@@ -117,7 +116,7 @@
                         android:paddingTop="15dp"
                         android:paddingBottom="15dp"
                         android:text="@string/register_dog_title"
-                        app:layout_constraintTop_toBottomOf="@+id/alert_description" />
+                        app:layout_constraintTop_toBottomOf="@+id/tv_alert_description" />
                 </LinearLayout>
 
                 <androidx.recyclerview.widget.RecyclerView

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -415,4 +415,41 @@
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">match_parent</item>
     </style>
+
+    <!-- Alert 관련 -->
+    <style name="Theme.AppCompat.Alert.Padding.Radius16" parent="Theme.AppCompat">
+        <item name="android:paddingTop">16dp</item>
+        <item name="android:paddingBottom">16dp</item>
+    </style>
+
+
+    <style name="Theme.AppCompat.blue.Alert.TextView.Button.Negative" parent="Theme.AppCompat.Alert.Padding.Radius16">
+        <item name="android:background">@drawable/sel_dialog_gray02_fill_16</item>
+        <item name="android:textSize">16dp</item>
+        <item name="android:textColor">@color/gray08</item>
+        <item name="android:gravity">center</item>
+    </style>
+
+    <style name="Theme.AppCompat.blue.Alert.TextView.Button.Positive" parent="Theme.AppCompat.Alert.Padding.Radius16">
+        <item name="android:background">@drawable/sel_dialog_blue_fill_16</item>
+        <item name="android:textSize">16dp</item>
+        <item name="android:textColor">@color/black</item>
+        <item name="android:gravity">center</item>
+    </style>
+
+    <style name="Theme.AppCompat.Red.Alert.TextView.Button.Negative" parent="Theme.AppCompat.Alert.Padding.Radius16">
+        <item name="android:background">@drawable/sel_dialog_gray02_fill_16</item>
+        <item name="android:textSize">16dp</item>
+        <item name="android:textColor">@color/gray08</item>
+        <item name="android:gravity">center</item>
+    </style>
+
+    <style name="Theme.AppCompat.Red.Alert.TextView.Button.Positive" parent="Theme.AppCompat.Alert.Padding.Radius16">
+        <item name="android:background">@drawable/sel_dialog_line_red_16</item>
+        <item name="android:textSize">16dp</item>
+        <item name="android:textColor">@color/red</item>
+        <item name="android:gravity">center</item>
+    </style>
+
+
 </resources>


### PR DESCRIPTION
## 이슈
- close #186 

## 개발 사항
- 기본 다이얼로그 추가
<img width="30%" src="https://github.com/user-attachments/assets/8502d8a1-89ad-442a-bfc1-d490869a26c2">   
<img width="30%" src="https://github.com/user-attachments/assets/f96cc10d-97fe-4cce-90fc-c5ec1ac1bb0c">   
<img width="30%" src="https://github.com/user-attachments/assets/bc269901-8dae-4ea8-a4e3-a40b542c043c">   

왼쪽부터 `DefaultRedAlertDialog`, `DefaultGrayAlertDialog`, `DefaultBlueAlertDialog`