### PR TITLE
[BE] feat: 로그아웃 기능 구현

### DIFF
--- a/.github/workflows/backend-cd-workflow.yml
+++ b/.github/workflows/backend-cd-workflow.yml
@@ -73,5 +73,5 @@ jobs:
           cd backend/build/libs
           echo "File creation time(KR-09:00):"
           ls -l --time=ctime friendogly-0.0.1-SNAPSHOT.jar
-          sudo nohup java -jar friendogly-0.0.1-SNAPSHOT.jar --spring.profiles.active=dev --jwt.secret-key=${{ secrets.JWT_SECRET_KEY }} --jwt.access-expiration-time=${{ secrets.JWT_ACCESS_EXPIRATION_TIME }} --jwt.refresh-expiration-time=${{ secrets.JWT_REFRESH_EXPIRATION_TIME }} &
+          sudo nohup java -jar friendogly-0.0.1-SNAPSHOT.jar --spring.profiles.active=dev --jwt.secret-key=${{ secrets.JWT_SECRET_KEY }} --jwt.access-expiration-time=${{ secrets.JWT_ACCESS_EXPIRATION_TIME }} --jwt.refresh-expiration-time=${{ secrets.JWT_REFRESH_EXPIRATION_TIME }} --kakao.admin-key=${{ secrets.KAKAO_ADMIN_KEY }} &
           echo "start backend server"

--- a/backend/src/main/java/com/happy/friendogly/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/happy/friendogly/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.happy.friendogly.auth.controller;
 
+import com.happy.friendogly.auth.Auth;
 import com.happy.friendogly.auth.dto.KakaoLoginRequest;
 import com.happy.friendogly.auth.dto.KakaoLoginResponse;
 import com.happy.friendogly.auth.dto.KakaoRefreshRequest;
