### PR TITLE
[BE] 모임 필터 리스트 정렬 추가

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/chat/controller/ChatRoomController.java
+++ b/backend/src/main/java/com/happy/friendogly/chat/controller/ChatRoomController.java
@@ -23,7 +23,6 @@ public class ChatRoomController {
     private final ChatRoomQueryService chatRoomQueryService;
     private final ChatRoomCommandService chatRoomCommandService;
 
-    // hello
     public ChatRoomController(
             ChatRoomQueryService chatRoomQueryService,
             ChatRoomCommandService chatRoomCommandService

--- a/backend/src/main/java/com/happy/friendogly/club/domain/Club.java
+++ b/backend/src/main/java/com/happy/friendogly/club/domain/Club.java
@@ -24,6 +24,7 @@ import jakarta.persistence.NamedAttributeNode;
 import jakarta.persistence.NamedEntityGraph;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.OrderBy;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -87,9 +88,11 @@ public class Club {
     private Status status;
 
     @OneToMany(mappedBy = "clubMemberId.club", orphanRemoval = true, cascade = CascadeType.ALL)
+    @OrderBy("createdAt")
     private Set<ClubMember> clubMembers = new HashSet<>();
 
     @OneToMany(mappedBy = "clubPetId.club", orphanRemoval = true, cascade = CascadeType.ALL)
+    @OrderBy
     private Set<ClubPet> clubPets = new HashSet<>();
 
     @OneToOne(fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.ALL)
@@ -220,7 +223,6 @@ public class Club {
     public void removeClubMember(Member member) {
         ClubMember targetClubMember = findTargetClubMember(member);
         clubMembers.remove(targetClubMember);
-//        targetClubMember.updateClub(null);
         removeClubPets(member);
         if (status.isFull()) {
             this.status = Status.OPEN;
@@ -236,8 +238,7 @@ public class Club {
 
     private void removeClubPets(Member member) {
         List<ClubPet> participatingMemberPets = findTargetClubPets(member);
-        clubPets.removeAll(participatingMemberPets);
-//        participatingMemberPets.forEach(clubPet -> clubPet.updateClub(null));
+        participatingMemberPets.forEach(clubPets::remove);
     }
 
     private List<ClubPet> findTargetClubPets(Member member) {

--- a/backend/src/main/java/com/happy/friendogly/club/repository/ClubSpecification.java
+++ b/backend/src/main/java/com/happy/friendogly/club/repository/ClubSpecification.java
@@ -64,7 +64,7 @@ public class ClubSpecification {
     }
 
     public ClubSpecification orderByCreatedAtDesc() {
-        spec.and((root, query, criteriaBuilder) -> {
+        spec = spec.and((root, query, criteriaBuilder) -> {
             Order orderByCreatedAt = criteriaBuilder.desc(root.get("createdAt"));
             query.orderBy(orderByCreatedAt);
             return criteriaBuilder.conjunction();

--- a/backend/src/test/java/com/happy/friendogly/club/service/ClubQueryServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/club/service/ClubQueryServiceTest.java
@@ -44,11 +44,18 @@ class ClubQueryServiceTest extends ClubServiceTest {
     @DisplayName("필터링된 모임을 정보를 조회한다.")
     @Test
     void findSearching() {
-        Club club = createSavedClub(
+        Club club1 = createSavedClub(
                 savedMember,
                 List.of(savedPet),
                 Set.of(Gender.FEMALE, Gender.FEMALE_NEUTERED),
                 Set.of(SizeType.SMALL)
+        );
+
+        Club club2 = createSavedClub(
+                savedMember,
+                List.of(savedPet),
+                Set.of(Gender.FEMALE, Gender.FEMALE_NEUTERED),
+                Set.of(SizeType.SMALL, SizeType.MEDIUM)
         );
 
         FindClubByFilterRequest request = new FindClubByFilterRequest(
@@ -62,24 +69,40 @@ class ClubQueryServiceTest extends ClubServiceTest {
 
         List<FindClubByFilterResponse> responses = clubQueryService.findByFilter(savedMember.getId(), request);
         List<FindClubByFilterResponse> expectedResponses = List.of(
-                new FindClubByFilterResponse(club, List.of(petImageUrl))
+                new FindClubByFilterResponse(club2, List.of(petImageUrl)),
+                new FindClubByFilterResponse(club1, List.of(petImageUrl))
         );
 
-        FindClubByFilterResponse actual = responses.get(0);
-        FindClubByFilterResponse expected = expectedResponses.get(0);
+        FindClubByFilterResponse actual1 = responses.get(0);
+        FindClubByFilterResponse expected1 = expectedResponses.get(0);
+        FindClubByFilterResponse actual2 = responses.get(1);
+        FindClubByFilterResponse expected2 = expectedResponses.get(1);
 
         assertAll(
-                () -> assertThat(actual.id()).isEqualTo(expected.id()),
-                () -> assertThat(actual.title()).isEqualTo(expected.title()),
-                () -> assertThat(actual.content()).isEqualTo(expected.content()),
-                () -> assertThat(actual.address()).isEqualTo(expected.address()),
-                () -> assertThat(actual.ownerMemberName()).isEqualTo(expected.ownerMemberName()),
-                () -> assertThat(actual.status()).isEqualTo(expected.status()),
-                () -> assertThat(actual.allowedSize()).containsExactlyInAnyOrderElementsOf(expected.allowedSize()),
-                () -> assertThat(actual.allowedGender()).containsExactlyInAnyOrderElementsOf(expected.allowedGender()),
-                () -> assertThat(actual.memberCapacity()).isEqualTo(expected.memberCapacity()),
-                () -> assertThat(actual.currentMemberCount()).isEqualTo(expected.currentMemberCount()),
-                () -> assertThat(actual.petImageUrls()).containsExactlyInAnyOrderElementsOf(expected.petImageUrls())
+                () -> assertThat(actual1.id()).isEqualTo(expected1.id()),
+                () -> assertThat(actual1.title()).isEqualTo(expected1.title()),
+                () -> assertThat(actual1.content()).isEqualTo(expected1.content()),
+                () -> assertThat(actual1.address()).isEqualTo(expected1.address()),
+                () -> assertThat(actual1.ownerMemberName()).isEqualTo(expected1.ownerMemberName()),
+                () -> assertThat(actual1.status()).isEqualTo(expected1.status()),
+                () -> assertThat(actual1.allowedSize()).containsExactlyInAnyOrderElementsOf(expected1.allowedSize()),
+                () -> assertThat(actual1.allowedGender()).containsExactlyInAnyOrderElementsOf(
+                        expected1.allowedGender()),
+                () -> assertThat(actual1.memberCapacity()).isEqualTo(expected1.memberCapacity()),
+                () -> assertThat(actual1.currentMemberCount()).isEqualTo(expected1.currentMemberCount()),
+                () -> assertThat(actual1.petImageUrls()).containsExactlyInAnyOrderElementsOf(expected1.petImageUrls()),
+                () -> assertThat(actual2.id()).isEqualTo(expected2.id()),
+                () -> assertThat(actual2.title()).isEqualTo(expected2.title()),
+                () -> assertThat(actual2.content()).isEqualTo(expected2.content()),
+                () -> assertThat(actual2.address()).isEqualTo(expected2.address()),
+                () -> assertThat(actual2.ownerMemberName()).isEqualTo(expected2.ownerMemberName()),
+                () -> assertThat(actual2.status()).isEqualTo(expected2.status()),
+                () -> assertThat(actual2.allowedSize()).containsExactlyInAnyOrderElementsOf(expected2.allowedSize()),
+                () -> assertThat(actual2.allowedGender()).containsExactlyInAnyOrderElementsOf(
+                        expected2.allowedGender()),
+                () -> assertThat(actual2.memberCapacity()).isEqualTo(expected2.memberCapacity()),
+                () -> assertThat(actual2.currentMemberCount()).isEqualTo(expected2.currentMemberCount()),
+                () -> assertThat(actual2.petImageUrls()).containsExactlyInAnyOrderElementsOf(expected2.petImageUrls())
         );
     }
 


### PR DESCRIPTION
## 이슈
- #528 

## 개발 사항
- 누락된 정렬 기능 추가
- 모임 회원 및 팻 갱신마다 순서가 바뀌는 현상 수정

## 리뷰 요청 사항 (없으면 삭제해 주세요)
- 

# 전달 사항 (없으면 삭제해 주세요)
-
