### PR TITLE
[BE] fix: 회원 탈퇴시 발자국 외래키 제약조건으로 인해 탈퇴하지 못하는 현상 수정

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/footprint/repository/FootprintRepository.java
+++ b/backend/src/main/java/com/happy/friendogly/footprint/repository/FootprintRepository.java
@@ -26,4 +26,6 @@ public interface FootprintRepository extends JpaRepository<Footprint, Long> {
         return findById(id)
                 .orElseThrow(() -> new FriendoglyException("발자국이 존재하지 않습니다."));
     }
+
+    void deleteAllByMemberId(Long memberId);
 }

--- a/backend/src/main/java/com/happy/friendogly/member/service/MemberCommandService.java
+++ b/backend/src/main/java/com/happy/friendogly/member/service/MemberCommandService.java
@@ -8,7 +8,6 @@ import com.happy.friendogly.auth.service.jwt.JwtProvider;
 import com.happy.friendogly.auth.service.jwt.TokenPayload;
 import com.happy.friendogly.club.repository.ClubRepository;
 import com.happy.friendogly.club.service.ClubCommandService;
-import com.happy.friendogly.footprint.domain.Footprint;
 import com.happy.friendogly.footprint.repository.FootprintRepository;
 import com.happy.friendogly.infra.FileStorageManager;
 import com.happy.friendogly.infra.ImageUpdateType;
@@ -103,9 +102,8 @@ public class MemberCommandService {
                 .forEach(club -> clubCommandService.deleteClubMember(club.getId(), memberId));
 
         // 해당 회원의 발자국 삭제
-        footprintRepository.findTopOneByMemberIdOrderByCreatedAtDesc(memberId)
-                .ifPresent(Footprint::updateToDeleted);
-        
+        footprintRepository.deleteAllByMemberId(memberId);
+
         // 해당 회원의 반려견 삭제
         // TODO: 해당 반려견 이미지 S3에서 삭제
         petRepository.deleteAllByMemberId(memberId);


### PR DESCRIPTION
## 이슈
- x

## 개발 사항
- 회원 탈퇴시 발자국 외래키 제약조건으로 인해 탈퇴하지 못하는 현상 수정

## 참고 사항
- 기존까지 발자국은 논리삭제 하고 있었습니다. 이 때 회원을 삭제하는 경우, 외래키 제약조건으로 인해 회원 삭제가 정상적으로 이루어지지 않는 현상이 발생했습니다.
- 탈퇴한 회원의 발자국도 물리삭제 하도록 변경했습니다.