### PR TITLE
[BE] feat: 채팅을 보낼 때 FCM으로 데이터를 같이 전송

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/notification/repository/DeviceTokenRepository.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/repository/DeviceTokenRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> {
 
@@ -13,9 +14,8 @@ public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> 
     @Query("""
             SELECT dt.deviceToken
             FROM DeviceToken dt
-            WHERE dt.member.id IN (SELECT chatRoomMember.member.id
-            FROM ChatRoomMember chatRoomMember
-            WHERE chatRoomMember.chatRoom.id = :chatRoomId)
+            INNER JOIN ChatRoomMember chatRoomMember ON dt.member.id = chatRoomMember.member.id
+            WHERE chatRoomMember.chatRoom.id = :chatRoomId
             """)
-    List<String> findAllByChatRoomId(Long chatRoomId);
+    List<String> findAllByChatRoomId(@Param("chatRoomId") Long chatRoomId);
 }

--- a/backend/src/main/java/com/happy/friendogly/notification/repository/DeviceTokenRepository.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/repository/DeviceTokenRepository.java
@@ -1,10 +1,21 @@
 package com.happy.friendogly.notification.repository;
 
 import com.happy.friendogly.notification.domain.DeviceToken;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> {
 
     Optional<DeviceToken> findByMemberId(Long memberId);
+
+    @Query("""
+            SELECT dt.deviceToken
+            FROM DeviceToken dt
+            WHERE dt.member.id IN (SELECT chatRoomMember.member.id
+            FROM ChatRoomMember chatRoomMember
+            WHERE chatRoomMember.chatRoom.id = :chatRoomId)
+            """)
+    List<String> findAllByChatRoomId(Long chatRoomId);
 }

--- a/backend/src/main/java/com/happy/friendogly/notification/service/FakeNotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/FakeNotificationService.java
@@ -1,6 +1,9 @@
 package com.happy.friendogly.notification.service;
 
+import com.happy.friendogly.chat.dto.response.ChatMessageResponse;
+import com.happy.friendogly.notification.domain.NotificationType;
 import java.util.List;
