### PR TITLE
[BE] feat: 회원 및 반려견 수정 API 개발

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/infra/FakeS3StorageManager.java
+++ b/backend/src/main/java/com/happy/friendogly/infra/FakeS3StorageManager.java
@@ -18,4 +18,10 @@ public class FakeS3StorageManager implements FileStorageManager {
 
         return "http://localhost/" + file.getOriginalFilename();
     }
+
+    @Override
+    public void removeFile(String oldImageUrl) {
+        // TODO: 구현
+        System.out.println("removed file");
+    }
 }

--- a/backend/src/main/java/com/happy/friendogly/infra/FileStorageManager.java
+++ b/backend/src/main/java/com/happy/friendogly/infra/FileStorageManager.java
@@ -5,4 +5,6 @@ import org.springframework.web.multipart.MultipartFile;
 public interface FileStorageManager {
 
     String uploadFile(MultipartFile file);
+
+    void removeFile(String oldImageUrl);
 }

--- a/backend/src/main/java/com/happy/friendogly/infra/S3StorageManager.java
+++ b/backend/src/main/java/com/happy/friendogly/infra/S3StorageManager.java
@@ -88,4 +88,10 @@ public class S3StorageManager implements FileStorageManager {
             throw new FriendoglyException("MultipartFile의 임시 파일 생성 중 에러 발생", INTERNAL_SERVER_ERROR);
         }
     }
+
+    @Override
+    public void removeFile(String oldImageUrl) {
+        // TODO: 구현
+        System.out.println("removed file");
+    }
 }

--- a/backend/src/main/java/com/happy/friendogly/member/controller/MemberController.java
+++ b/backend/src/main/java/com/happy/friendogly/member/controller/MemberController.java
@@ -3,14 +3,17 @@ package com.happy.friendogly.member.controller;
 import com.happy.friendogly.auth.Auth;
 import com.happy.friendogly.common.ApiResponse;
 import com.happy.friendogly.member.dto.request.SaveMemberRequest;
+import com.happy.friendogly.member.dto.request.UpdateMemberRequest;
 import com.happy.friendogly.member.dto.response.FindMemberResponse;
 import com.happy.friendogly.member.dto.response.SaveMemberResponse;
+import com.happy.friendogly.member.dto.response.UpdateMemberResponse;
 import com.happy.friendogly.member.service.MemberCommandService;
 import com.happy.friendogly.member.service.MemberQueryService;
 import jakarta.validation.Valid;
 import java.net.URI;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -50,5 +53,15 @@ public class MemberController {
     public ApiResponse<FindMemberResponse> findById(@PathVariable Long id) {
         FindMemberResponse response = memberQueryService.findById(id);
         return ApiResponse.ofSuccess(response);
+    }
+
+    @PatchMapping
+    public ResponseEntity<ApiResponse<UpdateMemberResponse>> update(
+            @Auth Long memberId,
+            @RequestPart @Valid UpdateMemberRequest request,
+            @RequestPart(required = false) MultipartFile image
+    ) {
+        UpdateMemberResponse response = memberCommandService.update(memberId, request, image);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(response));
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/member/domain/Member.java
+++ b/backend/src/main/java/com/happy/friendogly/member/domain/Member.java
@@ -32,4 +32,9 @@ public class Member {
         this.tag = tag;
         this.imageUrl = imageUrl;
     }
+
+    public void update(String name, String imageUrl) {
+        this.name = new Name(name);
+        this.imageUrl = imageUrl;
+    }
 }

