### PR TITLE
[BE] fix: 채팅 알림 기기 토큰 관련 예외 처리 추가, 자신에게는 채팅 알림을 전송하지 않도록 변경

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/notification/repository/DeviceTokenRepository.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/repository/DeviceTokenRepository.java
@@ -15,9 +15,10 @@ public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> 
             SELECT dt.deviceToken
             FROM DeviceToken dt
             INNER JOIN ChatRoomMember chatRoomMember ON dt.member.id = chatRoomMember.member.id
-            WHERE chatRoomMember.chatRoom.id = :chatRoomId
+            WHERE chatRoomMember.chatRoom.id = :chatRoomId AND dt.member.id != :myMemberId
             """)
-    List<String> findAllByChatRoomId(@Param("chatRoomId") Long chatRoomId);
+    List<String> findAllByChatRoomIdWithoutMine(
+            @Param("chatRoomId") Long chatRoomId, @Param("myMemberId") Long myMemberId);
 
     void deleteByMemberId(Long memberId);
 }

--- a/backend/src/main/java/com/happy/friendogly/notification/service/FcmNotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/FcmNotificationService.java
@@ -2,6 +2,7 @@ package com.happy.friendogly.notification.service;
 
 import static com.happy.friendogly.notification.domain.NotificationType.CHAT;
 import static com.happy.friendogly.notification.domain.NotificationType.FOOTPRINT;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.messaging.FirebaseMessaging;
@@ -15,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -55,7 +55,8 @@ public class FcmNotificationService implements NotificationService {
 
     @Override
     public void sendChatNotification(Long chatRoomId, ChatMessageResponse response) {
-        List<String> receiverTokens = deviceTokenRepository.findAllByChatRoomIdWithoutMine(chatRoomId, response.senderMemberId());
+        List<String> receiverTokens = deviceTokenRepository
+                .findAllByChatRoomIdWithoutMine(chatRoomId, response.senderMemberId());
 
         if (receiverTokens.isEmpty()) {
             throw new FriendoglyException("기기 토큰이 비어 있어 알림을 전송할 수 없습니다.");
@@ -92,7 +93,7 @@ public class FcmNotificationService implements NotificationService {
                 firebaseMessaging.sendEachForMulticast(message);
             } catch (FirebaseMessagingException e) {
                 throw new FriendoglyException("FCM을 통해 사용자에게 알림을 보내는 과정에서 에러가 발생했습니다.",
-                        HttpStatus.INTERNAL_SERVER_ERROR);
+                        INTERNAL_SERVER_ERROR);
             }
         }
     }

--- a/backend/src/main/java/com/happy/friendogly/notification/service/FcmNotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/FcmNotificationService.java
@@ -57,6 +57,10 @@ public class FcmNotificationService implements NotificationService {
     public void sendChatNotification(Long chatRoomId, ChatMessageResponse response) {
         List<String> receiverTokens = deviceTokenRepository.findAllByChatRoomIdWithoutMine(chatRoomId, response.senderMemberId());
 
+        if (receiverTokens.isEmpty()) {
+            throw new FriendoglyException("기기 토큰이 비어 있어 알림을 전송할 수 없습니다.");
+        }
+
         Map<String, String> data = Map.of(
                 "chatRoomId", chatRoomId.toString(),
                 "messageType", response.messageType().toString(),

--- a/backend/src/main/java/com/happy/friendogly/notification/service/FcmNotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/FcmNotificationService.java
@@ -55,7 +55,7 @@ public class FcmNotificationService implements NotificationService {
 
     @Override
     public void sendChatNotification(Long chatRoomId, ChatMessageResponse response) {
-        List<String> receiverTokens = deviceTokenRepository.findAllByChatRoomId(chatRoomId);
+        List<String> receiverTokens = deviceTokenRepository.findAllByChatRoomIdWithoutMine(chatRoomId, response.senderMemberId());
 
         Map<String, String> data = Map.of(
                 "chatRoomId", chatRoomId.toString(),

--- a/backend/src/main/java/com/happy/friendogly/notification/service/FcmNotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/FcmNotificationService.java
@@ -59,7 +59,7 @@ public class FcmNotificationService implements NotificationService {
                 .findAllByChatRoomIdWithoutMine(chatRoomId, response.senderMemberId());
 
         if (receiverTokens.isEmpty()) {
-            throw new FriendoglyException("기기 토큰이 비어 있어 알림을 전송할 수 없습니다.");
+            throw new FriendoglyException("기기 토큰이 비어 있어 알림을 전송할 수 없습니다.", INTERNAL_SERVER_ERROR);
         }
 
         Map<String, String> data = Map.of(

--- a/backend/src/test/java/com/happy/friendogly/notification/repository/DeviceTokenRepositoryTest.java
+++ b/backend/src/test/java/com/happy/friendogly/notification/repository/DeviceTokenRepositoryTest.java
@@ -24,23 +24,27 @@ class DeviceTokenRepositoryTest {
     @Autowired
     private ChatRoomRepository chatRoomRepository;
 
-    @DisplayName("채팅방 ID로부터 device token을 가져올 수 있다.")
+    @DisplayName("채팅방 ID로부터 자기 자신을 제외한 device token들을 가져올 수 있다.")
     @Test
     void findAllByChatRoomId() {
         // given
-        Member member1 = memberRepository.save(new Member("name1", "tag1", "https://test.com/test.jpg"));
-        Member member2 = memberRepository.save(new Member("name2", "tag2", "https://test.com/test.jpg"));
-        Member member3 = memberRepository.save(new Member("name3", "tag3", "https://test.com/test.jpg"));
+        Member me = memberRepository.save(new Member("name1", "tag1", "https://test.com/test.jpg"));
+        Member other1 = memberRepository.save(new Member("name2", "tag2", "https://test.com/test.jpg"));
+        Member other2 = memberRepository.save(new Member("name3", "tag3", "https://test.com/test.jpg"));
+        Member notInChatRoom = memberRepository.save(new Member("name4", "tag4", "https://test.com/test.jpg"));
 
-        deviceTokenRepository.save(new DeviceToken(member1, "token1"));
-        deviceTokenRepository.save(new DeviceToken(member2, "token2"));
-        deviceTokenRepository.save(new DeviceToken(member3, "token3"));
+        deviceTokenRepository.save(new DeviceToken(me, "token1"));
+        deviceTokenRepository.save(new DeviceToken(other1, "token2"));
+        deviceTokenRepository.save(new DeviceToken(other2, "token3"));
+        deviceTokenRepository.save(new DeviceToken(notInChatRoom, "token4"));
 
         ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.createGroup(5));
-        chatRoom.addMember(member1);
-        chatRoom.addMember(member2);
+        chatRoom.addMember(me);
+        chatRoom.addMember(other1);
+        chatRoom.addMember(other2);
 
         // when - then
-        assertThat(deviceTokenRepository.findAllByChatRoomId(chatRoom.getId())).containsExactly("token1", "token2");
+        assertThat(deviceTokenRepository.findAllByChatRoomIdWithoutMine(chatRoom.getId(), me.getId()))
+                .containsExactly("token2", "token3");
     }
 }


### PR DESCRIPTION
## 이슈
- close #524 

## 개발 사항
- 채팅 알림에서 기기 토큰이 비어 있는 경우 예외 발생 구현
- 자기 자신에게는 채팅 알림을 전송하지 않도록 수정

## 전달 사항
- 안드로이드에서 기기 토큰 저장 issue가 해결되었기 때문에, exception은 (정상적인 흐름이라면) 터지지 않을 것 같아요.
- 크리티컬한 이슈는 아니라서, 바로 머지하지 않아도 괜찮을 것 같네요.