### PR TITLE
[BE] feat: 반려견 정보 수정 API

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/infra/ImageUpdateType.java
+++ b/backend/src/main/java/com/happy/friendogly/infra/ImageUpdateType.java
@@ -1,0 +1,28 @@
+package com.happy.friendogly.infra;
+
+import com.happy.friendogly.exception.FriendoglyException;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+public enum ImageUpdateType {
+
+    UPDATE,
+    NOT_UPDATE,
+    DELETE;
+
+    public static ImageUpdateType from(String rawImageUpdateType) {
+        try {
+            return valueOf(rawImageUpdateType);
+        } catch (IllegalArgumentException e) {
+            throw new FriendoglyException(
+                    String.format("존재하지 않는 ImageUpdateType 입니다. %s 중 하나로 입력해주세요.", createAllowedValues())
+            );
+        }
+    }
+
+    private static String createAllowedValues() {
+        return Arrays.stream(values())
+                .map(Enum::name)
+                .collect(Collectors.joining(", "));
+    }
+}

--- a/backend/src/main/java/com/happy/friendogly/pet/controller/PetController.java
+++ b/backend/src/main/java/com/happy/friendogly/pet/controller/PetController.java
@@ -3,6 +3,7 @@ package com.happy.friendogly.pet.controller;
 import com.happy.friendogly.auth.Auth;
 import com.happy.friendogly.common.ApiResponse;
 import com.happy.friendogly.pet.dto.request.SavePetRequest;
+import com.happy.friendogly.pet.dto.request.UpdatePetRequest;
 import com.happy.friendogly.pet.dto.response.FindPetResponse;
 import com.happy.friendogly.pet.dto.response.SavePetResponse;
 import com.happy.friendogly.pet.service.PetCommandService;
