### PR TITLE
[BE] refactor: pet 도메인 지연 로딩 설정 및 N+1 문제 해결

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/pet/domain/Pet.java
+++ b/backend/src/main/java/com/happy/friendogly/pet/domain/Pet.java
@@ -29,7 +29,7 @@ public class Pet {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(nullable = false)
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     @Embedded

--- a/backend/src/main/java/com/happy/friendogly/pet/domain/Pet.java
+++ b/backend/src/main/java/com/happy/friendogly/pet/domain/Pet.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -27,7 +28,7 @@ public class Pet {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(nullable = false)
     private Member member;
 

--- a/backend/src/main/java/com/happy/friendogly/pet/repository/PetRepository.java
+++ b/backend/src/main/java/com/happy/friendogly/pet/repository/PetRepository.java
@@ -4,19 +4,35 @@ import com.happy.friendogly.exception.FriendoglyException;
 import com.happy.friendogly.member.domain.Member;
 import com.happy.friendogly.pet.domain.Pet;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PetRepository extends JpaRepository<Pet, Long> {
 
-    Long countByMember(Member member);
-
-    List<Pet> findByMemberId(Long memberId);
-
-    boolean existsByMemberId(Long memberId);
-
-    void deleteAllByMemberId(Long memberId);
+    @Query("""
+            SELECT p
+            FROM Pet p
+            JOIN FETCH p.member m
+            WHERE p.id = :id
+            """)
+    Optional<Pet> findById(Long id);
 
     default Pet getById(Long id) {
         return findById(id).orElseThrow(() -> new FriendoglyException("강아지 정보를 찾지 못했습니다."));
     }
+
+    @Query("""
+            SELECT p
+            FROM Pet p
+            JOIN FETCH p.member m
+            WHERE m.id = :memberId
+            """)
+    List<Pet> findByMemberId(Long memberId);
+
+    Long countByMember(Member member);
+
+    boolean existsByMemberId(Long memberId);
+
+    void deleteAllByMemberId(Long memberId);
 }

--- a/backend/src/main/java/com/happy/friendogly/pet/service/PetQueryService.java
+++ b/backend/src/main/java/com/happy/friendogly/pet/service/PetQueryService.java
@@ -6,8 +6,10 @@ import com.happy.friendogly.pet.dto.response.FindPetResponse;
 import com.happy.friendogly.pet.repository.PetRepository;
 import java.util.List;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 public class PetQueryService {
 
     private final PetRepository petRepository;

--- a/backend/src/test/java/com/happy/friendogly/pet/service/PetQueryServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/pet/service/PetQueryServiceTest.java
@@ -1,0 +1,72 @@
+package com.happy.friendogly.pet.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.happy.friendogly.member.domain.Member;
+import com.happy.friendogly.member.repository.MemberRepository;
+import com.happy.friendogly.pet.domain.Gender;
+import com.happy.friendogly.pet.domain.Pet;
+import com.happy.friendogly.pet.domain.SizeType;
+import com.happy.friendogly.pet.dto.response.FindPetResponse;
+import com.happy.friendogly.pet.repository.PetRepository;
+import com.happy.friendogly.support.ServiceTest;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class PetQueryServiceTest extends ServiceTest {
+
+    @Autowired
+    private PetQueryService petQueryService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PetRepository petRepository;
+
+    @DisplayName("pet 단건 조회 테스트")
+    @Test
+    void findById() {
+        Member member = memberRepository.save(new Member("member", "a1b2c3d4", "http://www.friendogly.com"));
+        Pet pet = petRepository.save(
+                new Pet(
+                        member,
+                        "땡이",
+                        "땡이에용",
+                        LocalDate.now().minusDays(1L),
+                        SizeType.SMALL,
+                        Gender.FEMALE_NEUTERED,
+                        "http://www.friendogly.com"
+                )
+        );
+
+        FindPetResponse response = petQueryService.findById(pet.getId());
+
+        assertThat(response.id()).isEqualTo(pet.getId());
+        assertThat(response.memberId()).isEqualTo(pet.getMember().getId());
+    }
+
+    @DisplayName("memberId로 pet 단건 조회 테스트")
+    @Test
+    void findByMemberId() {
+        Member member = memberRepository.save(new Member("member", "a1b2c3d4", "http://www.friendogly.com"));
+        Pet pet = petRepository.save(
+                new Pet(
+                        member,
+                        "땡이",
+                        "땡이에용",
+                        LocalDate.now().minusDays(1L),
+                        SizeType.SMALL,
+                        Gender.FEMALE_NEUTERED,
+                        "http://www.friendogly.com"
+                )
+        );
+
+        List<FindPetResponse> responses = petQueryService.findByMemberId(member.getId());
+        assertThat(responses.size()).isEqualTo(1);
+        assertThat(responses.get(0).id()).isEqualTo(pet.getId());
+    }
+}

--- a/backend/src/test/java/com/happy/friendogly/pet/service/PetQueryServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/pet/service/PetQueryServiceTest.java
@@ -1,6 +1,7 @@
 package com.happy.friendogly.pet.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.happy.friendogly.member.domain.Member;
 import com.happy.friendogly.member.repository.MemberRepository;
@@ -45,8 +46,10 @@ public class PetQueryServiceTest extends ServiceTest {
 
         FindPetResponse response = petQueryService.findById(pet.getId());
 
-        assertThat(response.id()).isEqualTo(pet.getId());
-        assertThat(response.memberId()).isEqualTo(pet.getMember().getId());
+        assertAll(
+                () -> assertThat(response.id()).isEqualTo(pet.getId()),
+                () -> assertThat(response.memberId()).isEqualTo(pet.getMember().getId())
+        );
     }
 
     @DisplayName("memberId로 pet 단건 조회 테스트")
@@ -66,7 +69,10 @@ public class PetQueryServiceTest extends ServiceTest {
         );
 
         List<FindPetResponse> responses = petQueryService.findByMemberId(member.getId());
-        assertThat(responses.size()).isEqualTo(1);
-        assertThat(responses.get(0).id()).isEqualTo(pet.getId());
+
+        assertAll(
+                () -> assertThat(responses.size()).isEqualTo(1),
+                () -> assertThat(responses.get(0).id()).isEqualTo(pet.getId())
+        );
     }
 }


### PR DESCRIPTION
## 이슈
- close #586 

## 개발 사항
- member fetch 전략 LAZY로 수정
- 단건 조회 시 N+1 문제가 발생하는 현상 수정

## 전달 사항
- 이슈에 세부 내용 있습니다~ 참고 부탁드려요!
