### PR TITLE
[BE] fix: 같은 kakaoMemberId로 여러 회원이 등록되는 현상 수정

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/auth/domain/KakaoMember.java
+++ b/backend/src/main/java/com/happy/friendogly/auth/domain/KakaoMember.java
@@ -19,10 +19,10 @@ public class KakaoMember {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "kakao_member_id", nullable = false)
+    @Column(name = "kakao_member_id", nullable = false, unique = true)
     private String kakaoMemberId;
 
-    @Column(name = "member_id", nullable = false)
+    @Column(name = "member_id", nullable = false, unique = true)
     private Long memberId;
 
     @Column(name = "refresh_token")

--- a/backend/src/test/java/com/happy/friendogly/kakaoMember/repository/KakaoMemberRepositoryTest.java
+++ b/backend/src/test/java/com/happy/friendogly/kakaoMember/repository/KakaoMemberRepositoryTest.java
@@ -1,0 +1,37 @@
+package com.happy.friendogly.kakaoMember.repository;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.happy.friendogly.auth.domain.KakaoMember;
+import com.happy.friendogly.auth.repository.KakaoMemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@DataJpaTest
+public class KakaoMemberRepositoryTest {
+
+    @Autowired
+    private KakaoMemberRepository kakaoMemberRepository;
+
+    @BeforeEach
+    void cleanUp() {
+        kakaoMemberRepository.deleteAll();
+    }
+
+    @DisplayName("중복된 카카오 회원 id를 가진 kakaoMember 저장 시 예외가 발생한다.")
+    @Test
+    void save_Fail_DuplicateKakaoMemberId() {
+        String duplicateKakaoMemberId = "duplicated";
+        KakaoMember kakaoMember1 = new KakaoMember(duplicateKakaoMemberId, 1L, "refreshToken");
+        KakaoMember kakaoMember2 = new KakaoMember(duplicateKakaoMemberId, 2L, "refreshToken");
+
+        kakaoMemberRepository.save(kakaoMember1);
+
+        assertThatThrownBy(() -> kakaoMemberRepository.save(kakaoMember2))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+}


### PR DESCRIPTION
## 이슈
- #380 

## 개발 사항
- 같은 `kakaoMemberId` 로 여러 회원이 등록되는 현상 수정

# 전달 사항
- **문제 상황**
  - kakao_member 테이블에서 `kakaoMemberId` 로 단건 조회 시 여러 row가 조회되어 아래와 같은 예외 발생
  
    ```
    Query did not return a unique result: 3 results were returned
    ```
- **원인**
  - 회원 프로필 등록 시 등록 버튼을 짧은 시간 이내에 여러 번 터치하는 경우(따닥), 하나의 `kakaoMemberId` 로 kakao_member 테이블에 여러 row가 생성되는 것으로 추측
- **해결**
  - kakao_member_id 컬럼에 unique 제약 조건을 걸어 해결
- 클라이언트 측에서 해당 문제로 로그인을 못하는 현상을 한 번씩 겪는듯 합니다. 😭 빠르게 확인 부탁드립니다!