+import java.util.Map;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
@@ -15,6 +18,20 @@ public class FakeNotificationService implements NotificationService {
 
     @Override
     public void sendNotification(String title, String content, List<String> receiverTokens) {
+
+    }
+
+    @Override
+    public void sendNotificationWithType(
+            NotificationType notificationType,
+            Map<String, String> data,
+            List<String> receiverTokens
+    ) {
+
+    }
+
+    @Override
+    public void sendChat(Long chatRoomId, ChatMessageResponse response) {
 
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/notification/service/FakeNotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/FakeNotificationService.java
@@ -1,9 +1,7 @@
 package com.happy.friendogly.notification.service;
 
 import com.happy.friendogly.chat.dto.response.ChatMessageResponse;
-import com.happy.friendogly.notification.domain.NotificationType;
 import java.util.List;
-import java.util.Map;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
@@ -18,16 +16,6 @@ public class FakeNotificationService implements NotificationService {
 
     @Override
     public void sendNotification(String title, String content, List<String> receiverTokens) {
-
-    }
-
-    @Override
-    public void sendNotificationWithType(
-            NotificationType notificationType,
-            String title,
-            Map<String, String> data,
-            List<String> receiverTokens
-    ) {
 
     }
 

--- a/backend/src/main/java/com/happy/friendogly/notification/service/FakeNotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/FakeNotificationService.java
@@ -24,6 +24,7 @@ public class FakeNotificationService implements NotificationService {
     @Override
     public void sendNotificationWithType(
             NotificationType notificationType,
+            String title,
             Map<String, String> data,
             List<String> receiverTokens
     ) {

--- a/backend/src/main/java/com/happy/friendogly/notification/service/FcmNotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/FcmNotificationService.java
@@ -1,8 +1,5 @@
 package com.happy.friendogly.notification.service;
 
-import static com.happy.friendogly.notification.domain.NotificationType.CHAT;
-import static com.happy.friendogly.notification.domain.NotificationType.FOOTPRINT;
-
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
@@ -10,7 +7,6 @@ import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.MulticastMessage;
 import com.happy.friendogly.chat.dto.response.ChatMessageResponse;
 import com.happy.friendogly.exception.FriendoglyException;
-import com.happy.friendogly.member.repository.MemberRepository;
 import com.happy.friendogly.notification.domain.NotificationType;
 import com.happy.friendogly.notification.repository.DeviceTokenRepository;
 import java.util.List;
@@ -41,7 +37,7 @@ public class FcmNotificationService implements NotificationService {
     @Override
     public void sendNotification(String title, String content, String receiverToken) {
         Message message = Message.builder()
-                .putData("type", FOOTPRINT.toString())
+                .putData("type", NotificationType.FOOTPRINT.toString())
                 .putData("title", title)
                 .putData("body", content)
                 .setToken(receiverToken)
@@ -56,7 +52,7 @@ public class FcmNotificationService implements NotificationService {
     @Override
     public void sendNotification(String title, String content, List<String> receiverTokens) {
         MulticastMessage message = MulticastMessage.builder()
-                .putData("type", FOOTPRINT.toString())
+                .putData("type", NotificationType.FOOTPRINT.toString())
                 .putData("title", title)
                 .putData("body", content)
                 .addAllTokens(receiverTokens)
@@ -101,6 +97,6 @@ public class FcmNotificationService implements NotificationService {
                 "profilePictureUrl", response.profilePictureUrl()
         );
 
-        sendNotificationWithType(CHAT, data, receiverTokens);
+        sendNotificationWithType(NotificationType.CHAT, data, receiverTokens);
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/notification/service/FcmNotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/FcmNotificationService.java
@@ -1,31 +1,47 @@
 package com.happy.friendogly.notification.service;
 
+import static com.happy.friendogly.notification.domain.NotificationType.CHAT;
+import static com.happy.friendogly.notification.domain.NotificationType.FOOTPRINT;
+
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.MulticastMessage;
+import com.happy.friendogly.chat.dto.response.ChatMessageResponse;
 import com.happy.friendogly.exception.FriendoglyException;
+import com.happy.friendogly.member.repository.MemberRepository;
 import com.happy.friendogly.notification.domain.NotificationType;
+import com.happy.friendogly.notification.repository.DeviceTokenRepository;
 import java.util.List;
+import java.util.Map;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 @Profile("!local")
 public class FcmNotificationService implements NotificationService {
 
-    private final FirebaseApp firebaseApp;
+    private static final String DEFAULT_TITLE = "반갑개";
 
-    public FcmNotificationService(FirebaseApp firebaseApp) {
+    private final FirebaseApp firebaseApp;
+    private final DeviceTokenRepository deviceTokenRepository;
+
+    public FcmNotificationService(
+            FirebaseApp firebaseApp,
+            DeviceTokenRepository deviceTokenRepository
+    ) {
         this.firebaseApp = firebaseApp;
+        this.deviceTokenRepository = deviceTokenRepository;
     }
 
     @Override
     public void sendNotification(String title, String content, String receiverToken) {
         Message message = Message.builder()
-                .putData("type", NotificationType.FOOTPRINT.toString())
+                .putData("type", FOOTPRINT.toString())
                 .putData("title", title)
                 .putData("body", content)
                 .setToken(receiverToken)
@@ -40,7 +56,7 @@ public class FcmNotificationService implements NotificationService {
     @Override
     public void sendNotification(String title, String content, List<String> receiverTokens) {
         MulticastMessage message = MulticastMessage.builder()
-                .putData("type", NotificationType.FOOTPRINT.toString())
+                .putData("type", FOOTPRINT.toString())
                 .putData("title", title)
                 .putData("body", content)
                 .addAllTokens(receiverTokens)
@@ -50,5 +66,41 @@ public class FcmNotificationService implements NotificationService {
         } catch (FirebaseMessagingException e) {
             throw new FriendoglyException("FCM을 통해 사용자에게 알림을 보내는 과정에서 에러가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
         }
+    }
+
+    @Override
+    public void sendNotificationWithType(
+            NotificationType notificationType,
+            Map<String, String> data,
+            List<String> receiverTokens
+    ) {
+        MulticastMessage message = MulticastMessage.builder()
+                .putAllData(data)
+                .putData("type", notificationType.toString())
+                .putData("title", DEFAULT_TITLE)
+                .addAllTokens(receiverTokens)
+                .build();
+
+        try {
+            FirebaseMessaging.getInstance(this.firebaseApp).sendEachForMulticast(message);
+        } catch (FirebaseMessagingException e) {
+            throw new FriendoglyException("FCM을 통해 사용자에게 알림을 보내는 과정에서 에러가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Override
+    public void sendChat(Long chatRoomId, ChatMessageResponse response) {
+        List<String> receiverTokens = deviceTokenRepository.findAllByChatRoomId(chatRoomId);
+
+        Map<String, String> data = Map.of(
+                "messageType", response.messageType().toString(),
+                "senderMemberId", response.senderMemberId().toString(),
+                "senderName", response.senderName(),
+                "content", response.content(),
+                "createdAt", response.createdAt().toString(),
+                "profilePictureUrl", response.profilePictureUrl()
+        );
+
+        sendNotificationWithType(CHAT, data, receiverTokens);
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/notification/service/FcmNotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/FcmNotificationService.java
@@ -21,8 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Profile("!local")
 public class FcmNotificationService implements NotificationService {
 
-    private static final String DEFAULT_TITLE = "반갑개";
-
     private final FirebaseApp firebaseApp;
     private final DeviceTokenRepository deviceTokenRepository;
 
@@ -67,13 +65,14 @@ public class FcmNotificationService implements NotificationService {
     @Override
     public void sendNotificationWithType(
             NotificationType notificationType,
+            String title,
             Map<String, String> data,
             List<String> receiverTokens
     ) {
         MulticastMessage message = MulticastMessage.builder()
                 .putAllData(data)
                 .putData("type", notificationType.toString())
-                .putData("title", DEFAULT_TITLE)
+                .putData("title", title)
                 .addAllTokens(receiverTokens)
                 .build();
 
@@ -89,6 +88,7 @@ public class FcmNotificationService implements NotificationService {
         List<String> receiverTokens = deviceTokenRepository.findAllByChatRoomId(chatRoomId);
 
         Map<String, String> data = Map.of(
+                "chatRoomId", chatRoomId.toString(),
                 "messageType", response.messageType().toString(),
                 "senderMemberId", response.senderMemberId().toString(),
                 "senderName", response.senderName(),
@@ -97,6 +97,6 @@ public class FcmNotificationService implements NotificationService {
                 "profilePictureUrl", response.profilePictureUrl()
         );
 
-        sendNotificationWithType(NotificationType.CHAT, data, receiverTokens);
+        sendNotificationWithType(NotificationType.CHAT, "채팅", data, receiverTokens);
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/notification/service/FcmNotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/FcmNotificationService.java
@@ -63,7 +63,23 @@ public class FcmNotificationService implements NotificationService {
     }
 
     @Override
-    public void sendNotificationWithType(
+    public void sendChat(Long chatRoomId, ChatMessageResponse response) {
+        List<String> receiverTokens = deviceTokenRepository.findAllByChatRoomId(chatRoomId);
+
+        Map<String, String> data = Map.of(
+                "chatRoomId", chatRoomId.toString(),
+                "messageType", response.messageType().toString(),
+                "senderMemberId", response.senderMemberId().toString(),
+                "senderName", response.senderName(),
+                "content", response.content(),
+                "createdAt", response.createdAt().toString(),
+                "profilePictureUrl", response.profilePictureUrl()
+        );
+
+        sendNotificationWithType(NotificationType.CHAT, "채팅", data, receiverTokens);
+    }
+
+    private void sendNotificationWithType(
             NotificationType notificationType,
             String title,
             Map<String, String> data,
@@ -81,22 +97,5 @@ public class FcmNotificationService implements NotificationService {
         } catch (FirebaseMessagingException e) {
             throw new FriendoglyException("FCM을 통해 사용자에게 알림을 보내는 과정에서 에러가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
         }
-    }
-
-    @Override
-    public void sendChat(Long chatRoomId, ChatMessageResponse response) {
-        List<String> receiverTokens = deviceTokenRepository.findAllByChatRoomId(chatRoomId);
-
-        Map<String, String> data = Map.of(
-                "chatRoomId", chatRoomId.toString(),
-                "messageType", response.messageType().toString(),
-                "senderMemberId", response.senderMemberId().toString(),
-                "senderName", response.senderName(),
-                "content", response.content(),
-                "createdAt", response.createdAt().toString(),
-                "profilePictureUrl", response.profilePictureUrl()
-        );
-
-        sendNotificationWithType(NotificationType.CHAT, "채팅", data, receiverTokens);
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/NotificationService.java
@@ -1,22 +1,13 @@
 package com.happy.friendogly.notification.service;
 
 import com.happy.friendogly.chat.dto.response.ChatMessageResponse;
-import com.happy.friendogly.notification.domain.NotificationType;
 import java.util.List;
-import java.util.Map;
 
 public interface NotificationService {
 
     void sendNotification(String title, String content, String receiverToken);
 
     void sendNotification(String title, String content, List<String> receiverTokens);
-
-    void sendNotificationWithType(
-            NotificationType notificationType,
-            String title,
-            Map<String, String> data,
-            List<String> receiverTokens
-    );
 
     void sendChat(Long chatRoomId, ChatMessageResponse response);
 }

--- a/backend/src/main/java/com/happy/friendogly/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/NotificationService.java
@@ -1,10 +1,21 @@
 package com.happy.friendogly.notification.service;
 
+import com.happy.friendogly.chat.dto.response.ChatMessageResponse;
+import com.happy.friendogly.notification.domain.NotificationType;
 import java.util.List;
+import java.util.Map;
 
 public interface NotificationService {
 
     void sendNotification(String title, String content, String receiverToken);
 
     void sendNotification(String title, String content, List<String> receiverTokens);
+
+    void sendNotificationWithType(
+            NotificationType notificationType,
+            Map<String, String> data,
+            List<String> receiverTokens
+    );
+
+    void sendChat(Long chatRoomId, ChatMessageResponse response);
 }

--- a/backend/src/main/java/com/happy/friendogly/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/NotificationService.java
@@ -13,6 +13,7 @@ public interface NotificationService {
 
     void sendNotificationWithType(
             NotificationType notificationType,
+            String title,
             Map<String, String> data,
             List<String> receiverTokens
     );

--- a/backend/src/test/java/com/happy/friendogly/notification/repository/DeviceTokenRepositoryTest.java
+++ b/backend/src/test/java/com/happy/friendogly/notification/repository/DeviceTokenRepositoryTest.java
@@ -1,0 +1,46 @@
+package com.happy.friendogly.notification.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.happy.friendogly.chat.domain.ChatRoom;
+import com.happy.friendogly.chat.repository.ChatRoomRepository;
+import com.happy.friendogly.member.domain.Member;
+import com.happy.friendogly.member.repository.MemberRepository;
+import com.happy.friendogly.notification.domain.DeviceToken;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class DeviceTokenRepositoryTest {
+
+    @Autowired
+    private DeviceTokenRepository deviceTokenRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    @DisplayName("채팅방 ID로부터 device token을 가져올 수 있다.")
+    @Test
+    void findAllByChatRoomId() {
+        // given
+        Member member1 = memberRepository.save(new Member("name1", "tag1", "https://test.com/test.jpg"));
+        Member member2 = memberRepository.save(new Member("name2", "tag2", "https://test.com/test.jpg"));
+        Member member3 = memberRepository.save(new Member("name3", "tag3", "https://test.com/test.jpg"));
+
+        deviceTokenRepository.save(new DeviceToken(member1, "token1"));
+        deviceTokenRepository.save(new DeviceToken(member2, "token2"));
+        deviceTokenRepository.save(new DeviceToken(member3, "token3"));
+
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.createGroup(5));
+        chatRoom.addMember(member1);
+        chatRoom.addMember(member2);
+
+        // when - then
+        assertThat(deviceTokenRepository.findAllByChatRoomId(chatRoom.getId())).containsExactly("token1", "token2");
+    }
+}


### PR DESCRIPTION
## 이슈
- close #446 

## 개발 사항
- 채팅 메시지를 전송하면 FCM으로도 같이 전송한다.

## 리뷰 요청 사항 (없으면 삭제해 주세요)
- 큰 변동 사항은 없고 subquery 쓰는 JPQL 부분만 봐주시면 좋을 것 같아요!

## 전달 사항 (없으면 삭제해 주세요)
- 안드로이드랑 연결해서 작동하는 것 확인되면 추가로 리팩토링 진행할 수도 있어요.