@@ -12,6 +13,7 @@ import java.net.URI;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -59,5 +61,15 @@ public class PetController {
     public ApiResponse<List<FindPetResponse>> findByMemberId(@RequestParam Long memberId) {
         List<FindPetResponse> response = petQueryService.findByMemberId(memberId);
         return ApiResponse.ofSuccess(response);
+    }
+
+    @PatchMapping("/{petId}")
+    public void update(
+            @PathVariable Long petId,
+            @Auth Long memberId,
+            @RequestPart @Valid UpdatePetRequest request,
+            @RequestPart(required = false) MultipartFile image
+    ) {
+        petCommandService.update(memberId, petId, request, image);
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/pet/domain/Description.java
+++ b/backend/src/main/java/com/happy/friendogly/pet/domain/Description.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 public class Description {
 
     private static final int MIN_DESCRIPTION_LENGTH = 1;
-    private static final int MAX_DESCRIPTION_LENGTH = 15;
+    private static final int MAX_DESCRIPTION_LENGTH = 20;
 
     @Column(name = "description", nullable = false)
     private String value;

--- a/backend/src/main/java/com/happy/friendogly/pet/domain/Name.java
+++ b/backend/src/main/java/com/happy/friendogly/pet/domain/Name.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 public class Name {
 
     private static final int MIN_NAME_LENGTH = 1;
-    private static final int MAX_NAME_LENGTH = 15;
+    private static final int MAX_NAME_LENGTH = 8;
 
     @Column(name = "name", nullable = false)
     private String value;

--- a/backend/src/main/java/com/happy/friendogly/pet/domain/Pet.java
+++ b/backend/src/main/java/com/happy/friendogly/pet/domain/Pet.java
@@ -71,20 +71,6 @@ public class Pet {
         this.imageUrl = imageUrl;
     }
 
-    public Pet(
-            Long id,
-            Member member,
-            String name,
-            String description,
-            LocalDate birthDate,
-            SizeType sizeType,
-            Gender gender,
-            String imageUrl
-    ) {
-        this(member, name, description, birthDate, sizeType, gender, imageUrl);
-        this.id = id;
-    }
-
     private void validateMember(Member member) {
         if (member == null) {
             throw new FriendoglyException("member는 null일 수 없습니다.");
@@ -93,5 +79,21 @@ public class Pet {
 
     public boolean isOwner(Member member) {
         return this.member.getId().equals(member.getId());
+    }
+
+    public void update(
+            String name,
+            String description,
+            LocalDate birthDate,
+            String sizeType,
+            String gender,
+            String imageUrl
+    ) {
+        this.name = new Name(name);
+        this.description = new Description(description);
+        this.birthDate = new BirthDate(birthDate);
+        this.sizeType = SizeType.toSizeType(sizeType);
+        this.gender = Gender.toGender(gender);
+        this.imageUrl = imageUrl;
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/pet/domain/Pet.java
+++ b/backend/src/main/java/com/happy/friendogly/pet/domain/Pet.java
@@ -61,7 +61,7 @@ public class Pet {
             String imageUrl
     ) {
         validateMember(member);
-        
+
         this.member = member;
         this.name = new Name(name);
         this.description = new Description(description);
@@ -69,6 +69,20 @@ public class Pet {
         this.sizeType = sizeType;
         this.gender = gender;
         this.imageUrl = imageUrl;
+    }
+
+    public Pet(
+            Long id,
+            Member member,
+            String name,
+            String description,
+            LocalDate birthDate,
+            SizeType sizeType,
+            Gender gender,
+            String imageUrl
+    ) {
+        this(member, name, description, birthDate, sizeType, gender, imageUrl);
+        this.id = id;
     }
 
     private void validateMember(Member member) {

--- a/backend/src/main/java/com/happy/friendogly/pet/dto/request/SavePetRequest.java
+++ b/backend/src/main/java/com/happy/friendogly/pet/dto/request/SavePetRequest.java
@@ -10,11 +10,11 @@ import org.hibernate.validator.constraints.URL;
 public record SavePetRequest(
 
         @NotBlank(message = "name은 빈 문자열이나 null을 입력할 수 없습니다.")
-        @Size(max = 15, message = "이름은 1글자 이상 15글자 이하여야 합니다.")
+        @Size(max = 8, message = "이름은 1글자 이상 8글자 이하여야 합니다.")
         String name,
 
         @NotBlank(message = "description은 빈 문자열이나 null을 입력할 수 없습니다.")
-        @Size(max = 15, message = "설명은 1글자 이상 15글자 이하여야 합니다.")
+        @Size(max = 20, message = "설명은 1글자 이상 20글자 이하여야 합니다.")
         String description,
 
         @NotNull(message = "birthDate는 빈 문자열이나 null을 입력할 수 없습니다.")

--- a/backend/src/main/java/com/happy/friendogly/pet/dto/request/UpdatePetRequest.java
+++ b/backend/src/main/java/com/happy/friendogly/pet/dto/request/UpdatePetRequest.java
@@ -23,7 +23,10 @@ public record UpdatePetRequest(
         String sizeType,
 
         @NotBlank(message = "gender는 빈 문자열이나 null을 입력할 수 없습니다.")
-        String gender
+        String gender,
+
+        @NotBlank(message = "imageUpdateType는 빈 문자열이나 null을 입력할 수 없습니다.")
+        String imageUpdateType
 ) {
 
 }

--- a/backend/src/main/java/com/happy/friendogly/pet/dto/request/UpdatePetRequest.java
+++ b/backend/src/main/java/com/happy/friendogly/pet/dto/request/UpdatePetRequest.java
@@ -1,0 +1,29 @@
+package com.happy.friendogly.pet.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+
+public record UpdatePetRequest(
+        @NotBlank(message = "name은 빈 문자열이나 null을 입력할 수 없습니다.")
+        @Size(max = 15, message = "이름은 1글자 이상 15글자 이하여야 합니다.")
+        String name,
+
+        @NotBlank(message = "description은 빈 문자열이나 null을 입력할 수 없습니다.")
+        @Size(max = 15, message = "설명은 1글자 이상 15글자 이하여야 합니다.")
+        String description,
+
+        @NotNull(message = "birthDate는 빈 문자열이나 null을 입력할 수 없습니다.")
+        @PastOrPresent(message = "birthDate는 현재 날짜와 같거나 이전이어야 합니다.")
+        LocalDate birthDate,
+
+        @NotBlank(message = "sizeType은 빈 문자열이나 null을 입력할 수 없습니다.")
+        String sizeType,
+
+        @NotBlank(message = "gender는 빈 문자열이나 null을 입력할 수 없습니다.")
+        String gender
+) {
+
+}

--- a/backend/src/main/java/com/happy/friendogly/pet/dto/request/UpdatePetRequest.java
+++ b/backend/src/main/java/com/happy/friendogly/pet/dto/request/UpdatePetRequest.java
@@ -8,11 +8,11 @@ import java.time.LocalDate;
 
 public record UpdatePetRequest(
         @NotBlank(message = "name은 빈 문자열이나 null을 입력할 수 없습니다.")
-        @Size(max = 15, message = "이름은 1글자 이상 15글자 이하여야 합니다.")
+        @Size(max = 8, message = "이름은 1글자 이상 8글자 이하여야 합니다.")
         String name,
 
         @NotBlank(message = "description은 빈 문자열이나 null을 입력할 수 없습니다.")
-        @Size(max = 15, message = "설명은 1글자 이상 15글자 이하여야 합니다.")
+        @Size(max = 20, message = "설명은 1글자 이상 20글자 이하여야 합니다.")
         String description,
 
         @NotNull(message = "birthDate는 빈 문자열이나 null을 입력할 수 없습니다.")

--- a/backend/src/main/java/com/happy/friendogly/pet/service/PetCommandService.java
+++ b/backend/src/main/java/com/happy/friendogly/pet/service/PetCommandService.java
@@ -8,6 +8,7 @@ import com.happy.friendogly.pet.domain.Gender;
 import com.happy.friendogly.pet.domain.Pet;
 import com.happy.friendogly.pet.domain.SizeType;
 import com.happy.friendogly.pet.dto.request.SavePetRequest;
+import com.happy.friendogly.pet.dto.request.UpdatePetRequest;
 import com.happy.friendogly.pet.dto.response.SavePetResponse;
 import com.happy.friendogly.pet.repository.PetRepository;
 import org.springframework.stereotype.Service;
@@ -63,5 +64,32 @@ public class PetCommandService {
             throw new FriendoglyException(String.format(
                     "강아지는 최대 %d 마리까지만 등록할 수 있습니다.", MAX_PET_CAPACITY));
         }
+    }
+
+    public void update(Long memberId, Long petId, UpdatePetRequest request, MultipartFile image) {
+        Member member = memberRepository.getById(memberId);
+        Pet pet = petRepository.getById(petId);
+
+        if (!pet.isOwner(member)) {
+            throw new FriendoglyException("자신의 강아지만 수정할 수 있습니다.");
+        }
+
+        String newImageUrl = pet.getImageUrl();
+        if (image != null && !image.isEmpty()) {
+            newImageUrl = fileStorageManager.uploadFile(image);
+        }
+
+        Pet newPet = new Pet(
+                pet.getId(),
+                member,
+                request.name(),
+                request.description(),
+                request.birthDate(),
+                SizeType.toSizeType(request.sizeType()),
+                Gender.toGender(request.gender()),
+                newImageUrl
+        );
+
+        petRepository.save(newPet);
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/pet/service/PetCommandService.java
+++ b/backend/src/main/java/com/happy/friendogly/pet/service/PetCommandService.java
@@ -79,17 +79,13 @@ public class PetCommandService {
             newImageUrl = fileStorageManager.uploadFile(image);
         }
 
-        Pet newPet = new Pet(
-                pet.getId(),
-                member,
+        pet.update(
                 request.name(),
                 request.description(),
                 request.birthDate(),
-                SizeType.toSizeType(request.sizeType()),
-                Gender.toGender(request.gender()),
+                request.sizeType(),
+                request.gender(),
                 newImageUrl
         );
-
-        petRepository.save(newPet);
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/pet/service/PetCommandService.java
+++ b/backend/src/main/java/com/happy/friendogly/pet/service/PetCommandService.java
@@ -2,6 +2,7 @@ package com.happy.friendogly.pet.service;
 
 import com.happy.friendogly.exception.FriendoglyException;
 import com.happy.friendogly.infra.FileStorageManager;
+import com.happy.friendogly.infra.ImageUpdateType;
 import com.happy.friendogly.member.domain.Member;
 import com.happy.friendogly.member.repository.MemberRepository;
 import com.happy.friendogly.pet.domain.Gender;
@@ -74,9 +75,23 @@ public class PetCommandService {
             throw new FriendoglyException("자신의 강아지만 수정할 수 있습니다.");
         }
 
-        String newImageUrl = pet.getImageUrl();
-        if (image != null && !image.isEmpty()) {
+        ImageUpdateType imageUpdateType = ImageUpdateType.from(request.imageUpdateType());
+
+        String oldImageUrl = pet.getImageUrl();
+        String newImageUrl = "";
+
+        if (imageUpdateType == ImageUpdateType.UPDATE) {
+            // TODO: 기존 이미지 S3에서 삭제
             newImageUrl = fileStorageManager.uploadFile(image);
+        }
+
+        if (imageUpdateType == ImageUpdateType.NOT_UPDATE) {
+            newImageUrl = oldImageUrl;
+        }
+
+        if (imageUpdateType == ImageUpdateType.DELETE) {
+            // TODO: 기존 이미지 S3에서 삭제
+            newImageUrl = "";
         }
 
         pet.update(

--- a/backend/src/test/java/com/happy/friendogly/docs/PetApiDocsTest.java
+++ b/backend/src/test/java/com/happy/friendogly/docs/PetApiDocsTest.java
@@ -17,6 +17,7 @@ import com.happy.friendogly.pet.controller.PetController;
 import com.happy.friendogly.pet.domain.Gender;
 import com.happy.friendogly.pet.domain.SizeType;
 import com.happy.friendogly.pet.dto.request.SavePetRequest;
+import com.happy.friendogly.pet.dto.request.UpdatePetRequest;
 import com.happy.friendogly.pet.dto.response.FindPetResponse;
 import com.happy.friendogly.pet.dto.response.SavePetResponse;
 import com.happy.friendogly.pet.service.PetCommandService;
@@ -28,10 +29,12 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
 
 public class PetApiDocsTest extends RestDocsTest {
 
@@ -301,6 +304,96 @@ public class PetApiDocsTest extends RestDocsTest {
                                                 .description("반려견 이미지 URL")
                                 )
                                 .responseSchema(Schema.schema("FindPetResponse"))
+                                .build()))
+                );
+    }
+
+    @DisplayName("반려견 정보 업데이트 문서화")
+    @Test
+    void update_Success() throws Exception {
+        // MultipartFile + PATCH Method 같이 사용하기 위한 코드
+        MockMultipartHttpServletRequestBuilder patchBuilder
+                = RestDocumentationRequestBuilders.multipart("/pets/{id}", 1L);
+        patchBuilder.with(request -> {
+            request.setMethod(HttpMethod.PATCH.name());
+            return request;
+        });
+
+        Mockito.doNothing()
+                .when(petCommandService)
+                .update(any(), any(), any(), any());
+
+        UpdatePetRequest requestDto = new UpdatePetRequest(
+                "도토리",
+                "도토리 설명",
+                LocalDate.now().minusYears(1),
+                "SMALL",
+                "MALE"
+        );
+
+        MockMultipartFile image = new MockMultipartFile(
+                "image", "image.jpg", MediaType.MULTIPART_FORM_DATA.toString(), "asdf".getBytes());
+        MockMultipartFile request = new MockMultipartFile(
+                "request", "request", MediaType.APPLICATION_JSON_VALUE, objectMapper.writeValueAsBytes(requestDto));
+
+        mockMvc.perform(patchBuilder
+                        .file(image)
+                        .file(request)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, getMemberToken()))
+                .andExpect(status().isOk())
+                .andDo(MockMvcRestDocumentationWrapper.document("pet-update-200",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        requestParts(
+                                partWithName("image").description("강아지 프로필 이미지 파일"),
+                                partWithName("request").description("강아지 등록 정보")
+                        ),
+                        requestPartFields(
+                                "request",
+                                fieldWithPath("name").type(JsonFieldType.STRING)
+                                        .description("반려견 이름"),
+                                fieldWithPath("description").type(JsonFieldType.STRING)
+                                        .description("반려견 한 줄 소개"),
+                                fieldWithPath("birthDate").type(JsonFieldType.STRING)
+                                        .description("반려견 생년월일: yyyy-MM-dd"),
+                                fieldWithPath("sizeType").type(JsonFieldType.STRING)
+                                        .description("반려견 크기: SMALL, MEDIUM, LARGE"),
+                                fieldWithPath("gender").type(JsonFieldType.STRING)
+                                        .description("반려견 성별: MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED")
+                        ),
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Pet API")
+                                .summary("""
+                                        반려견 정보 수정 API
+                                                                                
+                                        요청 이미지
+                                                                                
+                                        multipart/form-data "image" (null인 경우 이미지 변경을 하지 않음)
+                                                                                
+                                        요청 데이터
+                                                                                
+                                        application/json "request"
+                                                                                
+                                        {
+                                                                                
+                                          "name": "보리", // 변경할 강아지 이름
+                                          
+                                          "description": "귀여운 보리입니다", // 변경할 강아지 설명
+                                          
+                                          "birthDate": "2011-01-01", // 강아지 생일 yyyy-MM-dd
+                                          
+                                          "sizeType": "SMALL", // 변경할 강아지 크기 (SMALL, MEDIUM, LARGE)
+                                          
+                                          "gender": "MALE" // 변경할 반려견 성별 (MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED)
+                                                                                
+                                        }
+                                        """)
+                                .requestHeaders(
+                                        headerWithName(HttpHeaders.AUTHORIZATION).description("로그인한 회원의 accessToken")
+                                )
+                                .pathParameters(
+                                        parameterWithName("id").description("수정하려는 Pet ID"))
                                 .build()))
                 );
     }

--- a/backend/src/test/java/com/happy/friendogly/docs/PetApiDocsTest.java
+++ b/backend/src/test/java/com/happy/friendogly/docs/PetApiDocsTest.java
@@ -328,7 +328,8 @@ public class PetApiDocsTest extends RestDocsTest {
                 "도토리 설명",
                 LocalDate.now().minusYears(1),
                 "SMALL",
-                "MALE"
+                "MALE",
+                "UPDATE"
         );
 
         MockMultipartFile image = new MockMultipartFile(
@@ -360,7 +361,9 @@ public class PetApiDocsTest extends RestDocsTest {
                                 fieldWithPath("sizeType").type(JsonFieldType.STRING)
                                         .description("반려견 크기: SMALL, MEDIUM, LARGE"),
                                 fieldWithPath("gender").type(JsonFieldType.STRING)
-                                        .description("반려견 성별: MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED")
+                                        .description("반려견 성별: MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED"),
+                                fieldWithPath("imageUpdateType").type(JsonFieldType.STRING)
+                                        .description("이미지 업데이트 여부: UPDATE, NOT_UPDATE, DELETE")
                         ),
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Pet API")
@@ -385,8 +388,10 @@ public class PetApiDocsTest extends RestDocsTest {
                                           
                                           "sizeType": "SMALL", // 변경할 강아지 크기 (SMALL, MEDIUM, LARGE)
                                           
-                                          "gender": "MALE" // 변경할 반려견 성별 (MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED)
-                                                                                
+                                          "gender": "MALE", // 변경할 반려견 성별 (MALE, FEMALE, MALE_NEUTERED, FEMALE_NEUTERED)
+                                          
+                                          "imageUpdateType": "UPDATE" // 이미지 업데이트 여부 -> UPDATE(이미지 변경), NOT_UPDATE(이미지 변경 없음), DELETE(기본 이미지로 변경)
+                                                                               
                                         }
                                         """)
                                 .requestHeaders(

--- a/backend/src/test/java/com/happy/friendogly/pet/controller/PetControllerTest.java
+++ b/backend/src/test/java/com/happy/friendogly/pet/controller/PetControllerTest.java
@@ -60,11 +60,11 @@ class PetControllerTest extends ControllerTest {
                 .statusCode(HttpStatus.CREATED.value());
     }
 
-    @DisplayName("닉네임 길이가 15자를 초과하는 경우 400을 반환한다.")
+    @DisplayName("닉네임 길이가 8자를 초과하는 경우 400을 반환한다.")
     @Test
     void savePet_Fail_NameLengthOver() {
         SavePetRequest request = new SavePetRequest(
-                "1234567890123456",
+                "123456789",
                 "땡이입니다.",
                 LocalDate.now().minusDays(1L),
                 "SMALL",
@@ -82,12 +82,12 @@ class PetControllerTest extends ControllerTest {
                 .statusCode(HttpStatus.BAD_REQUEST.value());
     }
 
-    @DisplayName("한 줄 설명의 길이가 15자를 초과하는 경우 400을 반환한다.")
+    @DisplayName("한 줄 설명의 길이가 20자를 초과하는 경우 400을 반환한다.")
     @Test
     void savePet_Fail_DescriptionLengthOver() {
         SavePetRequest request = new SavePetRequest(
                 "땡이",
-                "1234567890123456",
+                "123456789012345678901",
                 LocalDate.now().minusDays(1L),
                 "SMALL",
                 "FEMALE_NEUTERED",

--- a/backend/src/test/java/com/happy/friendogly/pet/domain/PetTest.java
+++ b/backend/src/test/java/com/happy/friendogly/pet/domain/PetTest.java
@@ -65,13 +65,13 @@ class PetTest {
                 .hasMessage("이름은 빈 값이나 null일 수 없습니다.");
     }
 
-    @DisplayName("이름의 길이가 16글자 이상인 경우 예외가 발생한다.")
+    @DisplayName("이름의 길이가 8글자를 초과하는 경우 예외가 발생한다.")
     @Test
     void create_Fail_IllegalNameLength() {
         assertThatThrownBy(() ->
                 Pet.builder()
                         .member(member)
-                        .name("1234567890123456")
+                        .name("123456789")
                         .description("땡이입니다.")
                         .birthDate(LocalDate.now().minusDays(1L))
                         .sizeType(SizeType.SMALL)
@@ -79,7 +79,7 @@ class PetTest {
                         .imageUrl("http://www.google.com")
                         .build())
                 .isExactlyInstanceOf(FriendoglyException.class)
-                .hasMessage("이름은 1자 이상, 15자 이하여야 합니다.");
+                .hasMessage("이름은 1자 이상, 8자 이하여야 합니다.");
     }
 
     @DisplayName("한 줄 설명이 null인 경우 예외가 발생한다.")
@@ -99,21 +99,21 @@ class PetTest {
                 .hasMessage("한 줄 설명은 빈 값이나 null일 수 없습니다.");
     }
 
-    @DisplayName("한 줄 설명의 길이가 16글자 이상인 경우 예외가 발생한다.")
+    @DisplayName("한 줄 설명의 길이가 20글자를 초과하는 경우 예외가 발생한다.")
     @Test
     void create_Fail_IllegalDescriptionLength() {
         assertThatThrownBy(() ->
                 Pet.builder()
                         .member(member)
                         .name("땡이")
-                        .description("1234567890123456")
+                        .description("123456789012345678901")
                         .birthDate(LocalDate.now().minusDays(1L))
                         .sizeType(SizeType.SMALL)
                         .gender(Gender.FEMALE_NEUTERED)
                         .imageUrl("http://www.google.com")
                         .build())
                 .isExactlyInstanceOf(FriendoglyException.class)
-                .hasMessage("한 줄 설명은 1자 이상, 15자 이하여야 합니다.");
+                .hasMessage("한 줄 설명은 1자 이상, 20자 이하여야 합니다.");
     }
 
     @DisplayName("생년월일이 현재 날짜보다 미래인 경우 예외가 발생한다.")

--- a/backend/src/test/java/com/happy/friendogly/pet/service/PetCommandServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/pet/service/PetCommandServiceTest.java
@@ -1,0 +1,134 @@
+package com.happy.friendogly.pet.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.happy.friendogly.exception.FriendoglyException;
+import com.happy.friendogly.member.domain.Member;
+import com.happy.friendogly.pet.domain.Gender;
+import com.happy.friendogly.pet.domain.Pet;
+import com.happy.friendogly.pet.domain.SizeType;
+import com.happy.friendogly.pet.dto.request.UpdatePetRequest;
+import com.happy.friendogly.support.ServiceTest;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockMultipartFile;
+
+class PetCommandServiceTest extends ServiceTest {
+
+    @Autowired
+    private PetCommandService petCommandService;
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = memberRepository.save(new Member("트레", "1b32cff0", "https://image.com/image.jpg"));
+    }
+
+    @DisplayName("펫 정보를 수정할 수 있다.")
+    @Test
+    void update() {
+        // given
+        Pet pet = petRepository.save(new Pet(
+                member,
+                "도토리",
+                "귀여운 도토리입니다!",
+                LocalDate.now().minusYears(1),
+                SizeType.SMALL,
+                Gender.MALE_NEUTERED,
+                "https://picsum.photos/100"
+        ));
+
+        UpdatePetRequest request = new UpdatePetRequest(
+                "바둑이",
+                "새로운 펫이에요!",
+                LocalDate.now().minusYears(2),
+                "MEDIUM",
+                "MALE"
+        );
+
+        MockMultipartFile image = new MockMultipartFile("image", new byte[10]);
+
+        // when
+        petCommandService.update(member.getId(), pet.getId(), request, image);
+
+        // then
+        Pet newPet = petRepository.getById(pet.getId());
+
+        assertAll(
+                () -> assertThat(newPet.getId()).isEqualTo(pet.getId()),
+                () -> assertThat(newPet.getMember().getId()).isEqualTo(pet.getMember().getId()),
+                () -> assertThat(newPet.getName().getValue()).isEqualTo("바둑이"),
+                () -> assertThat(newPet.getDescription().getValue()).isEqualTo("새로운 펫이에요!"),
+                () -> assertThat(newPet.getBirthDate().getValue()).isEqualTo(LocalDate.now().minusYears(2)),
+                () -> assertThat(newPet.getSizeType()).isEqualTo(SizeType.MEDIUM),
+                () -> assertThat(newPet.getGender()).isEqualTo(Gender.MALE),
+                () -> assertThat(newPet.getImageUrl()).startsWith("http://localhost/")
+        );
+    }
+
+    @DisplayName("이미지가 null이면 기존 Image URL로 펫이 저장된다.")
+    @Test
+    void update_ImageNull() {
+        // given
+        Pet pet = petRepository.save(new Pet(
+                member,
+                "도토리",
+                "귀여운 도토리입니다!",
+                LocalDate.now().minusYears(1),
+                SizeType.SMALL,
+                Gender.MALE_NEUTERED,
+                "https://picsum.photos/100"
+        ));
+
+        UpdatePetRequest request = new UpdatePetRequest(
+                "바둑이",
+                "새로운 펫이에요!",
+                LocalDate.now().minusYears(2),
+                "MEDIUM",
+                "MALE"
+        );
+
+        // when
+        petCommandService.update(member.getId(), pet.getId(), request, null);
+
+        // then
+        Pet newPet = petRepository.getById(pet.getId());
+        assertThat(newPet.getImageUrl()).isEqualTo("https://picsum.photos/100");
+    }
+
+    @DisplayName("자신의 펫이 아니면 펫 정보를 수정할 수 없다.")
+    @Test
+    void update_NotMyPet() {
+        // given
+        Member other = memberRepository.save(new Member("다른사람", "12cdd5fb", "https://image.com/image.jpg"));
+
+        Pet pet = petRepository.save(new Pet(
+                other,
+                "도토리",
+                "귀여운 도토리입니다!",
+                LocalDate.now().minusYears(1),
+                SizeType.SMALL,
+                Gender.MALE_NEUTERED,
+                "https://picsum.photos/100"
+        ));
+
+        UpdatePetRequest request = new UpdatePetRequest(
+                "바둑이",
+                "새로운 펫이에요!",
+                LocalDate.now().minusYears(2),
+                "MEDIUM",
+                "MALE"
+        );
+
+        // when - then
+        assertThatThrownBy(() -> petCommandService.update(member.getId(), pet.getId(), request, null))
+                .isInstanceOf(FriendoglyException.class)
+                .hasMessage("자신의 강아지만 수정할 수 있습니다.");
+    }
+}

--- a/backend/src/test/java/com/happy/friendogly/pet/service/PetCommandServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/pet/service/PetCommandServiceTest.java
@@ -30,7 +30,7 @@ class PetCommandServiceTest extends ServiceTest {
         member = memberRepository.save(new Member("트레", "1b32cff0", "https://image.com/image.jpg"));
     }
 
-    @DisplayName("펫 정보를 수정할 수 있다.")
+    @DisplayName("펫 정보를 수정할 수 있다 (이미지 변경)")
     @Test
     void update() {
         // given
@@ -49,7 +49,8 @@ class PetCommandServiceTest extends ServiceTest {
                 "새로운 펫이에요!",
                 LocalDate.now().minusYears(2),
                 "MEDIUM",
-                "MALE"
+                "MALE",
+                "UPDATE"
         );
 
         MockMultipartFile image = new MockMultipartFile("image", new byte[10]);
@@ -59,7 +60,6 @@ class PetCommandServiceTest extends ServiceTest {
 
         // then
         Pet newPet = petRepository.getById(pet.getId());
-
         assertAll(
                 () -> assertThat(newPet.getId()).isEqualTo(pet.getId()),
                 () -> assertThat(newPet.getMember().getId()).isEqualTo(pet.getMember().getId()),
@@ -72,9 +72,9 @@ class PetCommandServiceTest extends ServiceTest {
         );
     }
 
-    @DisplayName("이미지가 null이면 기존 Image URL로 펫이 저장된다.")
+    @DisplayName("펫 정보를 수정할 수 있다 (이미지 변경 없음)")
     @Test
-    void update_ImageNull() {
+    void update_ImageNotUpdate() {
         // given
         Pet pet = petRepository.save(new Pet(
                 member,
@@ -91,7 +91,8 @@ class PetCommandServiceTest extends ServiceTest {
                 "새로운 펫이에요!",
                 LocalDate.now().minusYears(2),
                 "MEDIUM",
-                "MALE"
+                "MALE",
+                "NOT_UPDATE"
         );
 
         // when
@@ -100,6 +101,37 @@ class PetCommandServiceTest extends ServiceTest {
         // then
         Pet newPet = petRepository.getById(pet.getId());
         assertThat(newPet.getImageUrl()).isEqualTo("https://picsum.photos/100");
+    }
+
+    @DisplayName("펫 정보를 수정할 수 있다 (default 이미지로 변경)")
+    @Test
+    void update_ImageDelete() {
+        // given
+        Pet pet = petRepository.save(new Pet(
+                member,
+                "도토리",
+                "귀여운 도토리입니다!",
+                LocalDate.now().minusYears(1),
+                SizeType.SMALL,
+                Gender.MALE_NEUTERED,
+                "https://picsum.photos/100"
+        ));
+
+        UpdatePetRequest request = new UpdatePetRequest(
+                "바둑이",
+                "새로운 펫이에요!",
+                LocalDate.now().minusYears(2),
+                "MEDIUM",
+                "MALE",
+                "DELETE"
+        );
+
+        // when
+        petCommandService.update(member.getId(), pet.getId(), request, null);
+
+        // then
+        Pet newPet = petRepository.getById(pet.getId());
+        assertThat(newPet.getImageUrl()).isBlank();
     }
 
     @DisplayName("자신의 펫이 아니면 펫 정보를 수정할 수 없다.")
@@ -123,7 +155,8 @@ class PetCommandServiceTest extends ServiceTest {
                 "새로운 펫이에요!",
                 LocalDate.now().minusYears(2),
                 "MEDIUM",
-                "MALE"
+                "MALE",
+                "UPDATE"
         );
 
         // when - then


### PR DESCRIPTION
## 이슈
- closes #371 

## 개발 사항
- 반려견 정보 수정 API 구현 및 문서화

## 리뷰 요청 사항
- update 메서드 + 변경감지로 수정 구현했습니다!

## 전달 사항
- API 수정은 없고 추가만 되었습니다. 바로 merge해도 됩니다.
- image가 null인 경우 이미지 수정 없이 기존 이미지를 사용합니다.
- image가 null이 아닌 경우, 기존 이미지를 새로운 이미지로 대체합니다.
- multipart에 대한 API 문서화를 할 방법이 없어 summary에 String으로 작성하였습니다.
