### PR TITLE
[BE] fix: 내 모임 조회 시 인원 및 모임장이 잘못 조회되는 현상 수정

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/club/repository/ClubRepository.java
+++ b/backend/src/main/java/com/happy/friendogly/club/repository/ClubRepository.java
@@ -47,7 +47,13 @@ public interface ClubRepository extends JpaRepository<Club, Long>, JpaSpecificat
                 JOIN FETCH CM.clubMemberId.member AS M
                 JOIN FETCH C.clubPets AS CP
                 JOIN FETCH CP.clubPetId.pet
-                WHERE M.id = :memberId
+                WHERE C.id IN (
+                    SELECT C2.id
+                    FROM Club AS C2
+                    JOIN ClubMember AS CM2 ON CM2.clubMemberId.club = C2
+                    JOIN Member AS M2 ON CM2.clubMemberId.member = M2
+                    where M2.id = :memberId
+                )
                 ORDER BY C.createdAt DESC
             """)
     List<Club> findAllByParticipatingMemberId(@Param("memberId") Long memberId);


### PR DESCRIPTION
## 이슈
- close #529 

## 개발 사항
- 내 모임 조회 시 인원 및 모임장이 잘못 조회되는 현상 수정