### PR TITLE
[BE] hotfix: 주변 디바이스 토큰 조회시, 500에러 발생하는 버그 수정

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/footprint/service/FootprintCommandService.java
+++ b/backend/src/main/java/com/happy/friendogly/footprint/service/FootprintCommandService.java
@@ -11,12 +11,14 @@ import com.happy.friendogly.footprint.dto.response.UpdateWalkStatusResponse;
 import com.happy.friendogly.footprint.repository.FootprintRepository;
 import com.happy.friendogly.member.domain.Member;
 import com.happy.friendogly.member.repository.MemberRepository;
+import com.happy.friendogly.notification.domain.DeviceToken;
 import com.happy.friendogly.notification.repository.DeviceTokenRepository;
 import com.happy.friendogly.notification.service.NotificationService;
 import com.happy.friendogly.pet.domain.Pet;
 import com.happy.friendogly.pet.repository.PetRepository;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -134,8 +136,9 @@ public class FootprintCommandService {
         return footprints.stream()
                 .filter(otherFootprint -> otherFootprint.isInsideBoundary(standardFootprint.getLocation())
                         && otherFootprint.getMember() != member)
-                .map(otherFootprint -> otherFootprint.getMember().getId())
-                .map(otherMemberId -> deviceTokenRepository.findByMemberId(otherMemberId).get().getDeviceToken())
+                .map(otherFootprint -> deviceTokenRepository.findByMemberId(otherFootprint.getMember().getId()))
+                .flatMap(Optional::stream)
+                .map(DeviceToken::getDeviceToken)
                 .toList();
     }
 }


### PR DESCRIPTION
## 이슈
- #455 

## 개발 사항
- 발자국 저장시 알림보내기 위한 디바이스 토큰 조회하는 부분에서 500에러 발생
- 모두 다바이스 토큰 등록하는 기능이 있는 최신버전의 어플 사용하면 괜찮은데, 예전 버전 사용하는 사람이 있어 Optional의 value가 없는 경우가 발생
- 이에따라 코드를 어떤 경우에도 괜찮도록 변경
- **Optional::Stream은 value가 존재하는 것만 stream에 포함하도록 하는 함수**