### PR TITLE
[BE] refactor: 발자국 단건조회 API를 도메인 정책에 맞게 변경, 발자국 생성 API에 필드 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindOneFootprintResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/FindOneFootprintResponse.java
@@ -20,8 +20,32 @@ public record FindOneFootprintResponse(
         boolean isMine
 ) {
 
-    public FindOneFootprintResponse(Member member, Pet mainPet, Footprint footprint, boolean isMine) {
-        this(
+    public static FindOneFootprintResponse withMainPetImage(
+            Member member,
+            Pet mainPet,
+            Footprint footprint,
+            boolean isMine
+    ) {
+        return new FindOneFootprintResponse(
+                member.getName().getValue(),
+                mainPet.getName().getValue(),
+                mainPet.getDescription().getValue(),
+                mainPet.getBirthDate().getValue(),
+                mainPet.getSizeType(),
+                mainPet.getGender(),
+                mainPet.getImageUrl(),
+                footprint.getCreatedAt(),
+                isMine
+        );
+    }
+
+    public static FindOneFootprintResponse withFootprintImage(
+            Member member,
+            Pet mainPet,
+            Footprint footprint,
+            boolean isMine
+    ) {
+        return new FindOneFootprintResponse(
                 member.getName().getValue(),
                 mainPet.getName().getValue(),
                 mainPet.getDescription().getValue(),

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/SaveFootprintResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/dto/response/SaveFootprintResponse.java
@@ -1,9 +1,12 @@
 package com.woowacourse.friendogly.footprint.dto.response;
 
+import java.time.LocalDateTime;
+
 public record SaveFootprintResponse(
         Long id,
         double latitude,
-        double longitude
+        double longitude,
+        LocalDateTime createdAt
 ) {
 
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintCommandService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintCommandService.java
@@ -58,7 +58,8 @@ public class FootprintCommandService {
         return new SaveFootprintResponse(
                 footprint.getId(),
                 footprint.getLocation().getLatitude(),
-                footprint.getLocation().getLongitude()
+                footprint.getLocation().getLongitude(),
+                footprint.getCreatedAt()
         );
     }
 

--- a/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintQueryService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/footprint/service/FootprintQueryService.java
@@ -11,6 +11,7 @@ import com.woowacourse.friendogly.footprint.repository.FootprintRepository;
 import com.woowacourse.friendogly.member.domain.Member;
 import com.woowacourse.friendogly.pet.domain.Pet;
 import com.woowacourse.friendogly.pet.repository.PetRepository;
+import io.micrometer.common.util.StringUtils;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -42,7 +43,11 @@ public class FootprintQueryService {
         boolean isMine = footprint.isCreatedBy(memberId);
 
         // TODO: 대표 펫을 지정하는 기능이 없어서, 임시로 0번째 index의 pet 리턴
-        return new FindOneFootprintResponse(member, pets.get(0), footprint, isMine);
+        if (StringUtils.isBlank(footprint.getImageUrl())) {
+            return FindOneFootprintResponse.withMainPetImage(member, pets.get(0), footprint, isMine);
+        }
+
+        return FindOneFootprintResponse.withFootprintImage(member, pets.get(0), footprint, isMine);
     }
 
     public List<FindNearFootprintResponse> findNear(Long memberId, FindNearFootprintRequest request) {

--- a/backend/src/test/java/com/woowacourse/friendogly/docs/FootprintApiDocsTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/docs/FootprintApiDocsTest.java
@@ -54,7 +54,7 @@ public class FootprintApiDocsTest extends RestDocsTest {
     @Test
     void save() throws Exception {
         SaveFootprintRequest request = new SaveFootprintRequest(37.5173316, 127.1011661);
-        SaveFootprintResponse response = new SaveFootprintResponse(1L, 37.5173316, 127.1011661);
+        SaveFootprintResponse response = new SaveFootprintResponse(1L, 37.5173316, 127.1011661, LocalDateTime.now());
 
         given(footprintCommandService.save(any(), eq(request)))
                 .willReturn(response);
@@ -85,7 +85,8 @@ public class FootprintApiDocsTest extends RestDocsTest {
                                         fieldWithPath("isSuccess").description("응답 성공 여부"),
                                         fieldWithPath("data.id").description("생성된 발자국 ID"),
                                         fieldWithPath("data.latitude").description("생성된 발자국의 위도"),
-                                        fieldWithPath("data.longitude").description("생성된 발자국의 경도")
+                                        fieldWithPath("data.longitude").description("생성된 발자국의 경도"),
+                                        fieldWithPath("data.createdAt").description("발자국을 생성한 시간")
                                 )
                                 .requestSchema(Schema.schema("SaveFootprintRequest"))
                                 .responseSchema(Schema.schema("SaveFootprintResponse"))

--- a/backend/src/test/java/com/woowacourse/friendogly/footprint/controller/FootprintControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/footprint/controller/FootprintControllerTest.java
@@ -182,7 +182,7 @@ class FootprintControllerTest {
                 .body("data.petBirthDate", is(pet1.getBirthDate().getValue().toString()))
                 .body("data.petSizeType", is(pet1.getSizeType().name()))
                 .body("data.petGender", is(pet1.getGender().name()))
-                .body("data.footprintImageUrl", is(footprint.getImageUrl()))
+                .body("data.footprintImageUrl", is(pet1.getImageUrl()))
                 .body("data.isMine", is(footprint.isCreatedBy(member1.getId())));
     }
 

--- a/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintQueryServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintQueryServiceTest.java
@@ -15,6 +15,7 @@ import com.woowacourse.friendogly.pet.domain.Gender;
 import com.woowacourse.friendogly.pet.domain.Pet;
 import com.woowacourse.friendogly.pet.domain.SizeType;
 import com.woowacourse.friendogly.support.ServiceTest;
+import jakarta.transaction.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -36,6 +37,7 @@ class FootprintQueryServiceTest extends ServiceTest {
     private FootprintCommandService footprintCommandService;
 
     @DisplayName("Footprint ID를 통해 발자국의 정보를 조회할 수 있다.")
+    @Transactional
     @Test
     void findOne() {
         // given
@@ -65,6 +67,9 @@ class FootprintQueryServiceTest extends ServiceTest {
                         .build()
         );
 
+        String footprintImageUrl = "https://picsum.photos/100";
+        footprint.updateImageUrl(footprintImageUrl);
+
         // when
         FindOneFootprintResponse response = footprintQueryService.findOne(member.getId(), footprint.getId());
 
@@ -76,6 +81,53 @@ class FootprintQueryServiceTest extends ServiceTest {
                 () -> assertThat(response.petBirthDate()).isEqualTo(LocalDate.now().minusYears(1)),
                 () -> assertThat(response.petSizeType()).isEqualTo(SizeType.MEDIUM),
                 () -> assertThat(response.petGender()).isEqualTo(Gender.MALE_NEUTERED),
+                () -> assertThat(response.footprintImageUrl()).isEqualTo(footprintImageUrl),
+                () -> assertThat(response.isMine()).isTrue()
+        );
+    }
+
+    @DisplayName("발자국 사진을 찍지 않고 단건 조회하면 발자국 사진이 아닌 펫 이미지의 URL이 조회된다.")
+    @Test
+    void findOne_NoTakePicture() {
+        // given
+        Member member = memberRepository.save(
+                Member.builder()
+                        .name("name1")
+                        .email("test@test.com")
+                        .build()
+        );
+
+        Pet pet = petRepository.save(
+                Pet.builder()
+                        .member(member)
+                        .name("petname1")
+                        .description("petdescription1")
+                        .birthDate(LocalDate.now().minusYears(1))
+                        .sizeType(SizeType.MEDIUM)
+                        .gender(Gender.MALE_NEUTERED)
+                        .imageUrl("https://picsum.photos/200")
+                        .build()
+        );
+
+        Footprint footprint = footprintRepository.save(
+                Footprint.builder()
+                        .member(member)
+                        .location(new Location(0.0, 0.0))
+                        .build()
+        );
+
+        // when
+        FindOneFootprintResponse response = footprintQueryService.findOne(member.getId(), footprint.getId());
+
+        // then
+        assertAll(
+                () -> assertThat(response.memberName()).isEqualTo("name1"),
+                () -> assertThat(response.petName()).isEqualTo("petname1"),
+                () -> assertThat(response.petDescription()).isEqualTo("petdescription1"),
+                () -> assertThat(response.petBirthDate()).isEqualTo(LocalDate.now().minusYears(1)),
+                () -> assertThat(response.petSizeType()).isEqualTo(SizeType.MEDIUM),
+                () -> assertThat(response.petGender()).isEqualTo(Gender.MALE_NEUTERED),
+                () -> assertThat(response.footprintImageUrl()).isEqualTo(pet.getImageUrl()),
                 () -> assertThat(response.isMine()).isTrue()
         );
     }

--- a/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintQueryServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintQueryServiceTest.java
@@ -36,7 +36,7 @@ class FootprintQueryServiceTest extends ServiceTest {
     @Autowired
     private FootprintCommandService footprintCommandService;
 
-    @DisplayName("Footprint ID를 통해 발자국의 정보를 조회할 수 있다.")
+    @DisplayName("Footprint ID를 통해 발자국의 정보를 조회할 수 있다. (발자국 사진을 찍은 경우 - 발자국 사진 URL 조회)")
     @Transactional
     @Test
     void findOne() {
@@ -86,7 +86,7 @@ class FootprintQueryServiceTest extends ServiceTest {
         );
     }
 
-    @DisplayName("발자국 사진을 찍지 않고 단건 조회하면 발자국 사진이 아닌 펫 이미지의 URL이 조회된다.")
+    @DisplayName("Footprint ID를 통해 발자국의 정보를 조회할 수 있다. (발자국 사진을 안 찍은 경우 - 펫 사진 URL 조회)")
     @Test
     void findOne_NoTakePicture() {
         // given


### PR DESCRIPTION
## 이슈
- #222 

## 개발 사항
- 발자국 단건 상세조회 API에서 찍은 발자국 사진이 없는 경우 대표 펫의 사진을 보여준다.
- 발자국 생성 API에서, 발자국 생성 시간도 함께 response한다.

## 리뷰 요청 사항
- `발자국 사진이 없는 경우 펫 사진을 응답한다.`를 구현하기 위해서 [`FootprintResponse`](https://github.com/woowacourse-teams/2024-friendogly/pull/224/files#diff-01dc0a44b6eae08bcabd51e0857e7eca5e6678b98dced613c18fb37b0ba99dfe)에 정적 팩토리 메서드 2개를 사용하고 있는데 어색하지는 않은지 궁금해요.
- [해당 테스트 클래스](https://github.com/woowacourse-teams/2024-friendogly/blob/711817b07cb9caef9261a6b96dd087688648bf3f/backend/src/test/java/com/woowacourse/friendogly/footprint/service/FootprintQueryServiceTest.java#L40)에서 발자국 사진의 URL을 업데이트하는 부분을 더티 체킹하기 위해 트랜잭션을 사용했어요. 괜찮을까요?
  - 서비스 클래스의 메서드를 사용하지 않은 이유: `MultiPartFile`을 직접 넣어줄 수 없음
- 테스트 픽스처가 더러울 수 있는데 나중에 리팩토링해 볼게요~~