### PR TITLE
[BE] fix: 채팅 알림을 전송할 때 받는 사람의 기기 토큰이 비어 있어도 예외가 발생하지 않도록 수정

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/notification/service/FcmNotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/FcmNotificationService.java
@@ -14,7 +14,6 @@ import com.happy.friendogly.notification.domain.NotificationType;
 import com.happy.friendogly.notification.repository.DeviceTokenRepository;
 import java.util.List;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -22,7 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
-@Slf4j
 @Profile("!local")
 public class FcmNotificationService implements NotificationService {
 

--- a/backend/src/main/java/com/happy/friendogly/notification/service/FcmNotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/FcmNotificationService.java
@@ -14,6 +14,7 @@ import com.happy.friendogly.notification.domain.NotificationType;
 import com.happy.friendogly.notification.repository.DeviceTokenRepository;
 import java.util.List;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -21,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
+@Slf4j
 @Profile("!local")
 public class FcmNotificationService implements NotificationService {
 
@@ -57,10 +59,6 @@ public class FcmNotificationService implements NotificationService {
     public void sendChatNotification(Long chatRoomId, ChatMessageSocketResponse response) {
         List<String> receiverTokens = deviceTokenRepository
                 .findAllByChatRoomIdWithoutMine(chatRoomId, response.senderMemberId());
-
-        if (receiverTokens.isEmpty()) {
-            throw new FriendoglyException("기기 토큰이 비어 있어 알림을 전송할 수 없습니다.", INTERNAL_SERVER_ERROR);
-        }
 
         Map<String, String> data = Map.of(
                 "chatRoomId", chatRoomId.toString(),


### PR DESCRIPTION
## 이슈
- close #589 

## 개발 사항
- 단체 채팅방에 1명만 있는 경우 받는 사람의 기기 토큰 List가 empty인 것은 당연한데, 이것을 예외로 발생해서 채팅이 올바르게 전송되지 않고 있었습니다. 이 부분 반영하였습니다.