### PR TITLE
[BE] feat: 회원 수정 API 개발

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/infra/FakeS3StorageManager.java
+++ b/backend/src/main/java/com/happy/friendogly/infra/FakeS3StorageManager.java
@@ -18,4 +18,10 @@ public class FakeS3StorageManager implements FileStorageManager {
 
         return "http://localhost/" + file.getOriginalFilename();
     }
+
+    @Override
+    public void removeFile(String oldImageUrl) {
+        // TODO: 구현
+        System.out.println("removed file");
+    }
 }

--- a/backend/src/main/java/com/happy/friendogly/infra/FileStorageManager.java
+++ b/backend/src/main/java/com/happy/friendogly/infra/FileStorageManager.java
@@ -5,4 +5,6 @@ import org.springframework.web.multipart.MultipartFile;
 public interface FileStorageManager {
 
     String uploadFile(MultipartFile file);
+
+    void removeFile(String oldImageUrl);
 }

--- a/backend/src/main/java/com/happy/friendogly/infra/S3StorageManager.java
+++ b/backend/src/main/java/com/happy/friendogly/infra/S3StorageManager.java
@@ -88,4 +88,10 @@ public class S3StorageManager implements FileStorageManager {
             throw new FriendoglyException("MultipartFile의 임시 파일 생성 중 에러 발생", INTERNAL_SERVER_ERROR);
         }
     }
+
+    @Override
+    public void removeFile(String oldImageUrl) {
+        // TODO: 구현
+        System.out.println("removed file");
+    }
 }

--- a/backend/src/main/java/com/happy/friendogly/member/controller/MemberController.java
+++ b/backend/src/main/java/com/happy/friendogly/member/controller/MemberController.java
@@ -3,14 +3,17 @@ package com.happy.friendogly.member.controller;
 import com.happy.friendogly.auth.Auth;
 import com.happy.friendogly.common.ApiResponse;
 import com.happy.friendogly.member.dto.request.SaveMemberRequest;
+import com.happy.friendogly.member.dto.request.UpdateMemberRequest;
 import com.happy.friendogly.member.dto.response.FindMemberResponse;
 import com.happy.friendogly.member.dto.response.SaveMemberResponse;
+import com.happy.friendogly.member.dto.response.UpdateMemberResponse;
 import com.happy.friendogly.member.service.MemberCommandService;
 import com.happy.friendogly.member.service.MemberQueryService;
 import jakarta.validation.Valid;
 import java.net.URI;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -50,5 +53,15 @@ public class MemberController {
     public ApiResponse<FindMemberResponse> findById(@PathVariable Long id) {
         FindMemberResponse response = memberQueryService.findById(id);
         return ApiResponse.ofSuccess(response);
+    }
+
+    @PatchMapping
+    public ResponseEntity<ApiResponse<UpdateMemberResponse>> update(
+            @Auth Long memberId,
+            @RequestPart @Valid UpdateMemberRequest request,
+            @RequestPart(required = false) MultipartFile image
+    ) {
+        UpdateMemberResponse response = memberCommandService.update(memberId, request, image);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(response));
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/member/domain/Member.java
+++ b/backend/src/main/java/com/happy/friendogly/member/domain/Member.java
@@ -32,4 +32,9 @@ public class Member {
         this.tag = tag;
         this.imageUrl = imageUrl;
     }
+
+    public void update(String name, String imageUrl) {
+        this.name = new Name(name);
+        this.imageUrl = imageUrl;
+    }
 }

