### PR TITLE
[BE] feat: 채팅방에서 모임 상세 조회할 때 `myMemberId` 필드도 같이 응답

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/chat/dto/response/FindClubDetailsResponse.java
+++ b/backend/src/main/java/com/happy/friendogly/chat/dto/response/FindClubDetailsResponse.java
@@ -7,11 +7,12 @@ import java.util.Set;
 
 public record FindClubDetailsResponse(
         Long clubId,
+        Long myMemberId,
         Set<SizeType> allowedSizeTypes,
         Set<Gender> allowedGenders
 ) {
 
-    public FindClubDetailsResponse(Club club) {
-        this(club.getId(), club.getAllowedSizes(), club.getAllowedGenders());
+    public FindClubDetailsResponse(Long myMemberId, Club club) {
+        this(club.getId(), myMemberId, club.getAllowedSizes(), club.getAllowedGenders());
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/chat/service/ChatRoomQueryService.java
+++ b/backend/src/main/java/com/happy/friendogly/chat/service/ChatRoomQueryService.java
@@ -68,7 +68,7 @@ public class ChatRoomQueryService {
         ChatRoom chatRoom = chatRoomRepository.getById(chatRoomId);
         validateParticipation(chatRoom, member);
         Club club = clubRepository.getByChatRoomId(chatRoomId);
-        return new FindClubDetailsResponse(club);
+        return new FindClubDetailsResponse(memberId, club);
     }
 
     private void validateParticipation(ChatRoom chatRoom, Member member) {

--- a/backend/src/test/java/com/happy/friendogly/docs/ChatRoomApiDocsTest.java
+++ b/backend/src/test/java/com/happy/friendogly/docs/ChatRoomApiDocsTest.java
@@ -169,7 +169,7 @@ public class ChatRoomApiDocsTest extends RestDocsTest {
     @Test
     void findClubDetails() throws Exception {
         FindClubDetailsResponse response
-                = new FindClubDetailsResponse(5L, Set.of(SMALL, MEDIUM), Set.of(FEMALE_NEUTERED, MALE));
+                = new FindClubDetailsResponse(5L, 2L, Set.of(SMALL, MEDIUM), Set.of(FEMALE_NEUTERED, MALE));
 
         given(chatRoomQueryService.findClubDetails(any(), any()))
                 .willReturn(response);
@@ -193,6 +193,7 @@ public class ChatRoomApiDocsTest extends RestDocsTest {
                                 .responseFields(
                                         fieldWithPath("isSuccess").description("응답 성공 여부"),
                                         fieldWithPath("data.clubId").description("채팅방 ID"),
+                                        fieldWithPath("data.myMemberId").description("채팅방 ID"),
                                         fieldWithPath("data.allowedSizeTypes")
                                                 .description("채팅방 현재 인원 (SMALL, MEDIUM, LARGE)"),
                                         fieldWithPath("data.allowedGenders")


### PR DESCRIPTION
## 이슈
- close #497 

## 개발 사항
- 채팅방에서 모임 상세 조회할 때 `myMemberId` 필드도 같이 응답
