### PR TITLE
[BE] feat: 내 산책 상태 변경 시 나에게 알림 기능 구현

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/footprint/service/FootprintCommandService.java
+++ b/backend/src/main/java/com/happy/friendogly/footprint/service/FootprintCommandService.java
@@ -15,7 +15,6 @@ import com.happy.friendogly.footprint.dto.response.UpdateWalkStatusManualRespons
 import com.happy.friendogly.footprint.repository.FootprintRepository;
 import com.happy.friendogly.member.domain.Member;
 import com.happy.friendogly.member.repository.MemberRepository;
-import com.happy.friendogly.notification.repository.DeviceTokenRepository;
 import com.happy.friendogly.notification.service.FootprintNotificationService;
 import com.happy.friendogly.pet.domain.Pet;
 import com.happy.friendogly.pet.repository.PetRepository;
@@ -40,7 +39,7 @@ public class FootprintCommandService {
             FootprintRepository footprintRepository,
             MemberRepository memberRepository,
             PetRepository petRepository,
-            FootprintNotificationService footprintNotificationService,
+            FootprintNotificationService footprintNotificationService
     ) {
         this.footprintRepository = footprintRepository;
         this.memberRepository = memberRepository;

--- a/backend/src/main/java/com/happy/friendogly/footprint/service/FootprintCommandService.java
+++ b/backend/src/main/java/com/happy/friendogly/footprint/service/FootprintCommandService.java
@@ -41,7 +41,6 @@ public class FootprintCommandService {
             MemberRepository memberRepository,
             PetRepository petRepository,
             FootprintNotificationService footprintNotificationService,
-            DeviceTokenRepository deviceTokenRepository
     ) {
         this.footprintRepository = footprintRepository;
         this.memberRepository = memberRepository;

--- a/backend/src/main/java/com/happy/friendogly/notification/repository/DeviceTokenRepository.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/repository/DeviceTokenRepository.java
@@ -1,5 +1,6 @@
 package com.happy.friendogly.notification.repository;
 
+import com.happy.friendogly.exception.FriendoglyException;
 import com.happy.friendogly.notification.domain.DeviceToken;
 import java.util.List;
 import java.util.Optional;
@@ -10,6 +11,10 @@ import org.springframework.data.repository.query.Param;
 public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> {
 
     Optional<DeviceToken> findByMemberId(Long memberId);
+
+    default DeviceToken getByMemberId(Long memberId) {
+        return findByMemberId(memberId).orElseThrow(() -> new FriendoglyException("해당 멤버의 디바이스 토큰을 찾지 못했습니다."));
+    }
 
     @Query("""
             SELECT dt.deviceToken

--- a/backend/src/main/java/com/happy/friendogly/notification/service/FootprintNotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/FootprintNotificationService.java
@@ -1,0 +1,71 @@
+package com.happy.friendogly.notification.service;
+
+import com.happy.friendogly.footprint.domain.Footprint;
+import com.happy.friendogly.footprint.domain.WalkStatus;
+import com.happy.friendogly.notification.domain.DeviceToken;
+import com.happy.friendogly.notification.repository.DeviceTokenRepository;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FootprintNotificationService {
+
+    private final String DEFAULT_TITLE = "반갑개";
+    private final NotificationService notificationService;
+    private final DeviceTokenRepository deviceTokenRepository;
+
+    public FootprintNotificationService(
+            NotificationService notificationService,
+            DeviceTokenRepository deviceTokenRepository
+    ) {
+        this.notificationService = notificationService;
+        this.deviceTokenRepository = deviceTokenRepository;
+    }
+
+    public void sendWalkNotificationToMe(Long memberId, WalkStatus currentWalkStatus) {
+        String content = null;
+        if (currentWalkStatus.isOngoing()) {
+            content = "산책을 시작했습니다!";
+        }
+        if (currentWalkStatus.isAfter()) {
+            content = "산책을 종료했습니다!";
+        }
+        if (currentWalkStatus.isBefore()) {
+            return;
+        }
+
+        notificationService.sendFootprintNotification(
+                DEFAULT_TITLE,
+                content,
+                deviceTokenRepository.getByMemberId(memberId).getDeviceToken()
+        );
+    }
+
+    public void sendWalkComingNotification(String comingMemberName, List<Footprint> nearFootprints) {
+        List<String> nearDeviceTokens = toDeviceToken(nearFootprints);
+
+        notificationService.sendFootprintNotification(
+                DEFAULT_TITLE,
+                "내 산책 장소에 " + comingMemberName + "님도 산책온대요!",
+                nearDeviceTokens
+        );
+    }
+
+    public void sendWalkStartNotificationToNear(String startMemberName, List<Footprint> nearFootprints) {
+        List<String> nearDeviceTokens = toDeviceToken(nearFootprints);
+
+        notificationService.sendFootprintNotification(DEFAULT_TITLE,
+                "내 산책장소에 " + startMemberName + "님이 산책을 시작했어요!",
+                nearDeviceTokens
+        );
+    }
+
+    private List<String> toDeviceToken(List<Footprint> footprints) {
+        return footprints.stream()
+                .map(otherFootprint -> deviceTokenRepository.findByMemberId(otherFootprint.getMember().getId()))
+                .flatMap(Optional::stream)
+                .map(DeviceToken::getDeviceToken)
+                .toList();
+    }
+}


### PR DESCRIPTION
## 이슈
- #519 

## 개발 사항
- 내 산책 상태 변경 시 나에게 알림 기능 구현
- FootprintCommandService에 알림 로직 FootprintNotificationService클래스로 이동
  - 발자국과 관련이 없는 알림 메서드가 과도하게 많아져서 책임 분리
  - 이에 따라, FootprintCommandService는 NotificationService와 DeviceTokenRepository에 의존하지 않게 됨

# 전달 사항 
- 내 산책 상태 변경 시, 하단에 토스트메세지로 알려주는 것을 어플에서 삭제했다고함
  - 지도 열때마다 반복해서 메세지가 뜨는 버그 때문.
- **따라서 알림 기능이 필요했다.**