--- a/backend/src/main/java/com/happy/friendogly/member/domain/Name.java
+++ b/backend/src/main/java/com/happy/friendogly/member/domain/Name.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 public class Name {
 
     private static final int MIN_NAME_LENGTH = 1;
-    private static final int MAX_NAME_LENGTH = 15;
+    private static final int MAX_NAME_LENGTH = 8;
 
     @Column(name = "name", nullable = false)
     private String value;

--- a/backend/src/main/java/com/happy/friendogly/member/dto/request/SaveMemberRequest.java
+++ b/backend/src/main/java/com/happy/friendogly/member/dto/request/SaveMemberRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Size;
 
 public record SaveMemberRequest(
         @NotBlank(message = "빈 문자열이나 null을 입력할 수 없습니다.")
-        @Size(max = 15, message = "닉네임은 1글자 이상 15글자 이하여야 합니다.")
+        @Size(max = 15, message = "닉네임은 1글자 이상 8글자 이하여야 합니다.")
         String name,
 
         @NotBlank(message = "accessToken은 빈 문자열이나 null을 입력할 수 없습니다.")

--- a/backend/src/main/java/com/happy/friendogly/member/dto/request/UpdateMemberRequest.java
+++ b/backend/src/main/java/com/happy/friendogly/member/dto/request/UpdateMemberRequest.java
@@ -1,0 +1,19 @@
+package com.happy.friendogly.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record UpdateMemberRequest(
+        @NotBlank(message = "name은 빈 문자열이나 null을 입력할 수 없습니다.")
+        @Size(max = 15, message = "닉네임은 1글자 이상 15글자 이하여야 합니다.")
+        String name,
+
+        @NotNull(message = "oldImageUrl은 null을 입력할 수 없습니다.")
+        String oldImageUrl,
+
+        @NotNull(message = "newImageUrl은 null을 입력할 수 없습니다.")
+        String newImageUrl
+) {
+
+}

--- a/backend/src/main/java/com/happy/friendogly/member/dto/request/UpdateMemberRequest.java
+++ b/backend/src/main/java/com/happy/friendogly/member/dto/request/UpdateMemberRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Size;
 
 public record UpdateMemberRequest(
         @NotBlank(message = "name은 빈 문자열이나 null을 입력할 수 없습니다.")
-        @Size(max = 15, message = "닉네임은 1글자 이상 15글자 이하여야 합니다.")
+        @Size(max = 15, message = "닉네임은 1글자 이상 8글자 이하여야 합니다.")
         String name,
 
         @NotNull(message = "oldImageUrl은 null을 입력할 수 없습니다.")

--- a/backend/src/main/java/com/happy/friendogly/member/dto/response/UpdateMemberResponse.java
+++ b/backend/src/main/java/com/happy/friendogly/member/dto/response/UpdateMemberResponse.java
@@ -1,0 +1,20 @@
+package com.happy.friendogly.member.dto.response;
+
+import com.happy.friendogly.member.domain.Member;
+
+public record UpdateMemberResponse(
+        Long id,
+        String name,
+        String tag,
+        String imageUrl
+) {
+
+    public UpdateMemberResponse(Member member) {
+        this(
+                member.getId(),
+                member.getName().getValue(),
+                member.getTag(),
+                member.getImageUrl()
+        );
+    }
+}

--- a/backend/src/main/java/com/happy/friendogly/member/service/MemberCommandService.java
+++ b/backend/src/main/java/com/happy/friendogly/member/service/MemberCommandService.java
@@ -9,7 +9,9 @@ import com.happy.friendogly.auth.service.jwt.TokenPayload;
 import com.happy.friendogly.infra.FileStorageManager;
 import com.happy.friendogly.member.domain.Member;
 import com.happy.friendogly.member.dto.request.SaveMemberRequest;
+import com.happy.friendogly.member.dto.request.UpdateMemberRequest;
 import com.happy.friendogly.member.dto.response.SaveMemberResponse;
+import com.happy.friendogly.member.dto.response.UpdateMemberResponse;
 import com.happy.friendogly.member.repository.MemberRepository;
 import com.happy.friendogly.utils.UuidGenerator;
 import org.springframework.stereotype.Service;
@@ -59,5 +61,21 @@ public class MemberCommandService {
         kakaoMemberRepository.save(new KakaoMember(kakaoMemberId, savedMember.getId(), tokens.refreshToken()));
 
         return new SaveMemberResponse(savedMember, tokens);
+    }
+
+    public UpdateMemberResponse update(Long memberId, UpdateMemberRequest request, MultipartFile image) {
+        Member member = memberRepository.getById(memberId);
+
+        String newImageUrl = request.newImageUrl();
+        if (image != null && !image.isEmpty()) {
+            newImageUrl = fileStorageManager.uploadFile(image);
+        }
+        member.update(request.name(), newImageUrl);
+
+        if (!request.oldImageUrl().equals(request.newImageUrl())) {
+            fileStorageManager.removeFile(request.oldImageUrl());
+        }
+
+        return new UpdateMemberResponse(member);
     }
 }

--- a/backend/src/test/java/com/happy/friendogly/member/service/MemberCommandServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/member/service/MemberCommandServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.happy.friendogly.member.domain.Member;
 import com.happy.friendogly.member.dto.request.UpdateMemberRequest;
-import com.happy.friendogly.member.repository.MemberRepository;
 import com.happy.friendogly.support.ServiceTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,9 +14,6 @@ public class MemberCommandServiceTest extends ServiceTest {
 
     @Autowired
     private MemberCommandService memberCommandService;
-
-    @Autowired
-    private MemberRepository memberRepository;
 
     @DisplayName("회원 이름을 변경하는 경우, 변경된 회원 이름이 조회된다.")
     @Test

--- a/backend/src/test/java/com/happy/friendogly/member/service/MemberCommandServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/member/service/MemberCommandServiceTest.java
@@ -1,0 +1,34 @@
+package com.happy.friendogly.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.happy.friendogly.member.domain.Member;
+import com.happy.friendogly.member.dto.request.UpdateMemberRequest;
+import com.happy.friendogly.member.repository.MemberRepository;
+import com.happy.friendogly.support.ServiceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockMultipartFile;
+
+public class MemberCommandServiceTest extends ServiceTest {
+
+    @Autowired
+    private MemberCommandService memberCommandService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @DisplayName("회원 이름을 변경하는 경우, 변경된 회원 이름이 조회된다.")
+    @Test
+    void update_MemberName() {
+        Member member = memberRepository.save(new Member("member", "tag", "imageUrl"));
+        String newName = "newName";
+        UpdateMemberRequest request = new UpdateMemberRequest(newName, "imageUrl", "imageUrl");
+
+        memberCommandService.update(member.getId(), request, new MockMultipartFile("image", "image".getBytes()));
+        Member findMember = memberRepository.getById(member.getId());
+
+        assertThat(findMember.getName().getValue()).isEqualTo(newName);
+    }
+}


### PR DESCRIPTION
## 이슈
- close #366 
- close #397 

## 개발 사항
- 회원 및 반려견 수정 API 개발
- name 필드 길이 제한 클라이언트와 통일

## 리뷰 요청 사항
**MemberCommandService**
```java
public UpdateMemberResponse update(Long memberId, UpdateMemberRequest request, MultipartFile image) {
    Member member = memberRepository.getById(memberId);

    // 1. 새로운 이미지 파일이 요청으로 들어오는 경우, 해당 이미지를 S3에 업로드
    String newImageUrl = request.newImageUrl();
    if (image != null && !image.isEmpty()) {
        newImageUrl = fileStorageManager.uploadFile(image);
    }
    // 2. request DTO로 들어온 정보를 통해 member 엔티티 update
    member.update(request.name(), newImageUrl);

    // 3. 이미지가 교체되어 기존 이미지 파일을 더이상 사용하지 않는 경우, 해당 이미지를 S3에서 삭제
    if (!request.oldImageUrl().equals(request.newImageUrl())) {
        fileStorageManager.removeFile(request.oldImageUrl());
    }

    return new UpdateMemberResponse(member);
}
```
- 전체적으로 위와 같은 흐름으로 구현했습니다! [request DTO 스펙](https://www.notion.so/API-00e3590c96324047a1fcc79c67cbe307)을 보시면 더 쉽게 이해하실 수 있습니다.
- `fileStorageManager.removeFile()` 은 실제로 구현하진 않았고, `FileStorageManager` 인터페이스에 껍데기만 추가했습니다.
- Member의 image 관련 코드는 리팩토링에 크게 신경쓰지 않았습니다. 추후에 `FileStorageManager` 내부로 로직을 이동시키는 것을 고려해보면 좋을 것 같습니다~
- update의 흐름이 자연스럽게 이해되는지, 이미지 update 방식이 적절한지를 중점적으로 봐주시면 감사하겠습니다!
