### PR TITLE
[BE] feat: 모임 상세 조회 API 구현 및 검색 필터링 조건 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/friendogly/club/controller/ClubController.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/club/controller/ClubController.java
@@ -22,7 +22,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/clubs")
@@ -52,9 +54,10 @@ public class ClubController {
     @PostMapping
     public ResponseEntity<ApiResponse<SaveClubResponse>> save(
             @Auth Long memberId,
-            @Valid @RequestBody SaveClubRequest request
+            @Valid @RequestPart SaveClubRequest request,
+            @RequestPart(required = false) MultipartFile image
     ) {
-        SaveClubResponse response = clubCommandService.save(memberId, request);
+        SaveClubResponse response = clubCommandService.save(memberId, image, request);
         return ResponseEntity.created(URI.create("/clubs" + response.id())).body(ApiResponse.ofSuccess(response));
     }
 

--- a/backend/src/main/java/com/woowacourse/friendogly/club/controller/ClubController.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/club/controller/ClubController.java
@@ -4,6 +4,7 @@ import com.woowacourse.friendogly.auth.Auth;
 import com.woowacourse.friendogly.club.dto.request.FindSearchingClubRequest;
 import com.woowacourse.friendogly.club.dto.request.SaveClubMemberRequest;
 import com.woowacourse.friendogly.club.dto.request.SaveClubRequest;
+import com.woowacourse.friendogly.club.dto.response.FindClubResponse;
 import com.woowacourse.friendogly.club.dto.response.FindSearchingClubResponse;
 import com.woowacourse.friendogly.club.dto.response.SaveClubMemberResponse;
 import com.woowacourse.friendogly.club.dto.response.SaveClubResponse;
@@ -34,6 +35,12 @@ public class ClubController {
         this.clubQueryService = clubQueryService;
     }
 
+    @GetMapping("/{id}")
+    public ApiResponse<FindClubResponse> findById(@Auth Long memberId, @PathVariable Long id) {
+        return ApiResponse.ofSuccess(clubQueryService.findById(memberId, id));
+    }
+
+    // TODO: @ModelAttribute
     @GetMapping("/searching")
     public ApiResponse<List<FindSearchingClubResponse>> findSearching(@Valid FindSearchingClubRequest request) {
         return ApiResponse.ofSuccess(clubQueryService.findSearching(request));

--- a/backend/src/main/java/com/woowacourse/friendogly/club/controller/ClubController.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/club/controller/ClubController.java
@@ -42,8 +42,11 @@ public class ClubController {
 
     // TODO: @ModelAttribute
     @GetMapping("/searching")
-    public ApiResponse<List<FindSearchingClubResponse>> findSearching(@Valid FindSearchingClubRequest request) {
-        return ApiResponse.ofSuccess(clubQueryService.findSearching(request));
+    public ApiResponse<List<FindSearchingClubResponse>> findSearching(
+            @Auth Long memberId,
+            @Valid FindSearchingClubRequest request
+    ) {
+        return ApiResponse.ofSuccess(clubQueryService.findSearching(memberId, request));
     }
 
     @PostMapping

--- a/backend/src/main/java/com/woowacourse/friendogly/club/controller/ClubController.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/club/controller/ClubController.java
@@ -17,6 +17,7 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -40,11 +41,10 @@ public class ClubController {
         return ApiResponse.ofSuccess(clubQueryService.findById(memberId, id));
     }
 
-    // TODO: @ModelAttribute
     @GetMapping("/searching")
     public ApiResponse<List<FindSearchingClubResponse>> findByFilter(
             @Auth Long memberId,
-            @Valid FindSearchingClubRequest request
+            @Valid @ModelAttribute FindSearchingClubRequest request
     ) {
         return ApiResponse.ofSuccess(clubQueryService.findFindByFilter(memberId, request));
     }
@@ -59,7 +59,7 @@ public class ClubController {
     }
 
     @PostMapping("/{clubId}/members")
-    public ResponseEntity<ApiResponse<SaveClubMemberResponse>> saveClubMember(
+    public ResponseEntity<ApiResponse<SaveClubMemberResponse>> joinClub(
             @PathVariable Long clubId,
             @Auth Long memberId,
             @Valid @RequestBody SaveClubMemberRequest request
@@ -72,7 +72,7 @@ public class ClubController {
     @DeleteMapping("/{clubId}/members")
     public ResponseEntity<Void> deleteClubMember(
             @Auth Long memberId,
-            @PathVariable("clubId") Long clubId
+            @PathVariable Long clubId
     ) {
         clubCommandService.deleteClubMember(clubId, memberId);
         return ResponseEntity.noContent().build();

--- a/backend/src/main/java/com/woowacourse/friendogly/club/controller/ClubController.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/club/controller/ClubController.java
@@ -42,11 +42,11 @@ public class ClubController {
 
     // TODO: @ModelAttribute
     @GetMapping("/searching")
-    public ApiResponse<List<FindSearchingClubResponse>> findSearching(
+    public ApiResponse<List<FindSearchingClubResponse>> findByFilter(
             @Auth Long memberId,
             @Valid FindSearchingClubRequest request
     ) {
-        return ApiResponse.ofSuccess(clubQueryService.findSearching(memberId, request));
+        return ApiResponse.ofSuccess(clubQueryService.findFindByFilter(memberId, request));
     }
 
     @PostMapping

--- a/backend/src/main/java/com/woowacourse/friendogly/club/domain/Club.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/club/domain/Club.java
@@ -176,7 +176,7 @@ public class Club {
                 .anyMatch(pet -> !canNotJoin(pet));
         boolean isNotFull = !this.memberCapacity.isCapacityReached(countClubMember());
 
-        return hasJoinablePet && isNotFull && isAlreadyJoined(member);
+        return hasJoinablePet && isNotFull && isAlreadyJoined(member) && isOpen();
     }
 
     public void removeClubMember(Member member) {
@@ -211,6 +211,10 @@ public class Club {
 
     public boolean isEmpty() {
         return clubMembers.isEmpty();
+    }
+
+    public boolean isOpen() {
+        return this.status == Status.OPEN;
     }
 
     public boolean isOwner(Member targetMember) {

--- a/backend/src/main/java/com/woowacourse/friendogly/club/domain/Club.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/club/domain/Club.java
@@ -137,10 +137,14 @@ public class Club {
     }
 
     private void validateAlreadyExists(Member member) {
-        if (clubMembers.stream()
-                .anyMatch(clubMember -> clubMember.isSameMember(member))) {
+        if (isAlreadyJoined(member)) {
             throw new FriendoglyException("이미 참여 중인 모임입니다.");
         }
+    }
+
+    public boolean isAlreadyJoined(Member member) {
+        return clubMembers.stream()
+                .anyMatch(clubMember -> clubMember.isSameMember(member));
     }
 
     private void validateMemberCapacity() {
@@ -158,9 +162,21 @@ public class Club {
     }
 
     private void validateParticipatePet(Pet pet) {
-        if (!allowedGenders.contains(pet.getGender()) || !allowedSizes.contains(pet.getSizeType())) {
+        if (canNotJoin(pet)) {
             throw new FriendoglyException("모임에 데려갈 수 없는 강아지가 있습니다.");
         }
+    }
+
+    private boolean canNotJoin(Pet pet) {
+        return !allowedGenders.contains(pet.getGender()) || !allowedSizes.contains(pet.getSizeType());
+    }
+
+    public boolean isJoinable(Member member, List<Pet> pets) {
+        boolean hasJoinablePet = pets.stream()
+                .anyMatch(pet -> !canNotJoin(pet));
+        boolean isNotFull = !this.memberCapacity.isCapacityReached(countClubMember());
+
+        return hasJoinablePet && isNotFull && isAlreadyJoined(member);
     }
 
     public void removeClubMember(Member member) {
@@ -197,12 +213,16 @@ public class Club {
         return clubMembers.isEmpty();
     }
 
-    public boolean isOwner(ClubMember target) {
-        return findOwner().isSameMember(target.getClubMemberPk().getMember());
+    public boolean isOwner(Member targetMember) {
+        return findOwner().isSameMember(targetMember);
     }
 
     public Name findOwnerName() {
         return findOwner().getClubMemberPk().getMember().getName();
+    }
+
+    public String findOwnerImageUrl() {
+        return findOwner().getClubMemberPk().getMember().getImageUrl();
     }
 
     private ClubMember findOwner() {

--- a/backend/src/main/java/com/woowacourse/friendogly/club/domain/Club.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/club/domain/Club.java
@@ -162,18 +162,18 @@ public class Club {
     }
 
     private void validateParticipatePet(Pet pet) {
-        if (canNotJoin(pet)) {
+        if (!canJoinWith(pet)) {
             throw new FriendoglyException("모임에 데려갈 수 없는 강아지가 있습니다.");
         }
     }
 
-    private boolean canNotJoin(Pet pet) {
-        return !allowedGenders.contains(pet.getGender()) || !allowedSizes.contains(pet.getSizeType());
+    private boolean canJoinWith(Pet pet) {
+        return allowedGenders.contains(pet.getGender()) && allowedSizes.contains(pet.getSizeType());
     }
 
     public boolean isJoinable(Member member, List<Pet> pets) {
         boolean hasJoinablePet = pets.stream()
-                .anyMatch(pet -> !canNotJoin(pet));
+                .anyMatch(this::canJoinWith);
         boolean isNotFull = !this.memberCapacity.isCapacityReached(countClubMember());
 
         return hasJoinablePet && isNotFull && isAlreadyJoined(member) && isOpen();

--- a/backend/src/main/java/com/woowacourse/friendogly/club/domain/FilterCondition.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/club/domain/FilterCondition.java
@@ -8,11 +8,19 @@ public enum FilterCondition {
     OPEN,
     ABLE_TO_JOIN;
 
-    public static FilterCondition toFilterCondition(String filterCondition) {
+    public static FilterCondition from(String filterCondition) {
         try {
             return valueOf(filterCondition);
         } catch (IllegalArgumentException e) {
             throw new FriendoglyException("존재하지 않는 FilterCondition 입니다.");
         }
+    }
+
+    public boolean isOpen() {
+        return this == OPEN;
+    }
+
+    public boolean isAbleToJoin() {
+        return this == ABLE_TO_JOIN;
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/club/domain/FilterCondition.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/club/domain/FilterCondition.java
@@ -1,0 +1,18 @@
+package com.woowacourse.friendogly.club.domain;
+
+import com.woowacourse.friendogly.exception.FriendoglyException;
+
+public enum FilterCondition {
+
+    ALL,
+    OPEN,
+    ABLE_TO_JOIN;
+
+    public static FilterCondition toFilterCondition(String filterCondition) {
+        try {
+            return valueOf(filterCondition);
+        } catch (IllegalArgumentException e) {
+            throw new FriendoglyException("존재하지 않는 FilterCondition 입니다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/woowacourse/friendogly/club/dto/request/FindSearchingClubRequest.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/club/dto/request/FindSearchingClubRequest.java
@@ -7,6 +7,9 @@ import jakarta.validation.constraints.NotEmpty;
 import java.util.Set;
 
 public record FindSearchingClubRequest(
+        @NotBlank(message = "필터링 조건은 필수입니다.")
+        String filterCondition,
+
         @NotBlank(message = "주소 정보는 필수입니다.")
         String address,
 

--- a/backend/src/main/java/com/woowacourse/friendogly/club/dto/request/SaveClubRequest.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/club/dto/request/SaveClubRequest.java
@@ -19,9 +19,6 @@ public record SaveClubRequest(
         @Size(min = 1, max = 1000, message = "본문은 1글자 1000글자 사이입니다.")
         String content,
 
-        @NotBlank(message = "모임 사진을 등록해주세요.")
-        String imageUrl,
-
         @NotBlank(message = "주소를 읽을 수 없습니다. 다시 시도해주세요.")
         String address,
 

--- a/backend/src/main/java/com/woowacourse/friendogly/club/dto/response/ClubMemberDetailResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/club/dto/response/ClubMemberDetailResponse.java
@@ -1,0 +1,14 @@
+package com.woowacourse.friendogly.club.dto.response;
+
+import com.woowacourse.friendogly.member.domain.Member;
+
+public record ClubMemberDetailResponse(
+        Long id,
+        String name,
+        String imageUrl
+) {
+
+    public ClubMemberDetailResponse(Member member) {
+        this(member.getId(), member.getName().getValue(), member.getImageUrl());
+    }
+}

--- a/backend/src/main/java/com/woowacourse/friendogly/club/dto/response/ClubPetDetailResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/club/dto/response/ClubPetDetailResponse.java
@@ -5,10 +5,11 @@ import com.woowacourse.friendogly.pet.domain.Pet;
 public record ClubPetDetailResponse(
         Long id,
         String name,
-        String imageUrl
+        String imageUrl,
+        boolean isMine
 ){
 
-    public ClubPetDetailResponse(Pet pet) {
-        this(pet.getId(),pet.getName().getValue(), pet.getImageUrl());
+    public ClubPetDetailResponse(Pet pet, boolean isMine) {
+        this(pet.getId(),pet.getName().getValue(), pet.getImageUrl(), isMine);
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/club/dto/response/ClubPetDetailResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/club/dto/response/ClubPetDetailResponse.java
@@ -1,0 +1,14 @@
+package com.woowacourse.friendogly.club.dto.response;
+
+import com.woowacourse.friendogly.pet.domain.Pet;
+
+public record ClubPetDetailResponse(
+        Long id,
+        String name,
+        String imageUrl
+){
+
+    public ClubPetDetailResponse(Pet pet) {
+        this(pet.getId(),pet.getName().getValue(), pet.getImageUrl());
+    }
+}

--- a/backend/src/main/java/com/woowacourse/friendogly/club/dto/response/FindClubResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/club/dto/response/FindClubResponse.java
@@ -55,7 +55,7 @@ public record FindClubResponse(
                         .toList(),
                 club.getClubPets().stream()
                         .map(clubPet -> clubPet.getClubPetPk().getPet())
-                        .map(ClubPetDetailResponse::new)
+                        .map(pet -> new ClubPetDetailResponse(pet, pet.isOwner(member)))
                         .toList()
         );
     }

--- a/backend/src/main/java/com/woowacourse/friendogly/club/dto/response/FindClubResponse.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/club/dto/response/FindClubResponse.java
@@ -1,0 +1,62 @@
+package com.woowacourse.friendogly.club.dto.response;
+
+import com.woowacourse.friendogly.club.domain.Club;
+import com.woowacourse.friendogly.club.domain.Status;
+import com.woowacourse.friendogly.member.domain.Member;
+import com.woowacourse.friendogly.pet.domain.Gender;
+import com.woowacourse.friendogly.pet.domain.Pet;
+import com.woowacourse.friendogly.pet.domain.SizeType;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+public record FindClubResponse(
+        Long id,
+        String title,
+        String content,
+        String ownerMemberName,
+        String address,
+        Status status,
+        LocalDateTime createdAt,
+        Set<Gender> allowedGender,
+        Set<SizeType> allowedSize,
+        int memberCapacity,
+        int currentMemberCount,
+        String imageUrl,
+        String ownerImageUrl,
+        boolean isMine,
+        boolean alreadyParticipate,
+        boolean canParticipate,
+        List<ClubMemberDetailResponse> memberDetails,
+        List<ClubPetDetailResponse> petDetails
+) {
+
+    public FindClubResponse(Club club, Member member, List<Pet> myPets) {
+        this(
+                club.getId(),
+                club.getTitle().getValue(),
+                club.getContent().getValue(),
+                club.findOwnerName().getValue(),
+                club.getAddress().getValue(),
+                club.getStatus(),
+                club.getCreatedAt(),
+                club.getAllowedGenders(),
+                club.getAllowedSizes(),
+                club.getMemberCapacity().getValue(),
+                club.countClubMember(),
+                club.getImageUrl(),
+                club.findOwnerImageUrl(),
+                club.isOwner(member),
+                club.isAlreadyJoined(member),
+                club.isJoinable(member, myPets),
+                club.getClubMembers().stream()
+                        .map(clubMember -> clubMember.getClubMemberPk().getMember())
+                        .map(ClubMemberDetailResponse::new)
+                        .toList(),
+                club.getClubPets().stream()
+                        .map(clubPet -> clubPet.getClubPetPk().getPet())
+                        .map(ClubPetDetailResponse::new)
+                        .toList()
+        );
+    }
+}

--- a/backend/src/main/java/com/woowacourse/friendogly/club/service/ClubCommandService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/club/service/ClubCommandService.java
@@ -7,6 +7,7 @@ import com.woowacourse.friendogly.club.dto.request.SaveClubRequest;
 import com.woowacourse.friendogly.club.dto.response.SaveClubMemberResponse;
 import com.woowacourse.friendogly.club.dto.response.SaveClubResponse;
 import com.woowacourse.friendogly.club.repository.ClubRepository;
+import com.woowacourse.friendogly.infra.FileStorageManager;
 import com.woowacourse.friendogly.member.domain.Member;
 import com.woowacourse.friendogly.member.repository.MemberRepository;
 import com.woowacourse.friendogly.pet.domain.Pet;
@@ -14,6 +15,7 @@ import com.woowacourse.friendogly.pet.repository.PetRepository;
 import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Transactional
@@ -22,20 +24,28 @@ public class ClubCommandService {
     private final ClubRepository clubRepository;
     private final MemberRepository memberRepository;
     private final PetRepository petRepository;
+    private final FileStorageManager fileStorageManager;
 
     public ClubCommandService(
             ClubRepository clubRepository,
             MemberRepository memberRepository,
-            PetRepository petRepository
+            PetRepository petRepository,
+            FileStorageManager fileStorageManager
     ) {
         this.clubRepository = clubRepository;
         this.memberRepository = memberRepository;
         this.petRepository = petRepository;
+        this.fileStorageManager = fileStorageManager;
     }
 
-    public SaveClubResponse save(Long memberId, SaveClubRequest request) {
+    public SaveClubResponse save(Long memberId, MultipartFile image, SaveClubRequest request) {
         Member member = memberRepository.getById(memberId);
         List<Pet> participatingPets = mapToPets(request.participatingPetsId());
+
+        String imageUrl = "";
+        if (image != null && !image.isEmpty()) {
+            imageUrl = fileStorageManager.uploadFile(image);
+        }
 
         Club newClub = Club.create(
                 request.title(),
@@ -45,7 +55,7 @@ public class ClubCommandService {
                 member,
                 request.allowedGenders(),
                 request.allowedSizes(),
-                request.imageUrl(),
+                imageUrl,
                 participatingPets
         );
 

--- a/backend/src/main/java/com/woowacourse/friendogly/club/service/ClubQueryService.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/club/service/ClubQueryService.java
@@ -2,10 +2,14 @@ package com.woowacourse.friendogly.club.service;
 
 import com.woowacourse.friendogly.club.domain.Club;
 import com.woowacourse.friendogly.club.dto.request.FindSearchingClubRequest;
+import com.woowacourse.friendogly.club.dto.response.FindClubResponse;
 import com.woowacourse.friendogly.club.dto.response.FindSearchingClubResponse;
 import com.woowacourse.friendogly.club.repository.ClubRepository;
 import com.woowacourse.friendogly.club.repository.ClubSpecification;
+import com.woowacourse.friendogly.member.domain.Member;
+import com.woowacourse.friendogly.member.repository.MemberRepository;
 import com.woowacourse.friendogly.pet.domain.Pet;
+import com.woowacourse.friendogly.pet.repository.PetRepository;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -18,9 +22,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class ClubQueryService {
 
     private final ClubRepository clubRepository;
+    private final MemberRepository memberRepository;
+    private final PetRepository petRepository;
 
-    public ClubQueryService(ClubRepository clubRepository) {
+    public ClubQueryService(
+            ClubRepository clubRepository,
+            MemberRepository memberRepository,
+            PetRepository petRepository
+    ) {
         this.clubRepository = clubRepository;
+        this.memberRepository = memberRepository;
+        this.petRepository = petRepository;
     }
 
     public List<FindSearchingClubResponse> findSearching(FindSearchingClubRequest request) {
@@ -44,5 +56,13 @@ public class ClubQueryService {
         return groupPetsByMemberId.values().stream()
                 .map(petList -> petList.get(0).getImageUrl())
                 .toList();
+    }
+
+    public FindClubResponse findById(Long memberId, Long id) {
+        Club club = clubRepository.getById(id);
+        Member member = memberRepository.getById(memberId);
+        List<Pet> pets = petRepository.findByMemberId(memberId);
+
+        return new FindClubResponse(club, member, pets);
     }
 }

--- a/backend/src/main/java/com/woowacourse/friendogly/pet/domain/Pet.java
+++ b/backend/src/main/java/com/woowacourse/friendogly/pet/domain/Pet.java
@@ -76,4 +76,8 @@ public class Pet {
             throw new FriendoglyException("member는 null일 수 없습니다.");
         }
     }
+
+    public boolean isOwner(Member member) {
+        return this.member.getId().equals(member.getId());
+    }
 }

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -34,3 +34,28 @@ VALUES (1, '부', '곰돌이 컷 원조가 저에요~!', '2010-04-01', 'SMALL', 
         'https://mblogthumb-phinf.pstatic.net/MjAxNzA0MjhfMjg5/MDAxNDkzMzQzOTgxMDQy.4u283s2rrib7xSWR5IdL1r_yiipEITnM6VofjaJsZPUg.oTUM6w8LeF-orpapq_S8j45mjRxjofwrpq8jhQ5LC5Eg.PNG.fjvfeewt/20170428_104509.png?type=w800'),
        (8, '초코', '매일 저녁에 나와요!', '2017-12-01', 'MEDIUM', 'FEMALE',
         'https://cdn.pixabay.com/photo/2019/12/08/21/09/animal-4682251_960_720.jpg');
+
+INSERT INTO club (title, content, member_capacity, address, image_url, created_at, status)
+VALUES ('전국구 강아지 모임', '주먹이 가장 매운 강이지 모임', 3, '서울 송파구 신천동', 'http://example.com/image.jpg', '2023-08-01 12:00:00', 'OPEN'),
+       ('미녀 강아지 모임', '예쁜 강아지 모임', 5, '서울 송파구 신천동', 'http://example.com/image.jpg', '2023-07-31 01:00:00', 'OPEN');
+
+INSERT INTO club_gender (club_id, allowed_gender)
+VALUES (1, 'MALE'),
+       (1, 'FEMALE'),
+       (2, 'MALE_NEUTERED'),
+       (2, 'FEMALE_NEUTERED');
+
+INSERT INTO club_size (club_id, allowed_size)
+VALUES (1, 'LARGE'),
+       (2, 'SMALL'),
+       (2, 'MEDIUM');
+
+INSERT INTO club_member (club_id, member_id, created_at)
+VALUES (1, 6, '2023-07-31 01:00:00'),
+       (2, 5, '2023-07-31 01:00:00'),
+       (2, 7, '2023-07-31 02:00:00');
+
+INSERT INTO club_pet (club_id, pet_id)
+VALUES (1, 6),
+       (2, 5),
+       (2, 7);

--- a/backend/src/test/java/com/woowacourse/friendogly/club/service/ClubCommandServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/club/service/ClubCommandServiceTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.friendogly.club.domain.Club;
-import com.woowacourse.friendogly.club.domain.ClubMember;
 import com.woowacourse.friendogly.club.dto.request.SaveClubMemberRequest;
 import com.woowacourse.friendogly.club.dto.request.SaveClubRequest;
 import com.woowacourse.friendogly.club.dto.response.SaveClubResponse;
@@ -166,7 +165,7 @@ class ClubCommandServiceTest extends ClubServiceTest {
 
         assertAll(
                 () -> assertThat(savedClub.countClubMember()).isEqualTo(1),
-                () -> assertThat(savedClub.isOwner(ClubMember.create(savedClub, savedNewMember))).isTrue()
+                () -> assertThat(savedClub.isOwner(savedNewMember)).isTrue()
         );
     }
 

--- a/backend/src/test/java/com/woowacourse/friendogly/club/service/ClubCommandServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/club/service/ClubCommandServiceTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 
 class ClubCommandServiceTest extends ClubServiceTest {
 
@@ -42,19 +44,19 @@ class ClubCommandServiceTest extends ClubServiceTest {
         SaveClubRequest request = new SaveClubRequest(
                 "모임 제목",
                 "모임 내용",
-                "https://clubImage.com",
                 "서울특별시 송파구 신정동 잠실 5동",
                 Set.of(Gender.FEMALE, Gender.FEMALE_NEUTERED),
                 Set.of(SizeType.SMALL),
                 5,
                 List.of(savedPet.getId())
         );
-        SaveClubResponse actual = clubCommandService.save(savedMember.getId(), request);
+        MockMultipartFile image = new MockMultipartFile(
+                "image", "image", MediaType.MULTIPART_FORM_DATA.toString(), "asdf".getBytes());
+        SaveClubResponse actual = clubCommandService.save(savedMember.getId(), image, request);
 
         assertAll(
                 () -> assertThat(actual.title()).isEqualTo("모임 제목"),
                 () -> assertThat(actual.content()).isEqualTo("모임 내용"),
-                () -> assertThat(actual.imageUrl()).isEqualTo("https://clubImage.com"),
                 () -> assertThat(actual.address()).isEqualTo("서울특별시 송파구 신정동 잠실 5동"),
                 () -> assertThat(actual.allowedGender()).containsExactlyInAnyOrderElementsOf(
                         Set.of(Gender.FEMALE, Gender.FEMALE_NEUTERED))

--- a/backend/src/test/java/com/woowacourse/friendogly/club/service/ClubQueryServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/club/service/ClubQueryServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.friendogly.club.domain.Club;
+import com.woowacourse.friendogly.club.domain.FilterCondition;
 import com.woowacourse.friendogly.club.dto.request.FindSearchingClubRequest;
 import com.woowacourse.friendogly.club.dto.response.FindSearchingClubResponse;
 import com.woowacourse.friendogly.member.domain.Member;
@@ -43,12 +44,13 @@ class ClubQueryServiceTest extends ClubServiceTest {
         );
 
         FindSearchingClubRequest request = new FindSearchingClubRequest(
+                FilterCondition.ALL.name(),
                 address,
                 Set.of(Gender.FEMALE),
                 Set.of(SizeType.SMALL)
         );
 
-        List<FindSearchingClubResponse> responses = clubQueryService.findSearching(request);
+        List<FindSearchingClubResponse> responses = clubQueryService.findSearching(savedMember.getId(), request);
         List<FindSearchingClubResponse> expectedResponses = List.of(
                 new FindSearchingClubResponse(club, List.of(petImageUrl))
         );
@@ -82,12 +84,13 @@ class ClubQueryServiceTest extends ClubServiceTest {
         );
 
         FindSearchingClubRequest request = new FindSearchingClubRequest(
+                FilterCondition.ALL.name(),
                 address,
                 Set.of(Gender.MALE),
                 Set.of(SizeType.SMALL)
         );
 
-        List<FindSearchingClubResponse> responses = clubQueryService.findSearching(request);
+        List<FindSearchingClubResponse> responses = clubQueryService.findSearching(savedMember.getId(), request);
 
         assertThat(responses.isEmpty()).isTrue();
     }

--- a/backend/src/test/java/com/woowacourse/friendogly/club/service/ClubQueryServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/club/service/ClubQueryServiceTest.java
@@ -50,7 +50,7 @@ class ClubQueryServiceTest extends ClubServiceTest {
                 Set.of(SizeType.SMALL)
         );
 
-        List<FindSearchingClubResponse> responses = clubQueryService.findSearching(savedMember.getId(), request);
+        List<FindSearchingClubResponse> responses = clubQueryService.findFindByFilter(savedMember.getId(), request);
         List<FindSearchingClubResponse> expectedResponses = List.of(
                 new FindSearchingClubResponse(club, List.of(petImageUrl))
         );
@@ -90,7 +90,7 @@ class ClubQueryServiceTest extends ClubServiceTest {
                 Set.of(SizeType.SMALL)
         );
 
-        List<FindSearchingClubResponse> responses = clubQueryService.findSearching(savedMember.getId(), request);
+        List<FindSearchingClubResponse> responses = clubQueryService.findFindByFilter(savedMember.getId(), request);
 
         assertThat(responses.isEmpty()).isTrue();
     }

--- a/backend/src/test/java/com/woowacourse/friendogly/docs/ClubApiDocsTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/docs/ClubApiDocsTest.java
@@ -5,6 +5,7 @@ import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
@@ -22,6 +23,9 @@ import com.woowacourse.friendogly.club.domain.Status;
 import com.woowacourse.friendogly.club.dto.request.FindSearchingClubRequest;
 import com.woowacourse.friendogly.club.dto.request.SaveClubMemberRequest;
 import com.woowacourse.friendogly.club.dto.request.SaveClubRequest;
+import com.woowacourse.friendogly.club.dto.response.ClubMemberDetailResponse;
+import com.woowacourse.friendogly.club.dto.response.ClubPetDetailResponse;
+import com.woowacourse.friendogly.club.dto.response.FindClubResponse;
 import com.woowacourse.friendogly.club.dto.response.FindSearchingClubResponse;
 import com.woowacourse.friendogly.club.dto.response.SaveClubMemberResponse;
 import com.woowacourse.friendogly.club.dto.response.SaveClubResponse;
@@ -113,29 +117,85 @@ public class ClubApiDocsTest extends RestDocsTest {
                                         fieldWithPath("isSuccess").type(JsonFieldType.BOOLEAN).description("요청 성공 여부"),
                                         fieldWithPath("data.[].id").type(JsonFieldType.NUMBER).description("모임 식별자"),
                                         fieldWithPath("data.[].title").type(JsonFieldType.STRING).description("모임 제목"),
-                                        fieldWithPath("data.[].content").type(JsonFieldType.STRING)
-                                                .description("모임 본문"),
-                                        fieldWithPath("data.[].ownerMemberName").type(JsonFieldType.STRING)
-                                                .description("모임 방장 이름"),
-                                        fieldWithPath("data.[].address").type(JsonFieldType.STRING)
-                                                .description("모임의 주소"),
-                                        fieldWithPath("data.[].status").type(JsonFieldType.STRING)
-                                                .description("모임 상태(OPEN , CLOSED)"),
-                                        fieldWithPath("data.[].createdAt").type(JsonFieldType.STRING)
-                                                .description("모임 생성 시간(LocalDateTime)"),
-                                        fieldWithPath("data.[].allowedGender").type(JsonFieldType.ARRAY)
-                                                .description("허용되는 팻 성별(MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED)"),
-                                        fieldWithPath("data.[].allowedSize").type(JsonFieldType.ARRAY)
-                                                .description("허용되는 팻 크기(SMALL,MEDIUM,LARGE)"),
-                                        fieldWithPath("data.[].memberCapacity").type(JsonFieldType.NUMBER)
-                                                .description("모임 최대 인원"),
-                                        fieldWithPath("data.[].currentMemberCount").type(JsonFieldType.NUMBER)
-                                                .description("모임 현재 인원"),
-                                        fieldWithPath("data.[].imageUrl").type(JsonFieldType.STRING)
-                                                .description("모임 프로필 사진"),
-                                        fieldWithPath("data.[].petImageUrls").type(JsonFieldType.ARRAY)
-                                                .description("모임 리스트에 나오는 팻 사진 url 리스트"))
+                                        fieldWithPath("data.[].content").type(JsonFieldType.STRING).description("모임 본문"),
+                                        fieldWithPath("data.[].ownerMemberName").type(JsonFieldType.STRING).description("모임 방장 이름"),
+                                        fieldWithPath("data.[].address").type(JsonFieldType.STRING).description("모임의 주소"),
+                                        fieldWithPath("data.[].status").type(JsonFieldType.STRING).description("모임 상태(OPEN , CLOSED)"),
+                                        fieldWithPath("data.[].createdAt").type(JsonFieldType.STRING).description("모임 생성 시간(LocalDateTime)"),
+                                        fieldWithPath("data.[].allowedGender").type(JsonFieldType.ARRAY).description("허용되는 팻 성별(MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED)"),
+                                        fieldWithPath("data.[].allowedSize").type(JsonFieldType.ARRAY).description("허용되는 팻 크기(SMALL,MEDIUM,LARGE)"),
+                                        fieldWithPath("data.[].memberCapacity").type(JsonFieldType.NUMBER).description("모임 최대 인원"),
+                                        fieldWithPath("data.[].currentMemberCount").type(JsonFieldType.NUMBER).description("모임 현재 인원"),
+                                        fieldWithPath("data.[].imageUrl").type(JsonFieldType.STRING).description("모임 프로필 사진"),
+                                        fieldWithPath("data.[].petImageUrls").type(JsonFieldType.ARRAY).description("모임 리스트에 나오는 팻 사진 url 리스트"))
                                 .responseSchema(Schema.schema("FindSearchingClubResponse"))
+                                .build()))
+                );
+    }
+
+    @DisplayName("ID를 통해 모임의 상세 정보를 조회한다.")
+    @Test
+    void findById_200() throws Exception {
+        FindClubResponse response = new FindClubResponse(
+                1L,
+                "모임 제목1",
+                "모임 본문 내용1",
+                "브라운",
+                "서울특별시 송파구 신정동 잠실 6동",
+                Status.OPEN,
+                LocalDateTime.now(),
+                Set.of(Gender.FEMALE, Gender.FEMALE_NEUTERED),
+                Set.of(SizeType.SMALL),
+                4,
+                1,
+                "https://clubImage1.com",
+                "https://OwnerProfileImage.com",
+                true,
+                true,
+                false,
+                List.of(new ClubMemberDetailResponse(2L, "정지호", "https://땡이 영공때 사진.com"),
+                        new ClubMemberDetailResponse(3L, "쪙찌효", "https://땡이 근공때 사진.com")),
+                List.of(new ClubPetDetailResponse(1L, "땡이", "https://땡이의 귀여운 이미지.com"),
+                        new ClubPetDetailResponse(2L, "땡이 동생", "https://땡이 동생의 귀여운 이미지.com"))
+        );
+
+        when(clubQueryService.findById(anyLong(), anyLong()))
+                .thenReturn(response);
+
+        mockMvc.perform(get("/clubs/{id}",1L)
+                .header(HttpHeaders.AUTHORIZATION, 2L))
+                .andExpect(status().isOk())
+                .andDo(document("clubs/findById/200",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Club API")
+                                .summary("모임 상세 조회 API")
+                                .responseFields(
+                                        fieldWithPath("isSuccess").type(JsonFieldType.BOOLEAN).description("요청 성공 여부"),
+                                        fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("모임 식별자"),
+                                        fieldWithPath("data.title").type(JsonFieldType.STRING).description("모임 제목"),
+                                        fieldWithPath("data.content").type(JsonFieldType.STRING).description("모임 본문"),
+                                        fieldWithPath("data.ownerMemberName").type(JsonFieldType.STRING).description("모임 방장 이름"),
+                                        fieldWithPath("data.address").type(JsonFieldType.STRING).description("모임의 주소"),
+                                        fieldWithPath("data.status").type(JsonFieldType.STRING).description("모임 상태(OPEN , CLOSED)"),
+                                        fieldWithPath("data.createdAt").type(JsonFieldType.STRING).description("모임 생성 시간(LocalDateTime)"),
+                                        fieldWithPath("data.allowedGender").type(JsonFieldType.ARRAY).description("허용되는 팻 성별(MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED)"),
+                                        fieldWithPath("data.allowedSize").type(JsonFieldType.ARRAY).description("허용되는 팻 크기(SMALL,MEDIUM,LARGE)"),
+                                        fieldWithPath("data.memberCapacity").type(JsonFieldType.NUMBER).description("모임 최대 인원"),
+                                        fieldWithPath("data.currentMemberCount").type(JsonFieldType.NUMBER).description("모임 현재 인원"),
+                                        fieldWithPath("data.imageUrl").type(JsonFieldType.STRING).description("모임 프로필 사진"),
+                                        fieldWithPath("data.ownerImageUrl").type(JsonFieldType.STRING).description("모임 방장 프로필 사진"),
+                                        fieldWithPath("data.isMine").type(JsonFieldType.BOOLEAN).description("현재 로그인한 사용자가 방장인지 여부"),
+                                        fieldWithPath("data.alreadyParticipate").type(JsonFieldType.BOOLEAN).description("현재 로그인한 사용자가 모임에 참여 중인지 여부"),
+                                        fieldWithPath("data.canParticipate").type(JsonFieldType.BOOLEAN).description("현재 로그인한 사용자가 모임에 참여 가능한지 여부"),
+                                        fieldWithPath("data.memberDetails[].id").type(JsonFieldType.NUMBER).description("모임에 참여한 사용자 id"),
+                                        fieldWithPath("data.memberDetails[].name").type(JsonFieldType.STRING).description("모임에 참여한 사용자 이름"),
+                                        fieldWithPath("data.memberDetails[].imageUrl").type(JsonFieldType.STRING).description("모임에 참여한 사용자 이미지 URL"),
+                                        fieldWithPath("data.petDetails[].id").type(JsonFieldType.NUMBER).description("모임에 참여한 반려견 id"),
+                                        fieldWithPath("data.petDetails[].name").type(JsonFieldType.STRING).description("모임에 참여한 반려견 이름"),
+                                        fieldWithPath("data.petDetails[].imageUrl").type(JsonFieldType.STRING).description("모임에 참여한 반려견 이미지 URL"))
+                                .responseSchema(Schema.schema("FindClubResponse"))
                                 .build()))
                 );
     }
@@ -189,17 +249,12 @@ public class ClubApiDocsTest extends RestDocsTest {
                                 .requestFields(
                                         fieldWithPath("title").type(JsonFieldType.STRING).description("모임 제목"),
                                         fieldWithPath("content").type(JsonFieldType.STRING).description("모임 내용"),
-                                        fieldWithPath("imageUrl").type(JsonFieldType.STRING)
-                                                .description("모임 프로필 사진 url"),
+                                        fieldWithPath("imageUrl").type(JsonFieldType.STRING).description("모임 프로필 사진 url"),
                                         fieldWithPath("address").type(JsonFieldType.STRING).description("모임 주소"),
-                                        fieldWithPath("allowedGenders").type(JsonFieldType.ARRAY)
-                                                .description("참여가능한 강아지 성별"),
-                                        fieldWithPath("allowedSizes").type(JsonFieldType.ARRAY)
-                                                .description("참여가능한 강아지 사이즈"),
-                                        fieldWithPath("memberCapacity").type(JsonFieldType.NUMBER)
-                                                .description("모임 최대 인원"),
-                                        fieldWithPath("participatingPetsId").type(JsonFieldType.ARRAY)
-                                                .description("모임에 참여하는 방장 강아지의 ID 리스트")
+                                        fieldWithPath("allowedGenders").type(JsonFieldType.ARRAY).description("참여가능한 강아지 성별"),
+                                        fieldWithPath("allowedSizes").type(JsonFieldType.ARRAY).description("참여가능한 강아지 사이즈"),
+                                        fieldWithPath("memberCapacity").type(JsonFieldType.NUMBER).description("모임 최대 인원"),
+                                        fieldWithPath("participatingPetsId").type(JsonFieldType.ARRAY).description("모임에 참여하는 방장 강아지의 ID 리스트")
                                 )
                                 .responseHeaders(
                                         headerWithName(HttpHeaders.LOCATION).description("생성된 모임 리소스 Location"))
@@ -208,27 +263,17 @@ public class ClubApiDocsTest extends RestDocsTest {
                                         fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("모임 식별자"),
                                         fieldWithPath("data.title").type(JsonFieldType.STRING).description("모임 제목"),
                                         fieldWithPath("data.content").type(JsonFieldType.STRING).description("모임 본문"),
-                                        fieldWithPath("data.ownerMemberName").type(JsonFieldType.STRING)
-                                                .description("모임 방장 이름"),
+                                        fieldWithPath("data.ownerMemberName").type(JsonFieldType.STRING).description("모임 방장 이름"),
                                         fieldWithPath("data.address").type(JsonFieldType.STRING).description("모임의 주소"),
-                                        fieldWithPath("data.status").type(JsonFieldType.STRING)
-                                                .description("모임 상태(OPEN , CLOSED)"),
-                                        fieldWithPath("data.createdAt").type(JsonFieldType.STRING)
-                                                .description("모임 생성 시간(LocalDateTime)"),
-                                        fieldWithPath("data.allowedSize").type(JsonFieldType.ARRAY)
-                                                .description("허용되는 팻 크기(SMALL,MEDIUM,LARGE)"),
-                                        fieldWithPath("data.allowedGender").type(JsonFieldType.ARRAY)
-                                                .description("허용되는 팻 성별(MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED)"),
-                                        fieldWithPath("data.memberCapacity").type(JsonFieldType.NUMBER)
-                                                .description("모임 최대 인원"),
-                                        fieldWithPath("data.currentMemberCount").type(JsonFieldType.NUMBER)
-                                                .description("모임 현재 인원(대부분의 경우 1)"),
-                                        fieldWithPath("data.imageUrl").type(JsonFieldType.STRING)
-                                                .description("모임 프로필 사진"),
-                                        fieldWithPath("data.petImageUrls").type(JsonFieldType.ARRAY)
-                                                .description("모임 리스트에 참여하는 팻 프로필 url"),
-                                        fieldWithPath("data.isMine").type(JsonFieldType.BOOLEAN)
-                                                .description("현재 회원의 글인지 판단하는 값(대부분의 경우 true)"))
+                                        fieldWithPath("data.status").type(JsonFieldType.STRING).description("모임 상태(OPEN , CLOSED)"),
+                                        fieldWithPath("data.createdAt").type(JsonFieldType.STRING).description("모임 생성 시간(LocalDateTime)"),
+                                        fieldWithPath("data.allowedSize").type(JsonFieldType.ARRAY).description("허용되는 팻 크기(SMALL,MEDIUM,LARGE)"),
+                                        fieldWithPath("data.allowedGender").type(JsonFieldType.ARRAY).description("허용되는 팻 성별(MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED)"),
+                                        fieldWithPath("data.memberCapacity").type(JsonFieldType.NUMBER).description("모임 최대 인원"),
+                                        fieldWithPath("data.currentMemberCount").type(JsonFieldType.NUMBER).description("모임 현재 인원(대부분의 경우 1)"),
+                                        fieldWithPath("data.imageUrl").type(JsonFieldType.STRING).description("모임 프로필 사진"),
+                                        fieldWithPath("data.petImageUrls").type(JsonFieldType.ARRAY).description("모임 리스트에 참여하는 팻 프로필 url"),
+                                        fieldWithPath("data.isMine").type(JsonFieldType.BOOLEAN).description("현재 회원의 글인지 판단하는 값(대부분의 경우 true)"))
                                 .requestSchema(Schema.schema("saveClubRequest"))
                                 .responseSchema(Schema.schema("saveClubResponse"))
                                 .build()))
@@ -257,20 +302,16 @@ public class ClubApiDocsTest extends RestDocsTest {
                                 .summary("모임 참여 API")
                                 .pathParameters(
                                         parameterWithName("clubId").type(SimpleType.NUMBER).description("참여하는 모임의 ID"))
-                                .requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).type(SimpleType.NUMBER)
-                                        .description("로그인 중인 회원 ID"))
+                                .requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).type(SimpleType.NUMBER).description("로그인 중인 회원 ID"))
                                 .requestFields(
-                                        fieldWithPath("participatingPetsId").type(JsonFieldType.ARRAY)
-                                                .description("참여하는 팻 ID 리스트")
+                                        fieldWithPath("participatingPetsId").type(JsonFieldType.ARRAY).description("참여하는 팻 ID 리스트")
                                 )
                                 .responseHeaders(
-                                        headerWithName(HttpHeaders.LOCATION).type(SimpleType.STRING)
-                                                .description("모임-회원 연관관계 리소스 Location")
+                                        headerWithName(HttpHeaders.LOCATION).type(SimpleType.STRING).description("모임-회원 연관관계 리소스 Location")
                                 )
                                 .responseFields(
                                         fieldWithPath("isSuccess").type(JsonFieldType.BOOLEAN).description("요청 성공 여부"),
-                                        fieldWithPath("data.memberId").type(JsonFieldType.NUMBER)
-                                                .description("모임-회원 연관관계 ID(추후 채팅 생기면 변경)"))
+                                        fieldWithPath("data.memberId").type(JsonFieldType.NUMBER).description("모임-회원 연관관계 ID(추후 채팅 생기면 변경)"))
                                 .responseSchema(Schema.schema("SaveClubMemberResponse"))
                                 .build())
                 ));
@@ -298,17 +339,14 @@ public class ClubApiDocsTest extends RestDocsTest {
                                 .summary("모임 참여 API")
                                 .pathParameters(
                                         parameterWithName("clubId").type(SimpleType.NUMBER).description("참여하는 모임의 ID"))
-                                .requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).type(SimpleType.NUMBER)
-                                        .description("로그인 중인 회원 ID"))
+                                .requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).type(SimpleType.NUMBER).description("로그인 중인 회원 ID"))
                                 .requestFields(
-                                        fieldWithPath("participatingPetsId").type(JsonFieldType.ARRAY)
-                                                .description("참여하는 팻 ID 리스트")
+                                        fieldWithPath("participatingPetsId").type(JsonFieldType.ARRAY).description("참여하는 팻 ID 리스트")
                                 )
                                 .responseFields(
                                         fieldWithPath("isSuccess").type(JsonFieldType.BOOLEAN).description("요청 성공 여부"),
                                         fieldWithPath("data.errorCode").type(JsonFieldType.STRING).description("에러 코드"),
-                                        fieldWithPath("data.errorMessage").type(JsonFieldType.STRING)
-                                                .description("에러메세지"),
+                                        fieldWithPath("data.errorMessage").type(JsonFieldType.STRING).description("에러메세지"),
                                         fieldWithPath("data.detail").type(JsonFieldType.ARRAY).description("에러 디테일")
                                 )
                                 .build())
@@ -366,13 +404,11 @@ public class ClubApiDocsTest extends RestDocsTest {
                                 .responseFields(
                                         fieldWithPath("isSuccess").type(JsonFieldType.BOOLEAN).description("요청 성공 여부"),
                                         fieldWithPath("data.errorCode").type(JsonFieldType.STRING).description("에러 코드"),
-                                        fieldWithPath("data.errorMessage").type(JsonFieldType.STRING)
-                                                .description("에러메세지"),
+                                        fieldWithPath("data.errorMessage").type(JsonFieldType.STRING).description("에러메세지"),
                                         fieldWithPath("data.detail").type(JsonFieldType.ARRAY).description("에러 디테일")
                                 )
                                 .build())
                 ));
-
     }
 
     @Override

--- a/backend/src/test/java/com/woowacourse/friendogly/docs/ClubApiDocsTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/docs/ClubApiDocsTest.java
@@ -19,6 +19,7 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import com.epages.restdocs.apispec.SimpleType;
 import com.woowacourse.friendogly.club.controller.ClubController;
+import com.woowacourse.friendogly.club.domain.FilterCondition;
 import com.woowacourse.friendogly.club.domain.Status;
 import com.woowacourse.friendogly.club.dto.request.FindSearchingClubRequest;
 import com.woowacourse.friendogly.club.dto.request.SaveClubMemberRequest;
@@ -58,6 +59,7 @@ public class ClubApiDocsTest extends RestDocsTest {
     @Test
     void findSearching_200() throws Exception {
         FindSearchingClubRequest request = new FindSearchingClubRequest(
+                FilterCondition.ALL.name(),
                 "서울특별시 송파구 신청동 잠실 6동",
                 Set.of(Gender.FEMALE, Gender.FEMALE_NEUTERED),
                 Set.of(SizeType.SMALL)
@@ -95,10 +97,12 @@ public class ClubApiDocsTest extends RestDocsTest {
                 )
         );
 
-        when(clubQueryService.findSearching(request))
+        when(clubQueryService.findSearching(anyLong(), any()))
                 .thenReturn(responses);
 
         mockMvc.perform(get("/clubs/searching")
+                        .header(HttpHeaders.AUTHORIZATION, 1L)
+                        .param("filterCondition", request.filterCondition())
                         .param("address", request.address())
                         .param("genderParams", request.genderParams().stream().map(Enum::name).toArray(String[]::new))
                         .param("sizeParams", request.sizeParams().stream().map(Enum::name).toArray(String[]::new)))
@@ -110,6 +114,7 @@ public class ClubApiDocsTest extends RestDocsTest {
                                 .tag("Club API")
                                 .summary("모임 검색 조회 API")
                                 .queryParameters(
+                                        parameterWithName("filterCondition").description("모임의 필터 조건 (ALL, OPEN, ABLE_TO_JOIN)"),
                                         parameterWithName("address").description("모임의 주소"),
                                         parameterWithName("genderParams").description("모임에 참여가능한 팻 성별"),
                                         parameterWithName("sizeParams").description("모임에 참여가능한 팻 크기"))

--- a/backend/src/test/java/com/woowacourse/friendogly/docs/ClubApiDocsTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/docs/ClubApiDocsTest.java
@@ -160,8 +160,8 @@ public class ClubApiDocsTest extends RestDocsTest {
                 false,
                 List.of(new ClubMemberDetailResponse(2L, "정지호", "https://땡이 영공때 사진.com"),
                         new ClubMemberDetailResponse(3L, "쪙찌효", "https://땡이 근공때 사진.com")),
-                List.of(new ClubPetDetailResponse(1L, "땡이", "https://땡이의 귀여운 이미지.com"),
-                        new ClubPetDetailResponse(2L, "땡이 동생", "https://땡이 동생의 귀여운 이미지.com"))
+                List.of(new ClubPetDetailResponse(1L, "땡이", "https://땡이의 귀여운 이미지.com", true),
+                        new ClubPetDetailResponse(2L, "땡이 동생", "https://땡이 동생의 귀여운 이미지.com", true))
         );
 
         when(clubQueryService.findById(anyLong(), anyLong()))
@@ -199,7 +199,8 @@ public class ClubApiDocsTest extends RestDocsTest {
                                         fieldWithPath("data.memberDetails[].imageUrl").type(JsonFieldType.STRING).description("모임에 참여한 사용자 이미지 URL"),
                                         fieldWithPath("data.petDetails[].id").type(JsonFieldType.NUMBER).description("모임에 참여한 반려견 id"),
                                         fieldWithPath("data.petDetails[].name").type(JsonFieldType.STRING).description("모임에 참여한 반려견 이름"),
-                                        fieldWithPath("data.petDetails[].imageUrl").type(JsonFieldType.STRING).description("모임에 참여한 반려견 이미지 URL"))
+                                        fieldWithPath("data.petDetails[].imageUrl").type(JsonFieldType.STRING).description("모임에 참여한 반려견 이미지 URL"),
+                                        fieldWithPath("data.petDetails[].isMine").type(JsonFieldType.BOOLEAN).description("로그인한 사용자의 반려견인지 여부"))
                                 .responseSchema(Schema.schema("FindClubResponse"))
                                 .build()))
                 );

--- a/backend/src/test/java/com/woowacourse/friendogly/docs/ClubApiDocsTest.java
+++ b/backend/src/test/java/com/woowacourse/friendogly/docs/ClubApiDocsTest.java
@@ -97,7 +97,7 @@ public class ClubApiDocsTest extends RestDocsTest {
                 )
         );
 
-        when(clubQueryService.findSearching(anyLong(), any()))
+        when(clubQueryService.findFindByFilter(anyLong(), any()))
                 .thenReturn(responses);
 
         mockMvc.perform(get("/clubs/searching")


### PR DESCRIPTION
## 이슈
- close #244 
- close #273 

## 개발 사항
- 모임 상세 조회 API 구현
- 모임 검색 API에 필터링 조건 추가
- 모임 더미데이터 추가
- 모임 상세에 isMine 필드 추가
- 모임 도메인 이미지 적용

# 전달 사항
- 테스트는 아직 작성하지 않았습니다. 
  - 필터 조건이 ABLE_TO_JOIN, OPEN 인 경우의 테스트 미작성
  - Club 도메인 로직 테스트 미작성
- `ClubQueryServie#findSeaching()` 의 분기문을 어떻게 리팩토링 할지 함께 고민 부탁드립니다.

