### PR TITLE
[BE] feat: 채팅방에서 모임 정보 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/chat/controller/ChatRoomController.java
+++ b/backend/src/main/java/com/happy/friendogly/chat/controller/ChatRoomController.java
@@ -3,6 +3,7 @@ package com.happy.friendogly.chat.controller;
 import com.happy.friendogly.auth.Auth;
 import com.happy.friendogly.chat.dto.request.SaveChatRoomRequest;
 import com.happy.friendogly.chat.dto.response.FindChatRoomMembersInfoResponse;
+import com.happy.friendogly.chat.dto.response.FindClubDetailsResponse;
 import com.happy.friendogly.chat.dto.response.FindMyChatRoomResponse;
 import com.happy.friendogly.chat.dto.response.SaveChatRoomResponse;
 import com.happy.friendogly.chat.service.ChatRoomCommandService;
@@ -43,5 +44,11 @@ public class ChatRoomController {
     @GetMapping("/{chatRoomId}")
     public List<FindChatRoomMembersInfoResponse> findMemberInfo(@Auth Long memberId, @PathVariable Long chatRoomId) {
         return chatRoomQueryService.findMemberInfo(memberId, chatRoomId);
+    }
+
+    @GetMapping("/{chatRoomId}/club")
+    public ApiResponse<FindClubDetailsResponse> findClubDetails(@Auth Long memberId, @PathVariable Long chatRoomId) {
+        FindClubDetailsResponse response = chatRoomQueryService.findClubDetails(memberId, chatRoomId);
+        return ApiResponse.ofSuccess(response);
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/chat/dto/response/FindClubDetailsResponse.java
+++ b/backend/src/main/java/com/happy/friendogly/chat/dto/response/FindClubDetailsResponse.java
@@ -1,0 +1,17 @@
+package com.happy.friendogly.chat.dto.response;
+
+import com.happy.friendogly.club.domain.Club;
+import com.happy.friendogly.pet.domain.Gender;
+import com.happy.friendogly.pet.domain.SizeType;
+import java.util.Set;
+
+public record FindClubDetailsResponse(
+        Long clubId,
+        Set<SizeType> allowedSizeTypes,
+        Set<Gender> allowedGenders
+) {
+
+    public FindClubDetailsResponse(Club club) {
+        this(club.getId(), club.getAllowedSizes(), club.getAllowedGenders());
+    }
+}

--- a/backend/src/main/java/com/happy/friendogly/chat/service/ChatRoomQueryService.java
+++ b/backend/src/main/java/com/happy/friendogly/chat/service/ChatRoomQueryService.java
@@ -4,6 +4,7 @@ import com.happy.friendogly.chat.domain.ChatRoom;
 import com.happy.friendogly.chat.dto.request.InviteToChatRoomRequest;
 import com.happy.friendogly.chat.dto.response.ChatRoomDetail;
 import com.happy.friendogly.chat.dto.response.FindChatRoomMembersInfoResponse;
+import com.happy.friendogly.chat.dto.response.FindClubDetailsResponse;
 import com.happy.friendogly.chat.dto.response.FindMyChatRoomResponse;
 import com.happy.friendogly.chat.repository.ChatRoomRepository;
 import com.happy.friendogly.club.domain.Club;
@@ -60,6 +61,14 @@ public class ChatRoomQueryService {
         ChatRoom chatRoom = chatRoomRepository.getById(request.chatRoomId());
         Member sender = memberRepository.getById(senderMemberId);
         validateParticipation(chatRoom, sender);
+    }
+
+    public FindClubDetailsResponse findClubDetails(Long memberId, Long chatRoomId) {
+        Member member = memberRepository.getById(memberId);
+        ChatRoom chatRoom = chatRoomRepository.getById(chatRoomId);
+        validateParticipation(chatRoom, member);
+        Club club = clubRepository.getByChatRoomId(chatRoomId);
+        return new FindClubDetailsResponse(club);
     }
 
     private void validateParticipation(ChatRoom chatRoom, Member member) {

--- a/backend/src/test/java/com/happy/friendogly/chat/service/ChatRoomQueryServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/chat/service/ChatRoomQueryServiceTest.java
@@ -28,10 +28,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
 class ChatRoomQueryServiceTest extends ServiceTest {
 
     @Autowired

--- a/backend/src/test/java/com/happy/friendogly/chat/service/ChatRoomQueryServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/chat/service/ChatRoomQueryServiceTest.java
@@ -161,7 +161,7 @@ class ChatRoomQueryServiceTest extends ServiceTest {
 
         // then
         assertAll(
-                () -> assertThat(response.id())
+                () -> assertThat(response.clubId())
                         .isEqualTo(club1.getId()),
                 () -> assertThat(response.allowedSizeTypes())
                         .containsExactlyInAnyOrder(SMALL, MEDIUM, LARGE),

--- a/backend/src/test/java/com/happy/friendogly/chat/service/ChatRoomQueryServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/chat/service/ChatRoomQueryServiceTest.java
@@ -52,7 +52,6 @@ class ChatRoomQueryServiceTest extends ServiceTest {
     private Club club2;
 
     @BeforeEach
-    @Transactional
     void setUp() {
         member1 = memberRepository.save(new Member("name", "a", "https://a.com"));
         member2 = memberRepository.save(new Member("name2", "b", "https://b.com"));
@@ -106,7 +105,6 @@ class ChatRoomQueryServiceTest extends ServiceTest {
     }
 
     @DisplayName("내가 속해 있는 채팅방을 찾을 수 있다.")
-    @Transactional
     @Test
     void findMine() {
         // when
@@ -130,7 +128,6 @@ class ChatRoomQueryServiceTest extends ServiceTest {
     }
 
     @DisplayName("채팅방 내 멤버 세부정보를 조회할 수 있다.")
-    @Transactional
     @Test
     void findMemberInfo() {
         // when
@@ -167,7 +164,6 @@ class ChatRoomQueryServiceTest extends ServiceTest {
     }
 
     @DisplayName("자신이 참여한 채팅방이 아니면 채팅방에서 모임 정보를 받아올 수 없다.")
-    @Transactional
     @Test
     void findClubDetails_Fail() {
         // when - then

--- a/backend/src/test/java/com/happy/friendogly/chat/service/ChatRoomQueryServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/chat/service/ChatRoomQueryServiceTest.java
@@ -53,9 +53,9 @@ class ChatRoomQueryServiceTest extends ServiceTest {
 
     @BeforeEach
     void setUp() {
-        member1 = memberRepository.save(new Member("name", "a", "https://a.com"));
-        member2 = memberRepository.save(new Member("name2", "b", "https://b.com"));
-        member3 = memberRepository.save(new Member("name3", "c", "https://c.com"));
+        member1 = memberRepository.save(new Member("트레", "a4a82b2g", "https://img1.com/image.jpg"));
+        member2 = memberRepository.save(new Member("벼리", "fb7123cc", "https://img2.com/image.jpg"));
+        member3 = memberRepository.save(new Member("위브", "169a7fb9", "https://img3.com/image.jpg"));
 
         pet1 = petRepository.save(new Pet(member1, "땡이", "귀여워요", LocalDate.now().minusYears(1),
                 SMALL, MALE, "https://image.com/image1.jpg"));

--- a/backend/src/test/java/com/happy/friendogly/chat/service/ChatRoomQueryServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/chat/service/ChatRoomQueryServiceTest.java
@@ -77,9 +77,6 @@ class ChatRoomQueryServiceTest extends ServiceTest {
                 "https://image.com",
                 List.of(pet1)
         );
-        club1.addClubMember(member2);
-        club1.addClubPet(List.of(pet2));
-        club1.addChatRoomMember(member2);
         clubRepository.save(club1);
 
         club2 = Club.create(
@@ -95,9 +92,6 @@ class ChatRoomQueryServiceTest extends ServiceTest {
                 "https://image.com",
                 List.of(pet1)
         );
-        club2.addClubMember(member3);
-        club2.addClubPet(List.of(pet3));
-        club2.addChatRoomMember(member3);
         clubRepository.save(club2);
 
         chatRoom1 = club1.getChatRoom();
@@ -120,7 +114,7 @@ class ChatRoomQueryServiceTest extends ServiceTest {
                         .containsExactly("모임 제목1", "모임 제목2"),
                 () -> assertThat(response.chatRooms())
                         .extracting(ChatRoomDetail::memberCount)
-                        .containsExactly(2, 2),
+                        .containsExactly(1, 1),
                 () -> assertThat(response.chatRooms())
                         .extracting(ChatRoomDetail::clubImageUrl)
                         .containsExactly("https://image.com", "https://image.com")
@@ -128,8 +122,14 @@ class ChatRoomQueryServiceTest extends ServiceTest {
     }
 
     @DisplayName("채팅방 내 멤버 세부정보를 조회할 수 있다.")
+    @Transactional
     @Test
     void findMemberInfo() {
+        // given
+        club1.addClubMember(member2);
+        club1.addClubPet(List.of(pet2));
+        club1.addChatRoomMember(member2);
+
         // when
         List<FindChatRoomMembersInfoResponse> response
                 = chatRoomQueryService.findMemberInfo(member1.getId(), chatRoom1.getId());
@@ -138,7 +138,7 @@ class ChatRoomQueryServiceTest extends ServiceTest {
         assertAll(
                 () -> assertThat(response)
                         .extracting(FindChatRoomMembersInfoResponse::memberName)
-                        .containsExactly("name", "name2"),
+                        .containsExactly("트레", "벼리"),
                 () -> assertThat(response)
                         .extracting(FindChatRoomMembersInfoResponse::isOwner)
                         .containsExactly(true, false)

--- a/backend/src/test/java/com/happy/friendogly/chat/service/ChatRoomQueryServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/chat/service/ChatRoomQueryServiceTest.java
@@ -16,7 +16,6 @@ import com.happy.friendogly.chat.dto.response.ChatRoomDetail;
 import com.happy.friendogly.chat.dto.response.FindChatRoomMembersInfoResponse;
 import com.happy.friendogly.chat.dto.response.FindClubDetailsResponse;
 import com.happy.friendogly.chat.dto.response.FindMyChatRoomResponse;
-import com.happy.friendogly.chat.repository.ChatRoomRepository;
 import com.happy.friendogly.club.domain.Club;
 import com.happy.friendogly.exception.FriendoglyException;
 import com.happy.friendogly.member.domain.Member;
@@ -34,9 +33,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 class ChatRoomQueryServiceTest extends ServiceTest {
-
-    @Autowired
-    private ChatRoomRepository chatRoomRepository;
 
     @Autowired
     private ChatRoomQueryService chatRoomQueryService;

--- a/backend/src/test/java/com/happy/friendogly/docs/ChatRoomApiDocsTest.java
+++ b/backend/src/test/java/com/happy/friendogly/docs/ChatRoomApiDocsTest.java
@@ -1,0 +1,211 @@
+package com.happy.friendogly.docs;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static com.happy.friendogly.pet.domain.Gender.FEMALE_NEUTERED;
+import static com.happy.friendogly.pet.domain.Gender.MALE;
+import static com.happy.friendogly.pet.domain.SizeType.MEDIUM;
+import static com.happy.friendogly.pet.domain.SizeType.SMALL;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.happy.friendogly.chat.controller.ChatRoomController;
+import com.happy.friendogly.chat.dto.request.SaveChatRoomRequest;
+import com.happy.friendogly.chat.dto.response.ChatRoomDetail;
+import com.happy.friendogly.chat.dto.response.FindChatRoomMembersInfoResponse;
+import com.happy.friendogly.chat.dto.response.FindClubDetailsResponse;
+import com.happy.friendogly.chat.dto.response.FindMyChatRoomResponse;
+import com.happy.friendogly.chat.dto.response.SaveChatRoomResponse;
+import com.happy.friendogly.chat.service.ChatRoomCommandService;
+import com.happy.friendogly.chat.service.ChatRoomQueryService;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.http.HttpHeaders;
+
+public class ChatRoomApiDocsTest extends RestDocsTest {
+
+    @Mock
+    private ChatRoomQueryService chatRoomQueryService;
+
+    @Mock
+    private ChatRoomCommandService chatRoomCommandService;
+
+    @DisplayName("일대일 채팅방 생성")
+    @Test
+    void savePrivate() throws Exception {
+        SaveChatRoomRequest request = new SaveChatRoomRequest(3L);
+        SaveChatRoomResponse response = new SaveChatRoomResponse(7L);
+
+        given(chatRoomCommandService.savePrivate(any(), any()))
+                .willReturn(response);
+
+        mockMvc
+                .perform(post("/chat-rooms")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(APPLICATION_JSON)
+                        .header(AUTHORIZATION, getMemberToken()))
+                .andDo(print())
+                .andDo(document("chat-rooms/savePrivate",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("ChatRoom API")
+                                .summary("일대일 채팅방 생성 API")
+                                .requestHeaders(
+                                        headerWithName(HttpHeaders.AUTHORIZATION).description("로그인한 회원의 access token")
+                                )
+                                .requestFields(
+                                        fieldWithPath("otherMemberId").description("채팅방에 초대할 회원의 Member ID")
+                                )
+                                .responseFields(
+                                        fieldWithPath("isSuccess").description("응답 성공 여부"),
+                                        fieldWithPath("data.chatRoomId").description("생성된 채팅방 ID")
+                                )
+                                .requestSchema(Schema.schema("SaveChatRoomRequest"))
+                                .responseSchema(Schema.schema("SaveChatRoomResponse"))
+                                .build()
+                        )
+                ))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("내가 참여한 채팅방 목록 조회")
+    @Test
+    void findMine() throws Exception {
+        ChatRoomDetail detail1 = new ChatRoomDetail(3L, 5, "신천동 소형견 모임", "https://image1.com/image.jpg");
+        ChatRoomDetail detail2 = new ChatRoomDetail(7L, 3, "귀여운 강아지들 모임", "https://image2.com/image.jpg");
+        ChatRoomDetail detail3 = new ChatRoomDetail(11L, 6, "멋진 멍멍이 모임", "https://image3.com/image.jpg");
+        FindMyChatRoomResponse response = new FindMyChatRoomResponse(1L, List.of(detail1, detail2, detail3));
+
+        given(chatRoomQueryService.findMine(any()))
+                .willReturn(response);
+
+        mockMvc
+                .perform(get("/chat-rooms/mine")
+                        .header(AUTHORIZATION, getMemberToken()))
+                .andDo(print())
+                .andDo(document("chat-rooms/findMine",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("ChatRoom API")
+                                .summary("내가 참여한 채팅방 목록 조회 API")
+                                .requestHeaders(
+                                        headerWithName(HttpHeaders.AUTHORIZATION).description("로그인한 회원의 access token")
+                                )
+                                .responseFields(
+                                        fieldWithPath("isSuccess").description("응답 성공 여부"),
+                                        fieldWithPath("data.myMemberId").description("나의 Member ID"),
+                                        fieldWithPath("data.chatRooms.[].chatRoomId").description("채팅방 ID"),
+                                        fieldWithPath("data.chatRooms.[].memberCount").description("채팅방 현재 인원"),
+                                        fieldWithPath("data.chatRooms.[].clubName").description("모임 이름"),
+                                        fieldWithPath("data.chatRooms.[].clubImageUrl").description("모임 이미지 URL")
+                                )
+                                .responseSchema(Schema.schema("FindMyChatRoomResponse"))
+                                .build()
+                        )
+                ))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("채팅방 내 Member 목록 조회")
+    @Test
+    void findMemberInfo() throws Exception {
+        FindChatRoomMembersInfoResponse memberInfo1
+                = new FindChatRoomMembersInfoResponse(true, 3L, "트레", "https://image1.com/image.jpg");
+        FindChatRoomMembersInfoResponse memberInfo2
+                = new FindChatRoomMembersInfoResponse(false, 5L, "벼리", "https://image2.com/image.jpg");
+        FindChatRoomMembersInfoResponse memberInfo3
+                = new FindChatRoomMembersInfoResponse(false, 9L, "땡이", "https://image3.com/image.jpg");
+
+        given(chatRoomQueryService.findMemberInfo(any(), any()))
+                .willReturn(List.of(memberInfo1, memberInfo2, memberInfo3));
+
+        mockMvc
+                .perform(get("/chat-rooms/{chatRoomId}", 1L)
+                        .header(AUTHORIZATION, getMemberToken()))
+                .andDo(print())
+                .andDo(document("chat-rooms/findMemberInfo",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("ChatRoom API")
+                                .summary("채팅방 내 Member 목록 조회 API")
+                                .requestHeaders(
+                                        headerWithName(HttpHeaders.AUTHORIZATION).description("로그인한 회원의 access token")
+                                )
+                                .pathParameters(
+                                        parameterWithName("chatRoomId").description("채팅방 ID")
+                                )
+                                .responseFields(
+                                        fieldWithPath("[].isOwner").description("채팅방 ID"),
+                                        fieldWithPath("[].memberId").description("채팅방 현재 인원"),
+                                        fieldWithPath("[].memberName").description("모임 이름"),
+                                        fieldWithPath("[].memberProfileImageUrl").description("모임 이미지 URL")
+                                )
+                                .responseSchema(Schema.schema("FindChatRoomMembersInfoResponse"))
+                                .build()
+                        )
+                ))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("채팅방 내 모임 상세정보 조회")
+    @Test
+    void findClubDetails() throws Exception {
+        FindClubDetailsResponse response
+                = new FindClubDetailsResponse(5L, Set.of(SMALL, MEDIUM), Set.of(FEMALE_NEUTERED, MALE));
+
+        given(chatRoomQueryService.findClubDetails(any(), any()))
+                .willReturn(response);
+
+        mockMvc
+                .perform(get("/chat-rooms/{chatRoomId}/club", 1L)
+                        .header(AUTHORIZATION, getMemberToken()))
+                .andDo(print())
+                .andDo(document("chat-rooms/findClubDetails",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("ChatRoom API")
+                                .summary("채팅방 내 모임 상세정보 조회 API")
+                                .requestHeaders(
+                                        headerWithName(HttpHeaders.AUTHORIZATION).description("로그인한 회원의 access token")
+                                )
+                                .pathParameters(
+                                        parameterWithName("chatRoomId").description("채팅방 ID")
+                                )
+                                .responseFields(
+                                        fieldWithPath("isSuccess").description("응답 성공 여부"),
+                                        fieldWithPath("data.clubId").description("채팅방 ID"),
+                                        fieldWithPath("data.allowedSizeTypes")
+                                                .description("채팅방 현재 인원 (SMALL, MEDIUM, LARGE)"),
+                                        fieldWithPath("data.allowedGenders")
+                                                .description("모임 이름 (MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED)")
+                                )
+                                .responseSchema(Schema.schema("FindClubDetailsResponse"))
+                                .build()
+                        )
+                ))
+                .andExpect(status().isOk());
+    }
+
+    @Override
+    protected Object controller() {
+        return new ChatRoomController(chatRoomQueryService, chatRoomCommandService);
+    }
+}


### PR DESCRIPTION
## 이슈
- closes #370 

## 개발 사항
- 채팅방에서 모임 정보 조회 가능 -> 모임 ID, 허용되는 강아지 사이즈, 허용되는 강아지 성별
- 채팅방 REST Docs 테스트 코드 추가

## 전달 사항
- API 수정 없이 추가만 했습니다. 바로 머지해도 됩니다!