--- a/backend/src/main/java/com/happy/friendogly/member/domain/Name.java
+++ b/backend/src/main/java/com/happy/friendogly/member/domain/Name.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 public class Name {
 
     private static final int MIN_NAME_LENGTH = 1;
-    private static final int MAX_NAME_LENGTH = 15;
+    private static final int MAX_NAME_LENGTH = 8;
 
     @Column(name = "name", nullable = false)
     private String value;

--- a/backend/src/main/java/com/happy/friendogly/member/dto/request/SaveMemberRequest.java
+++ b/backend/src/main/java/com/happy/friendogly/member/dto/request/SaveMemberRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Size;
 
 public record SaveMemberRequest(
         @NotBlank(message = "빈 문자열이나 null을 입력할 수 없습니다.")
-        @Size(max = 15, message = "닉네임은 1글자 이상 15글자 이하여야 합니다.")
+        @Size(max = 8, message = "닉네임은 1글자 이상 8글자 이하여야 합니다.")
         String name,
 
         @NotBlank(message = "accessToken은 빈 문자열이나 null을 입력할 수 없습니다.")

--- a/backend/src/main/java/com/happy/friendogly/member/dto/request/UpdateMemberRequest.java
+++ b/backend/src/main/java/com/happy/friendogly/member/dto/request/UpdateMemberRequest.java
@@ -1,0 +1,19 @@
+package com.happy.friendogly.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record UpdateMemberRequest(
+        @NotBlank(message = "name은 빈 문자열이나 null을 입력할 수 없습니다.")
+        @Size(max = 15, message = "닉네임은 1글자 이상 15글자 이하여야 합니다.")
+        String name,
+
+        @NotNull(message = "oldImageUrl은 null을 입력할 수 없습니다.")
+        String oldImageUrl,
+
+        @NotNull(message = "newImageUrl은 null을 입력할 수 없습니다.")
+        String newImageUrl
+) {
+
+}

--- a/backend/src/main/java/com/happy/friendogly/member/dto/request/UpdateMemberRequest.java
+++ b/backend/src/main/java/com/happy/friendogly/member/dto/request/UpdateMemberRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Size;
 
 public record UpdateMemberRequest(
         @NotBlank(message = "name은 빈 문자열이나 null을 입력할 수 없습니다.")
-        @Size(max = 15, message = "닉네임은 1글자 이상 15글자 이하여야 합니다.")
+        @Size(max = 8, message = "닉네임은 1글자 이상 8글자 이하여야 합니다.")
         String name,
 
         @NotNull(message = "oldImageUrl은 null을 입력할 수 없습니다.")

--- a/backend/src/main/java/com/happy/friendogly/member/dto/response/UpdateMemberResponse.java
+++ b/backend/src/main/java/com/happy/friendogly/member/dto/response/UpdateMemberResponse.java
@@ -1,0 +1,20 @@
+package com.happy.friendogly.member.dto.response;
+
+import com.happy.friendogly.member.domain.Member;
+
+public record UpdateMemberResponse(
+        Long id,
+        String name,
+        String tag,
+        String imageUrl
+) {
+
+    public UpdateMemberResponse(Member member) {
+        this(
+                member.getId(),
+                member.getName().getValue(),
+                member.getTag(),
+                member.getImageUrl()
+        );
+    }
+}

--- a/backend/src/main/java/com/happy/friendogly/member/service/MemberCommandService.java
+++ b/backend/src/main/java/com/happy/friendogly/member/service/MemberCommandService.java
@@ -9,7 +9,9 @@ import com.happy.friendogly.auth.service.jwt.TokenPayload;
 import com.happy.friendogly.infra.FileStorageManager;
 import com.happy.friendogly.member.domain.Member;
 import com.happy.friendogly.member.dto.request.SaveMemberRequest;
+import com.happy.friendogly.member.dto.request.UpdateMemberRequest;
 import com.happy.friendogly.member.dto.response.SaveMemberResponse;
+import com.happy.friendogly.member.dto.response.UpdateMemberResponse;
 import com.happy.friendogly.member.repository.MemberRepository;
 import com.happy.friendogly.utils.UuidGenerator;
 import org.springframework.stereotype.Service;
@@ -59,5 +61,21 @@ public class MemberCommandService {
         kakaoMemberRepository.save(new KakaoMember(kakaoMemberId, savedMember.getId(), tokens.refreshToken()));
 
         return new SaveMemberResponse(savedMember, tokens);
+    }
+
+    public UpdateMemberResponse update(Long memberId, UpdateMemberRequest request, MultipartFile image) {
+        Member member = memberRepository.getById(memberId);
+
+        String newImageUrl = request.newImageUrl();
+        if (image != null && !image.isEmpty()) {
+            newImageUrl = fileStorageManager.uploadFile(image);
+        }
+        member.update(request.name(), newImageUrl);
+
+        if (!request.oldImageUrl().equals(request.newImageUrl())) {
+            fileStorageManager.removeFile(request.oldImageUrl());
+        }
+
+        return new UpdateMemberResponse(member);
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/pet/controller/PetController.java
+++ b/backend/src/main/java/com/happy/friendogly/pet/controller/PetController.java
@@ -3,8 +3,10 @@ package com.happy.friendogly.pet.controller;
 import com.happy.friendogly.auth.Auth;
 import com.happy.friendogly.common.ApiResponse;
 import com.happy.friendogly.pet.dto.request.SavePetRequest;
+import com.happy.friendogly.pet.dto.request.UpdatePetRequest;
 import com.happy.friendogly.pet.dto.response.FindPetResponse;
 import com.happy.friendogly.pet.dto.response.SavePetResponse;
+import com.happy.friendogly.pet.dto.response.UpdatePetResponse;
 import com.happy.friendogly.pet.service.PetCommandService;
 import com.happy.friendogly.pet.service.PetQueryService;
 import jakarta.validation.Valid;
@@ -12,6 +14,7 @@ import java.net.URI;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -59,5 +62,16 @@ public class PetController {
     public ApiResponse<List<FindPetResponse>> findByMemberId(@RequestParam Long memberId) {
         List<FindPetResponse> response = petQueryService.findByMemberId(memberId);
         return ApiResponse.ofSuccess(response);
+    }
+
+    @PatchMapping("/{petId}")
+    public ResponseEntity<ApiResponse<UpdatePetResponse>> update(
+            @Auth Long memberId,
+            @PathVariable Long petId,
+            @RequestPart @Valid UpdatePetRequest request,
+            @RequestPart(required = false) MultipartFile image
+    ) {
+        UpdatePetResponse response = petCommandService.update(memberId, petId, request, image);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(response));
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/pet/domain/Description.java
+++ b/backend/src/main/java/com/happy/friendogly/pet/domain/Description.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 public class Description {
 
     private static final int MIN_DESCRIPTION_LENGTH = 1;
-    private static final int MAX_DESCRIPTION_LENGTH = 15;
+    private static final int MAX_DESCRIPTION_LENGTH = 20;
 
     @Column(name = "description", nullable = false)
     private String value;

--- a/backend/src/main/java/com/happy/friendogly/pet/domain/Name.java
+++ b/backend/src/main/java/com/happy/friendogly/pet/domain/Name.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 public class Name {
 
     private static final int MIN_NAME_LENGTH = 1;
-    private static final int MAX_NAME_LENGTH = 15;
+    private static final int MAX_NAME_LENGTH = 8;
 
     @Column(name = "name", nullable = false)
     private String value;

--- a/backend/src/main/java/com/happy/friendogly/pet/domain/Pet.java
+++ b/backend/src/main/java/com/happy/friendogly/pet/domain/Pet.java
@@ -80,4 +80,20 @@ public class Pet {
     public boolean isOwner(Member member) {
         return this.member.getId().equals(member.getId());
     }
+
+    public void update(
+            String name,
+            String description,
+            LocalDate birthDate,
+            SizeType sizeType,
+            Gender gender,
+            String newImageUrl
+    ) {
+        this.name = new Name(name);
+        this.description = new Description(description);
+        this.birthDate = new BirthDate(birthDate);
+        this.sizeType = sizeType;
+        this.gender = gender;
+        this.imageUrl = newImageUrl;
+    }
 }

--- a/backend/src/main/java/com/happy/friendogly/pet/dto/request/SavePetRequest.java
+++ b/backend/src/main/java/com/happy/friendogly/pet/dto/request/SavePetRequest.java
@@ -8,11 +8,11 @@ import java.time.LocalDate;
 
 public record SavePetRequest(
         @NotBlank(message = "name은 빈 문자열이나 null을 입력할 수 없습니다.")
-        @Size(max = 15, message = "이름은 1글자 이상 15글자 이하여야 합니다.")
+        @Size(max = 8, message = "이름은 1글자 이상 8글자 이하여야 합니다.")
         String name,
 
         @NotBlank(message = "description은 빈 문자열이나 null을 입력할 수 없습니다.")
-        @Size(max = 15, message = "설명은 1글자 이상 15글자 이하여야 합니다.")
+        @Size(max = 20, message = "설명은 1글자 이상 20글자 이하여야 합니다.")
         String description,
 
         @NotNull(message = "birthDate는 빈 문자열이나 null을 입력할 수 없습니다.")

--- a/backend/src/main/java/com/happy/friendogly/pet/dto/request/SavePetRequest.java
+++ b/backend/src/main/java/com/happy/friendogly/pet/dto/request/SavePetRequest.java
@@ -5,10 +5,8 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PastOrPresent;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
-import org.hibernate.validator.constraints.URL;
 
 public record SavePetRequest(
-
         @NotBlank(message = "name은 빈 문자열이나 null을 입력할 수 없습니다.")
         @Size(max = 15, message = "이름은 1글자 이상 15글자 이하여야 합니다.")
         String name,
@@ -25,10 +23,7 @@ public record SavePetRequest(
         String sizeType,
 
         @NotBlank(message = "gender는 빈 문자열이나 null을 입력할 수 없습니다.")
-        String gender,
-
-        @URL
-        String imageUrl
+        String gender
 ) {
 
 }

--- a/backend/src/main/java/com/happy/friendogly/pet/dto/request/UpdatePetRequest.java
+++ b/backend/src/main/java/com/happy/friendogly/pet/dto/request/UpdatePetRequest.java
@@ -1,0 +1,35 @@
+package com.happy.friendogly.pet.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+
+public record UpdatePetRequest(
+        @NotBlank(message = "name은 빈 문자열이나 null을 입력할 수 없습니다.")
+        @Size(max = 15, message = "이름은 1글자 이상 15글자 이하여야 합니다.")
+        String name,
+
+        @NotBlank(message = "description은 빈 문자열이나 null을 입력할 수 없습니다.")
+        @Size(max = 15, message = "설명은 1글자 이상 15글자 이하여야 합니다.")
+        String description,
+
+        @NotNull(message = "birthDate는 빈 문자열이나 null을 입력할 수 없습니다.")
+        @PastOrPresent(message = "birthDate는 현재 날짜와 같거나 이전이어야 합니다.")
+        LocalDate birthDate,
+
+        @NotBlank(message = "sizeType은 빈 문자열이나 null을 입력할 수 없습니다.")
+        String sizeType,
+
+        @NotBlank(message = "gender는 빈 문자열이나 null을 입력할 수 없습니다.")
+        String gender,
+
+        @NotNull(message = "oldImageUrl은 null을 입력할 수 없습니다.")
+        String oldImageUrl,
+
+        @NotNull(message = "newImageUrl은 null을 입력할 수 없습니다.")
+        String newImageUrl
+) {
+
+}

--- a/backend/src/main/java/com/happy/friendogly/pet/dto/request/UpdatePetRequest.java
+++ b/backend/src/main/java/com/happy/friendogly/pet/dto/request/UpdatePetRequest.java
@@ -8,11 +8,11 @@ import java.time.LocalDate;
 
 public record UpdatePetRequest(
         @NotBlank(message = "name은 빈 문자열이나 null을 입력할 수 없습니다.")
-        @Size(max = 15, message = "이름은 1글자 이상 15글자 이하여야 합니다.")
+        @Size(max = 8, message = "이름은 1글자 이상 8글자 이하여야 합니다.")
         String name,
 
         @NotBlank(message = "description은 빈 문자열이나 null을 입력할 수 없습니다.")
-        @Size(max = 15, message = "설명은 1글자 이상 15글자 이하여야 합니다.")
+        @Size(max = 20, message = "설명은 1글자 이상 20글자 이하여야 합니다.")
         String description,
 
         @NotNull(message = "birthDate는 빈 문자열이나 null을 입력할 수 없습니다.")

--- a/backend/src/main/java/com/happy/friendogly/pet/dto/response/UpdatePetResponse.java
+++ b/backend/src/main/java/com/happy/friendogly/pet/dto/response/UpdatePetResponse.java
@@ -1,0 +1,29 @@
+package com.happy.friendogly.pet.dto.response;
+
+import com.happy.friendogly.pet.domain.Pet;
+import java.time.LocalDate;
+
+public record UpdatePetResponse(
+        Long id,
+        Long memberId,
+        String name,
+        String description,
+        LocalDate birthDate,
+        String sizeType,
+        String gender,
+        String imageUrl
+) {
+
+    public UpdatePetResponse(Pet pet) {
+        this(
+                pet.getId(),
+                pet.getMember().getId(),
+                pet.getName().getValue(),
+                pet.getDescription().getValue(),
+                pet.getBirthDate().getValue(),
+                pet.getSizeType().toString(),
+                pet.getGender().toString(),
+                pet.getImageUrl()
+        );
+    }
+}

--- a/backend/src/test/java/com/happy/friendogly/docs/PetApiDocsTest.java
+++ b/backend/src/test/java/com/happy/friendogly/docs/PetApiDocsTest.java
@@ -50,8 +50,7 @@ public class PetApiDocsTest extends RestDocsTest {
                 "땡이입니다.",
                 LocalDate.now().minusDays(1L),
                 SizeType.SMALL.toString(),
-                Gender.FEMALE.toString(),
-                "https://google.com"
+                Gender.FEMALE.toString()
         );
         SavePetResponse response = new SavePetResponse(
                 1L,
@@ -92,8 +91,7 @@ public class PetApiDocsTest extends RestDocsTest {
                                 fieldWithPath("sizeType").type(JsonFieldType.STRING)
                                         .description("반려견 크기: SMALL, MEDIUM, LARGE"),
                                 fieldWithPath("gender").type(JsonFieldType.STRING)
-                                        .description("반려견 성별: MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED"),
-                                fieldWithPath("imageUrl").type(JsonFieldType.STRING).description("반려견 이미지 URL")
+                                        .description("반려견 성별: MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED")
                         ),
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Pet API")

--- a/backend/src/test/java/com/happy/friendogly/member/service/MemberCommandServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/member/service/MemberCommandServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.happy.friendogly.member.domain.Member;
 import com.happy.friendogly.member.dto.request.UpdateMemberRequest;
-import com.happy.friendogly.member.repository.MemberRepository;
 import com.happy.friendogly.support.ServiceTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,9 +14,6 @@ public class MemberCommandServiceTest extends ServiceTest {
 
     @Autowired
     private MemberCommandService memberCommandService;
-
-    @Autowired
-    private MemberRepository memberRepository;
 
     @DisplayName("회원 이름을 변경하는 경우, 변경된 회원 이름이 조회된다.")
     @Test

--- a/backend/src/test/java/com/happy/friendogly/member/service/MemberCommandServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/member/service/MemberCommandServiceTest.java
@@ -1,0 +1,34 @@
+package com.happy.friendogly.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.happy.friendogly.member.domain.Member;
+import com.happy.friendogly.member.dto.request.UpdateMemberRequest;
+import com.happy.friendogly.member.repository.MemberRepository;
+import com.happy.friendogly.support.ServiceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockMultipartFile;
+
+public class MemberCommandServiceTest extends ServiceTest {
+
+    @Autowired
+    private MemberCommandService memberCommandService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @DisplayName("회원 이름을 변경하는 경우, 변경된 회원 이름이 조회된다.")
+    @Test
+    void update_MemberName() {
+        Member member = memberRepository.save(new Member("member", "tag", "imageUrl"));
+        String newName = "newName";
+        UpdateMemberRequest request = new UpdateMemberRequest(newName, "imageUrl", "imageUrl");
+
+        memberCommandService.update(member.getId(), request, new MockMultipartFile("image", "image".getBytes()));
+        Member findMember = memberRepository.getById(member.getId());
+
+        assertThat(findMember.getName().getValue()).isEqualTo(newName);
+    }
+}

--- a/backend/src/test/java/com/happy/friendogly/pet/controller/PetControllerTest.java
+++ b/backend/src/test/java/com/happy/friendogly/pet/controller/PetControllerTest.java
@@ -59,11 +59,11 @@ class PetControllerTest extends ControllerTest {
                 .statusCode(HttpStatus.CREATED.value());
     }
 
-    @DisplayName("닉네임 길이가 15자를 초과하는 경우 400을 반환한다.")
+    @DisplayName("닉네임 길이가 8자를 초과하는 경우 400을 반환한다.")
     @Test
     void savePet_Fail_NameLengthOver() {
         SavePetRequest request = new SavePetRequest(
-                "1234567890123456",
+                "123456789",
                 "땡이입니다.",
                 LocalDate.now().minusDays(1L),
                 "SMALL",
@@ -80,12 +80,12 @@ class PetControllerTest extends ControllerTest {
                 .statusCode(HttpStatus.BAD_REQUEST.value());
     }
 
-    @DisplayName("한 줄 설명의 길이가 15자를 초과하는 경우 400을 반환한다.")
+    @DisplayName("한 줄 설명의 길이가 20자를 초과하는 경우 400을 반환한다.")
     @Test
     void savePet_Fail_DescriptionLengthOver() {
         SavePetRequest request = new SavePetRequest(
                 "땡이",
-                "1234567890123456",
+                "123456789012345678901",
                 LocalDate.now().minusDays(1L),
                 "SMALL",
                 "FEMALE_NEUTERED"

--- a/backend/src/test/java/com/happy/friendogly/pet/controller/PetControllerTest.java
+++ b/backend/src/test/java/com/happy/friendogly/pet/controller/PetControllerTest.java
@@ -46,8 +46,7 @@ class PetControllerTest extends ControllerTest {
                 "땡이입니다.",
                 LocalDate.now().minusDays(1L),
                 "SMALL",
-                "FEMALE_NEUTERED",
-                "http://www.google.com"
+                "FEMALE_NEUTERED"
         );
 
         RestAssured.given().log().all()
@@ -68,8 +67,7 @@ class PetControllerTest extends ControllerTest {
                 "땡이입니다.",
                 LocalDate.now().minusDays(1L),
                 "SMALL",
-                "FEMALE_NEUTERED",
-                "http://www.google.com"
+                "FEMALE_NEUTERED"
         );
 
         RestAssured.given().log().all()
@@ -90,8 +88,7 @@ class PetControllerTest extends ControllerTest {
                 "1234567890123456",
                 LocalDate.now().minusDays(1L),
                 "SMALL",
-                "FEMALE_NEUTERED",
-                "http://www.google.com"
+                "FEMALE_NEUTERED"
         );
 
         RestAssured.given().log().all()
@@ -112,30 +109,7 @@ class PetControllerTest extends ControllerTest {
                 "땡이입니다.",
                 LocalDate.now().plusDays(1L),
                 "SMALL",
-                "FEMALE_NEUTERED",
-                "http://www.google.com"
-        );
-
-        RestAssured.given().log().all()
-                .contentType(ContentType.MULTIPART)
-                .header(HttpHeaders.AUTHORIZATION, getMemberAccessToken(member.getId()))
-                .multiPart("image", new File("./src/test/resources/real_ddang.jpg"))
-                .multiPart("request", request, "application/json")
-                .when().post("/pets")
-                .then().log().all()
-                .statusCode(HttpStatus.BAD_REQUEST.value());
-    }
-
-    @DisplayName("이미지 URL이 형식에 맞지 않는 경우 400을 반환한다.")
-    @Test
-    void savePet_Fail_InvalidUrlFormat() {
-        SavePetRequest request = new SavePetRequest(
-                "땡이",
-                "땡이입니다.",
-                LocalDate.now().minusDays(1L),
-                "SMALL",
-                "FEMALE_NEUTERED",
-                "내맘대로 URL주소 지정하기~"
+                "FEMALE_NEUTERED"
         );
 
         RestAssured.given().log().all()
@@ -156,8 +130,7 @@ class PetControllerTest extends ControllerTest {
                 "땡이입니다.",
                 LocalDate.now().minusDays(1L),
                 "SMALL",
-                "FEMALE_NEUTERED",
-                "http://www.google.com"
+                "FEMALE_NEUTERED"
         );
 
         RestAssured.given().log().all()

--- a/backend/src/test/java/com/happy/friendogly/pet/domain/PetTest.java
+++ b/backend/src/test/java/com/happy/friendogly/pet/domain/PetTest.java
@@ -65,13 +65,13 @@ class PetTest {
                 .hasMessage("이름은 빈 값이나 null일 수 없습니다.");
     }
 
-    @DisplayName("이름의 길이가 16글자 이상인 경우 예외가 발생한다.")
+    @DisplayName("이름의 길이가 8글자를 초과하는 경우 예외가 발생한다.")
     @Test
     void create_Fail_IllegalNameLength() {
         assertThatThrownBy(() ->
                 Pet.builder()
                         .member(member)
-                        .name("1234567890123456")
+                        .name("123456789")
                         .description("땡이입니다.")
                         .birthDate(LocalDate.now().minusDays(1L))
                         .sizeType(SizeType.SMALL)
@@ -79,7 +79,7 @@ class PetTest {
                         .imageUrl("http://www.google.com")
                         .build())
                 .isExactlyInstanceOf(FriendoglyException.class)
-                .hasMessage("이름은 1자 이상, 15자 이하여야 합니다.");
+                .hasMessage("이름은 1자 이상, 8자 이하여야 합니다.");
     }
 
     @DisplayName("한 줄 설명이 null인 경우 예외가 발생한다.")
@@ -99,21 +99,21 @@ class PetTest {
                 .hasMessage("한 줄 설명은 빈 값이나 null일 수 없습니다.");
     }
 
-    @DisplayName("한 줄 설명의 길이가 16글자 이상인 경우 예외가 발생한다.")
+    @DisplayName("한 줄 설명의 길이가 20글자를 초과하는 경우 예외가 발생한다.")
     @Test
     void create_Fail_IllegalDescriptionLength() {
         assertThatThrownBy(() ->
                 Pet.builder()
                         .member(member)
                         .name("땡이")
-                        .description("1234567890123456")
+                        .description("123456789012345678901")
                         .birthDate(LocalDate.now().minusDays(1L))
                         .sizeType(SizeType.SMALL)
                         .gender(Gender.FEMALE_NEUTERED)
                         .imageUrl("http://www.google.com")
                         .build())
                 .isExactlyInstanceOf(FriendoglyException.class)
-                .hasMessage("한 줄 설명은 1자 이상, 15자 이하여야 합니다.");
+                .hasMessage("한 줄 설명은 1자 이상, 20자 이하여야 합니다.");
     }
 
     @DisplayName("생년월일이 현재 날짜보다 미래인 경우 예외가 발생한다.")

--- a/backend/src/test/java/com/happy/friendogly/pet/service/PetCommandServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/pet/service/PetCommandServiceTest.java
@@ -1,0 +1,77 @@
+package com.happy.friendogly.pet.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.happy.friendogly.exception.FriendoglyException;
+import com.happy.friendogly.member.domain.Member;
+import com.happy.friendogly.pet.domain.Gender;
+import com.happy.friendogly.pet.domain.Pet;
+import com.happy.friendogly.pet.domain.SizeType;
+import com.happy.friendogly.pet.dto.request.UpdatePetRequest;
+import com.happy.friendogly.support.ServiceTest;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockMultipartFile;
+
+public class PetCommandServiceTest extends ServiceTest {
+
+    @Autowired
+    private PetCommandService petCommandService;
+
+    @DisplayName("반려견 이름을 변경하는 경우, 변경된 반려견 이름이 조회된다.")
+    @Test
+    void update_PetName() {
+        Member member = memberRepository.save(new Member("member", "tag", "imageUrl"));
+        Pet pet = petRepository.save(
+                new Pet(member, "name", "pet", LocalDate.now().minusDays(1L), SizeType.SMALL, Gender.MALE, "imageUrl"));
+
+        String newName = "newName";
+        UpdatePetRequest request = new UpdatePetRequest(
+                newName,
+                pet.getDescription().getValue(),
+                pet.getBirthDate().getValue(),
+                pet.getSizeType().name(),
+                pet.getGender().name(),
+                pet.getImageUrl(),
+                pet.getImageUrl()
+        );
+
+        petCommandService.update(member.getId(), pet.getId(), request, new MockMultipartFile("img", "img".getBytes()));
+        Pet findPet = petRepository.getById(pet.getId());
+
+        assertThat(findPet.getName().getValue()).isEqualTo(newName);
+    }
+
+    @DisplayName("로그인한 사용자가 반려견의 주인이 아닌 경우, 반려견 정보 수정 요청 시 예외가 발생한다.")
+    @Test
+    void update_Fail_NotOwner() {
+        Member owner = memberRepository.save(new Member("owner", "tag", "imageUrl"));
+        Member notOwner = memberRepository.save(new Member("notOwner", "tag", "imageUrl"));
+        Pet pet = petRepository.save(
+                new Pet(owner, "name", "pet", LocalDate.now().minusDays(1L), SizeType.SMALL, Gender.MALE, "imageUrl"));
+
+        String newName = "newName";
+        UpdatePetRequest request = new UpdatePetRequest(
+                newName,
+                pet.getDescription().getValue(),
+                pet.getBirthDate().getValue(),
+                pet.getSizeType().name(),
+                pet.getGender().name(),
+                pet.getImageUrl(),
+                pet.getImageUrl()
+        );
+
+        assertThatThrownBy(() ->
+                petCommandService.update(
+                        notOwner.getId(),
+                        pet.getId(),
+                        request,
+                        new MockMultipartFile("img", "img".getBytes())
+                ))
+                .isInstanceOf(FriendoglyException.class)
+                .hasMessage("자신이 주인인 반려견의 정보만 수정할 수 있습니다.");
+    }
+}


### PR DESCRIPTION
## 이슈
- close #366 
- close #395
- close #397 

## 개발 사항
- 회원 및 반려견 수정 API 개발
- name, description 등 필드 길이 제한 클라이언트와 통일

## 리뷰 요청 사항
**MemberCommandService**
```java
public UpdateMemberResponse update(Long memberId, UpdateMemberRequest request, MultipartFile image) {
    Member member = memberRepository.getById(memberId);

    // 1. 새로운 이미지 파일이 요청으로 들어오는 경우, 해당 이미지를 S3에 업로드
    String newImageUrl = request.newImageUrl();
    if (image != null && !image.isEmpty()) {
        newImageUrl = fileStorageManager.uploadFile(image);
    }
    // 2. request DTO로 들어온 정보를 통해 member 엔티티 update
    member.update(request.name(), newImageUrl);

    // 3. 이미지가 교체되어 기존 이미지 파일을 더이상 사용하지 않는 경우, 해당 이미지를 S3에서 삭제
    if (!request.oldImageUrl().equals(request.newImageUrl())) {
        fileStorageManager.removeFile(request.oldImageUrl());
    }

    return new UpdateMemberResponse(member);
}
```
- 전체적으로 위와 같은 흐름으로 구현했습니다! [request DTO 스펙](https://www.notion.so/API-00e3590c96324047a1fcc79c67cbe307)을 보시면 더 쉽게 이해하실 수 있습니다.
- `fileStorageManager.removeFile()` 은 실제로 구현하진 않았고, `FileStorageManager` 인터페이스에 껍데기만 추가했습니다.
- Member와 Pet 모두 image 관련 코드는 리팩토링에 크게 신경쓰지 않았습니다. 추후에 `FileStorageManager` 내부로 로직을 이동시키는 것을 고려해보면 좋을 것 같습니다~
- update의 흐름이 자연스럽게 이해되는지, 이미지 update 방식이 적절한지를 중점적으로 봐주시면 감사하겠습니다!