@@ -7,6 +8,7 @@ import com.happy.friendogly.auth.dto.TokenResponse;
 import com.happy.friendogly.auth.service.AuthService;
 import com.happy.friendogly.auth.service.KakaoMemberService;
 import com.happy.friendogly.common.ApiResponse;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,6 +32,12 @@ public class AuthController {
     @PostMapping("/kakao/login")
     public ApiResponse<KakaoLoginResponse> login(@RequestBody KakaoLoginRequest request) {
         return ApiResponse.ofSuccess(kakaoMemberService.login(request));
+    }
+
+    @PostMapping("/kakao/logout")
+    public ResponseEntity<Void> logout(@Auth Long memberId) {
+        kakaoMemberService.logout(memberId);
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/kakao/refresh")

--- a/backend/src/main/java/com/happy/friendogly/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/happy/friendogly/auth/controller/AuthController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/auth")
 public class AuthController {
 
+    // TODO: KakaoMemberService와 AuthService 통합
     private final KakaoMemberService kakaoMemberService;
     private final AuthService authService;
 

--- a/backend/src/main/java/com/happy/friendogly/auth/dto/KakaoLogoutRequest.java
+++ b/backend/src/main/java/com/happy/friendogly/auth/dto/KakaoLogoutRequest.java
@@ -1,0 +1,8 @@
+package com.happy.friendogly.auth.dto;
+
+public record KakaoLogoutRequest(String target_id_type, Long target_id) {
+
+    public KakaoLogoutRequest(Long target_id) {
+        this("user_id", target_id);
+    }
+}

--- a/backend/src/main/java/com/happy/friendogly/auth/dto/KakaoLogoutRequest.java
+++ b/backend/src/main/java/com/happy/friendogly/auth/dto/KakaoLogoutRequest.java
@@ -1,8 +1,0 @@
-package com.happy.friendogly.auth.dto;
-
-public record KakaoLogoutRequest(String target_id_type, Long target_id) {
-
-    public KakaoLogoutRequest(Long target_id) {
-        this("user_id", target_id);
-    }
-}

--- a/backend/src/main/java/com/happy/friendogly/auth/repository/KakaoMemberRepository.java
+++ b/backend/src/main/java/com/happy/friendogly/auth/repository/KakaoMemberRepository.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpStatus;
 
 public interface KakaoMemberRepository extends JpaRepository<KakaoMember, Long> {
 
-    Optional<KakaoMember> findByKakaoMemberId(String KakaoMemberId);
+    Optional<KakaoMember> findByMemberId(Long memberId);
+
+    Optional<KakaoMember> findByKakaoMemberId(String kakaoMemberId);
 
     Optional<KakaoMember> findByRefreshToken(String refreshToken);
 
@@ -16,4 +18,9 @@ public interface KakaoMemberRepository extends JpaRepository<KakaoMember, Long> 
         return findByRefreshToken(refreshToken)
                 .orElseThrow(() -> new FriendoglyException("유효하지 않은 리프레시 토큰입니다.", HttpStatus.UNAUTHORIZED));
     }
+
+    default KakaoMember getByMemberId(Long memberId) {
+        return findByMemberId(memberId)
+                .orElseThrow(() -> new FriendoglyException("존재하지 않는 회원입니다.", HttpStatus.UNAUTHORIZED));
+    };
 }

--- a/backend/src/main/java/com/happy/friendogly/auth/service/KakaoMemberService.java
+++ b/backend/src/main/java/com/happy/friendogly/auth/service/KakaoMemberService.java
@@ -46,7 +46,7 @@ public class KakaoMemberService {
 
     public void logout(Long memberId) {
         KakaoMember kakaoMember = kakaoMemberRepository.getByMemberId(memberId);
-        kakaoOauthClient.logout(kakaoMember.getKakaoMemberId());
+//        kakaoOauthClient.logout(kakaoMember.getKakaoMemberId());
         kakaoMember.updateRefreshToken(null);
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/auth/service/KakaoMemberService.java
+++ b/backend/src/main/java/com/happy/friendogly/auth/service/KakaoMemberService.java
@@ -3,6 +3,7 @@ package com.happy.friendogly.auth.service;
 import com.happy.friendogly.auth.domain.KakaoMember;
 import com.happy.friendogly.auth.dto.KakaoLoginRequest;
 import com.happy.friendogly.auth.dto.KakaoLoginResponse;
+import com.happy.friendogly.auth.dto.KakaoLogoutRequest;
 import com.happy.friendogly.auth.dto.TokenResponse;
 import com.happy.friendogly.auth.repository.KakaoMemberRepository;
 import com.happy.friendogly.auth.service.jwt.JwtProvider;
@@ -42,5 +43,13 @@ public class KakaoMemberService {
             return KakaoLoginResponse.ofRegistered(tokens);
         }
         return KakaoLoginResponse.ofNotRegistered();
+    }
+
+    public void logout(Long memberId) {
+        KakaoMember kakaoMember = kakaoMemberRepository.getByMemberId(memberId);
+        KakaoLogoutRequest kakaoLogoutRequest = new KakaoLogoutRequest(Long.parseLong(kakaoMember.getKakaoMemberId()));
+
+        kakaoOauthClient.logout(kakaoLogoutRequest);
+        kakaoMember.updateRefreshToken(null);
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/auth/service/KakaoMemberService.java
+++ b/backend/src/main/java/com/happy/friendogly/auth/service/KakaoMemberService.java
@@ -3,7 +3,6 @@ package com.happy.friendogly.auth.service;
 import com.happy.friendogly.auth.domain.KakaoMember;
 import com.happy.friendogly.auth.dto.KakaoLoginRequest;
 import com.happy.friendogly.auth.dto.KakaoLoginResponse;
-import com.happy.friendogly.auth.dto.KakaoLogoutRequest;
 import com.happy.friendogly.auth.dto.TokenResponse;
 import com.happy.friendogly.auth.repository.KakaoMemberRepository;
 import com.happy.friendogly.auth.service.jwt.JwtProvider;
@@ -47,9 +46,7 @@ public class KakaoMemberService {
 
     public void logout(Long memberId) {
         KakaoMember kakaoMember = kakaoMemberRepository.getByMemberId(memberId);
-        KakaoLogoutRequest kakaoLogoutRequest = new KakaoLogoutRequest(Long.parseLong(kakaoMember.getKakaoMemberId()));
-
-        kakaoOauthClient.logout(kakaoLogoutRequest);
+        kakaoOauthClient.logout(kakaoMember.getKakaoMemberId());
         kakaoMember.updateRefreshToken(null);
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/auth/service/KakaoOauthClient.java
+++ b/backend/src/main/java/com/happy/friendogly/auth/service/KakaoOauthClient.java
@@ -1,10 +1,12 @@
 package com.happy.friendogly.auth.service;
 
-import com.happy.friendogly.auth.dto.KakaoLogoutRequest;
 import com.happy.friendogly.auth.dto.KakaoUserResponse;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 
 @Component
@@ -13,14 +15,19 @@ public class KakaoOauthClient {
     private static final String KAKAO_REQUEST_USER_INFO_URI = "https://kapi.kakao.com/v2/user/me";
     private static final String KAKAO_REQUEST_LOGOUT_URI = "https://kapi.kakao.com/v1/user/logout";
     private static final String BEARER = "Bearer ";
-    private static final String KAKAO_AK = "KakaoAk ";
+    private static final String KAKAO_AK = "KakaoAK ";
 
     private final RestClient restClient;
     private final AuthErrorHandler errorHandler;
+    private final String adminKey;
 
-    public KakaoOauthClient(AuthErrorHandler errorHandler) {
+    public KakaoOauthClient(
+            AuthErrorHandler errorHandler,
+            @Value("${kakao.admin-key}") String adminKey
+    ) {
         this.restClient = RestClient.create();
         this.errorHandler = errorHandler;
+        this.adminKey = adminKey;
     }
 
     // TODO: 타임아웃 설정
@@ -35,12 +42,16 @@ public class KakaoOauthClient {
     }
 
     // TODO: 타임아웃 설정
-    public void logout(KakaoLogoutRequest request) {
+    public void logout(String targetKakaoMemberId) {
+        MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
+        requestBody.add("target_id_type", "user_id");
+        requestBody.add("target_id", targetKakaoMemberId);
+
         restClient.post()
                 .uri(KAKAO_REQUEST_LOGOUT_URI)
-                .header(HttpHeaders.AUTHORIZATION, KAKAO_AK + "admin key!!")    // TODO: admin key 주입
+                .header(HttpHeaders.AUTHORIZATION, KAKAO_AK + adminKey)
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .body(request)
+                .body(requestBody)
                 .retrieve()
                 .onStatus(errorHandler);
     }

--- a/backend/src/main/java/com/happy/friendogly/auth/service/KakaoOauthClient.java
+++ b/backend/src/main/java/com/happy/friendogly/auth/service/KakaoOauthClient.java
@@ -1,5 +1,6 @@
 package com.happy.friendogly.auth.service;
 
+import com.happy.friendogly.auth.dto.KakaoLogoutRequest;
 import com.happy.friendogly.auth.dto.KakaoUserResponse;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -10,7 +11,9 @@ import org.springframework.web.client.RestClient;
 public class KakaoOauthClient {
 
     private static final String KAKAO_REQUEST_USER_INFO_URI = "https://kapi.kakao.com/v2/user/me";
+    private static final String KAKAO_REQUEST_LOGOUT_URI = "https://kapi.kakao.com/v1/user/logout";
     private static final String BEARER = "Bearer ";
+    private static final String KAKAO_AK = "KakaoAk ";
 
     private final RestClient restClient;
     private final AuthErrorHandler errorHandler;
@@ -29,5 +32,16 @@ public class KakaoOauthClient {
                 .retrieve()
                 .onStatus(errorHandler)
                 .body(KakaoUserResponse.class);
+    }
+
+    // TODO: 타임아웃 설정
+    public void logout(KakaoLogoutRequest request) {
+        restClient.post()
+                .uri(KAKAO_REQUEST_LOGOUT_URI)
+                .header(HttpHeaders.AUTHORIZATION, KAKAO_AK + "admin key!!")    // TODO: admin key 주입
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(request)
+                .retrieve()
+                .onStatus(errorHandler);
     }
 }

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -9,6 +9,9 @@ jwt:
   access-expiration-time: ${JWT_ACCESS_EXPIRATION_TIME}
   refresh-expiration-time: ${JWT_REFRESH_EXPIRATION_TIME}
 
+kakao:
+  admin-key: ${KAKAO_ADMIN_KEY}
+
 management:
   endpoint:
     metrics:

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,12 +1,12 @@
 INSERT INTO member(name, tag, image_url)
 VALUES ('도도', '4e52d416', 'https://avatars.githubusercontent.com/u/79188587?v=4'),
        ('땡이', 'a582a275', 'https://avatars.githubusercontent.com/u/110461155?v=4'),
-       ('트레', '68fc8014', null),
+       ('트레', '68fc8014', ''),
        ('위브', '3dde7373', 'https://avatars.githubusercontent.com/u/28584160?v=4'),
-       ('벼리', '525ec19f', null),
-       ('누누', '5f0f8307', null),
+       ('벼리', '525ec19f', ''),
+       ('누누', '5f0f8307', ''),
        ('채드', '114d8979', 'https://avatars.githubusercontent.com/u/102402485?v=4'),
-       ('에디', 'c065a053', null);
+       ('에디', 'c065a053', '');
 
 INSERT INTO footprint(member_id, latitude, longitude, walk_status, created_at, is_deleted)
 VALUES (1, 37.5173316, 127.1011661, 'BEFORE', TIMESTAMPADD(MINUTE, -10, NOW()), FALSE),

--- a/backend/src/test/resources/application-local.yml
+++ b/backend/src/test/resources/application-local.yml
@@ -5,3 +5,6 @@ jwt:
   secret-key: 행복하세요~행복하세요~행복하세요~행복하세요~행복하세요~행복하세요~행복하세요~행복하세요~
   access-expiration-time: 5_184_000_000 # 24시간 (ms)
   refresh-expiration-time: 36_288_000_000 # 7일 (ms)
+
+kakao:
+  admin-key: sdfsdfsdfdsfsdfsdf


### PR DESCRIPTION
## 이슈
- close #367 

## 개발 사항
- 로그아웃 API 구현

# 전달 사항
- 로그아웃 시 DB에 저장된 refresh token을 null로 업데이트 하도록 구현했습니다.
- 카카오 로그아웃도 구현 후 로컬에서 테스트도 완료했으나, 카카오 로그아웃이 정말 필요한가 의논이 필요한 것 같아 호출하는 부분을 주석처리 해두었습니다.
