### PR TITLE
[BE] feat: 놀이터 상세 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/playground/controller/PlaygroundController.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/controller/PlaygroundController.java
@@ -30,8 +30,10 @@ public class PlaygroundController {
     private final PlaygroundCommandService playgroundCommandService;
     private final PlaygroundQueryService playgroundQueryService;
 
-    public PlaygroundController(PlaygroundCommandService playgroundCommandService,
-                                PlaygroundQueryService playgroundQueryService) {
+    public PlaygroundController(
+            PlaygroundCommandService playgroundCommandService,
+            PlaygroundQueryService playgroundQueryService
+    ) {
         this.playgroundCommandService = playgroundCommandService;
         this.playgroundQueryService = playgroundQueryService;
     }

--- a/backend/src/main/java/com/happy/friendogly/playground/controller/PlaygroundController.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/controller/PlaygroundController.java
@@ -75,27 +75,28 @@ public class PlaygroundController {
     }
 
     @GetMapping("/{id}")
-    public ApiResponse<FindPlaygroundDetailResponse> findById(@PathVariable Long id) {
+    public ApiResponse<FindPlaygroundDetailResponse> findById(@Auth Long memberId, @PathVariable Long id) {
         return ApiResponse.ofSuccess(new FindPlaygroundDetailResponse(
                         1L,
-                        20,
-                        10,
+                        3,
+                        0,
+                        false,
                         List.of(
-                                PlaygroundPetDetail.dummyOf(
+                                PlaygroundPetDetail.of(
                                         1L,
                                         dummyPet1,
                                         null,
                                         true,
-                                        true
+                                        false
                                 ),
-                                PlaygroundPetDetail.dummyOf(
+                                PlaygroundPetDetail.of(
                                         1L,
                                         dummyPet2,
                                         null,
                                         true,
-                                        true
+                                        false
                                 ),
-                                PlaygroundPetDetail.dummyOf(
+                                PlaygroundPetDetail.of(
                                         2L,
                                         dummyPet3,
                                         "7시에 가요~",

--- a/backend/src/main/java/com/happy/friendogly/playground/controller/PlaygroundController.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/controller/PlaygroundController.java
@@ -2,10 +2,6 @@ package com.happy.friendogly.playground.controller;
 
 import com.happy.friendogly.auth.Auth;
 import com.happy.friendogly.common.ApiResponse;
-import com.happy.friendogly.member.domain.Member;
-import com.happy.friendogly.pet.domain.Gender;
-import com.happy.friendogly.pet.domain.Pet;
-import com.happy.friendogly.pet.domain.SizeType;
 import com.happy.friendogly.playground.dto.request.SavePlaygroundRequest;
 import com.happy.friendogly.playground.dto.request.UpdatePlaygroundArrivalRequest;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundDetailResponse;
@@ -13,10 +9,10 @@ import com.happy.friendogly.playground.dto.response.FindPlaygroundLocationRespon
 import com.happy.friendogly.playground.dto.response.FindPlaygroundSummaryResponse;
 import com.happy.friendogly.playground.dto.response.SavePlaygroundResponse;
 import com.happy.friendogly.playground.dto.response.UpdatePlaygroundArrivalResponse;
-import com.happy.friendogly.playground.dto.response.detail.PlaygroundPetDetail;
+import com.happy.friendogly.playground.service.PlaygroundCommandService;
+import com.happy.friendogly.playground.service.PlaygroundQueryService;
 import jakarta.validation.Valid;
 import java.net.URI;
-import java.time.LocalDate;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -31,34 +27,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/playgrounds")
 public class PlaygroundController {
 
-    public static Pet dummyPet1 = new Pet(
-            new Member("김도선", "tag1", "imgaeUrl"),
-            "초코",
-            "뛰어놀기 좋아해요",
-            LocalDate.of(2024, 9, 27),
-            SizeType.LARGE,
-            Gender.FEMALE,
-            "https://i.pinimg.com/564x/d1/62/cb/d162cb12dfa0011a7bd67188a14d661c.jpg"
-    );
-    public static Pet dummyPet2 = new Pet(
-            new Member("김도선", "tag1", "imageUrl"),
-            "치키",
-            "가만히 있길 좋아해요",
-            LocalDate.of(2024, 9, 25),
-            SizeType.MEDIUM,
-            Gender.FEMALE,
-            "https://i.pinimg.com/564x/96/d4/43/96d443c92059f2b3a240a7ff74692bbf.jpg"
-    );
+    private final PlaygroundCommandService playgroundCommandService;
+    private final PlaygroundQueryService playgroundQueryService;
 
-    public static Pet dummyPet3 = new Pet(
-            new Member("박예찬", "tag2", "imageUrl"),
-            "토리",
-            "먹기 좋아해요",
-            LocalDate.of(2024, 9, 26),
-            SizeType.SMALL,
-            Gender.FEMALE,
-            "https://i.pinimg.com/564x/08/01/67/080167a359545bc40068045f984a9994.jpg"
-    );
+    public PlaygroundController(PlaygroundCommandService playgroundCommandService,
+                                PlaygroundQueryService playgroundQueryService) {
+        this.playgroundCommandService = playgroundCommandService;
+        this.playgroundQueryService = playgroundQueryService;
+    }
 
     @PostMapping
     public ResponseEntity<ApiResponse<SavePlaygroundResponse>> save(
@@ -76,36 +52,8 @@ public class PlaygroundController {
 
     @GetMapping("/{id}")
     public ApiResponse<FindPlaygroundDetailResponse> findById(@Auth Long memberId, @PathVariable Long id) {
-        return ApiResponse.ofSuccess(new FindPlaygroundDetailResponse(
-                        1L,
-                        3,
-                        0,
-                        false,
-                        List.of(
-                                PlaygroundPetDetail.of(
-                                        1L,
-                                        dummyPet1,
-                                        null,
-                                        true,
-                                        false
-                                ),
-                                PlaygroundPetDetail.of(
-                                        1L,
-                                        dummyPet2,
-                                        null,
-                                        true,
-                                        false
-                                ),
-                                PlaygroundPetDetail.of(
-                                        2L,
-                                        dummyPet3,
-                                        "7시에 가요~",
-                                        false,
-                                        false
-                                )
-                        )
-                )
-        );
+        FindPlaygroundDetailResponse response = playgroundQueryService.findDetail(memberId, id);
+        return ApiResponse.ofSuccess(response);
     }
 
     @GetMapping("/{id}/summary")

--- a/backend/src/main/java/com/happy/friendogly/playground/controller/PlaygroundController.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/controller/PlaygroundController.java
@@ -43,13 +43,9 @@ public class PlaygroundController {
             @Auth Long memberId,
             @Valid @RequestBody SavePlaygroundRequest request
     ) {
-        SavePlaygroundResponse savePlaygroundResponse = new SavePlaygroundResponse(
-                1L,
-                request.latitude(),
-                request.longitude()
-        );
-        return ResponseEntity.created(URI.create("/playgrounds/" + 1))
-                .body(ApiResponse.ofSuccess(savePlaygroundResponse));
+        SavePlaygroundResponse response = playgroundCommandService.save(request, memberId);
+        return ResponseEntity.created(URI.create("/playgrounds/" + response.id()))
+                .body(ApiResponse.ofSuccess(response));
     }
 
     @GetMapping("/{playgroundId}")

--- a/backend/src/main/java/com/happy/friendogly/playground/controller/PlaygroundController.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/controller/PlaygroundController.java
@@ -65,14 +65,7 @@ public class PlaygroundController {
 
     @GetMapping("/locations")
     public ApiResponse<List<FindPlaygroundLocationResponse>> findAllLocation(@Auth Long memberId) {
-        return ApiResponse.ofSuccess(
-                List.of(
-                        new FindPlaygroundLocationResponse(1L, 37.5173316, 127.1011661, true),
-                        new FindPlaygroundLocationResponse(2L, 37.5185122, 127.098778, false),
-                        new FindPlaygroundLocationResponse(3L, 37.5136533, 127.0983182, false),
-                        new FindPlaygroundLocationResponse(4L, 37.5131474, 127.1042528, false)
-                )
-        );
+        return ApiResponse.ofSuccess(playgroundQueryService.findLocations(memberId));
     }
 
     @PatchMapping("/arrival")

--- a/backend/src/main/java/com/happy/friendogly/playground/controller/PlaygroundController.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/controller/PlaygroundController.java
@@ -52,9 +52,9 @@ public class PlaygroundController {
                 .body(ApiResponse.ofSuccess(savePlaygroundResponse));
     }
 
-    @GetMapping("/{id}")
-    public ApiResponse<FindPlaygroundDetailResponse> findById(@Auth Long memberId, @PathVariable Long id) {
-        FindPlaygroundDetailResponse response = playgroundQueryService.findDetail(memberId, id);
+    @GetMapping("/{playgroundId}")
+    public ApiResponse<FindPlaygroundDetailResponse> findById(@Auth Long memberId, @PathVariable Long playgroundId) {
+        FindPlaygroundDetailResponse response = playgroundQueryService.findDetail(memberId, playgroundId);
         return ApiResponse.ofSuccess(response);
     }
 

--- a/backend/src/main/java/com/happy/friendogly/playground/domain/Playground.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/domain/Playground.java
@@ -5,8 +5,13 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class Playground {
 
     @Id
@@ -15,4 +20,8 @@ public class Playground {
 
     @Embedded
     private Location location;
+
+    public Playground(Location location) {
+        this.location = location;
+    }
 }

--- a/backend/src/main/java/com/happy/friendogly/playground/domain/PlaygroundMember.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/domain/PlaygroundMember.java
@@ -9,12 +9,20 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedAttributeNode;
+import jakarta.persistence.NamedEntityGraph;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@NamedEntityGraph(
+        name = "graph.PlaygroundMember",
+        attributeNodes = {
+                @NamedAttributeNode("member")
+        }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class PlaygroundMember {
@@ -52,5 +60,9 @@ public class PlaygroundMember {
         this.message = message;
         this.isInside = isInside;
         this.exitTime = exitTime;
+    }
+
+    public boolean equalsMemberId(Long memberId) {
+        return member.getId().equals(memberId);
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/playground/domain/PlaygroundMember.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/domain/PlaygroundMember.java
@@ -9,20 +9,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.NamedAttributeNode;
-import jakarta.persistence.NamedEntityGraph;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@NamedEntityGraph(
-        name = "graph.PlaygroundMember",
-        attributeNodes = {
-                @NamedAttributeNode("member")
-        }
-)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class PlaygroundMember {

--- a/backend/src/main/java/com/happy/friendogly/playground/domain/PlaygroundMember.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/domain/PlaygroundMember.java
@@ -55,6 +55,13 @@ public class PlaygroundMember {
         this.exitTime = exitTime;
     }
 
+    public PlaygroundMember(
+            Playground playground,
+            Member member
+    ) {
+        this(playground, member, null, false, null);
+    }
+
     public boolean equalsMemberId(Long memberId) {
         return member.getId().equals(memberId);
     }

--- a/backend/src/main/java/com/happy/friendogly/playground/domain/PlaygroundMember.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/domain/PlaygroundMember.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -27,7 +28,7 @@ public class PlaygroundMember {
     @JoinColumn(name = "playground_id", nullable = false)
     private Playground playground;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 

--- a/backend/src/main/java/com/happy/friendogly/playground/dto/response/FindPlaygroundDetailResponse.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/dto/response/FindPlaygroundDetailResponse.java
@@ -9,6 +9,7 @@ public record FindPlaygroundDetailResponse(
         Long id,
         int totalPetCount,
         int arrivedPetCount,
+        boolean isParticipating,
         List<PlaygroundPetDetail> playgroundPetDetails
 ) {
 

--- a/backend/src/main/java/com/happy/friendogly/playground/dto/response/FindPlaygroundLocationResponse.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/dto/response/FindPlaygroundLocationResponse.java
@@ -5,7 +5,7 @@ public record FindPlaygroundLocationResponse(
         Long id,
         double latitude,
         double longitude,
-        boolean isParticipated
+        boolean isParticipating
 ) {
 
 }

--- a/backend/src/main/java/com/happy/friendogly/playground/dto/response/SavePlaygroundResponse.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/dto/response/SavePlaygroundResponse.java
@@ -1,5 +1,7 @@
 package com.happy.friendogly.playground.dto.response;
 
+import com.happy.friendogly.playground.domain.Playground;
+
 public record SavePlaygroundResponse(
 
         Long id,
@@ -7,4 +9,11 @@ public record SavePlaygroundResponse(
         double longitude
 ) {
 
+    public static SavePlaygroundResponse from(Playground playground) {
+        return new SavePlaygroundResponse(
+                playground.getId(),
+                playground.getLocation().getLatitude(),
+                playground.getLocation().getLongitude()
+        );
+    }
 }

--- a/backend/src/main/java/com/happy/friendogly/playground/dto/response/detail/PlaygroundPetDetail.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/dto/response/detail/PlaygroundPetDetail.java
@@ -22,15 +22,15 @@ public record PlaygroundPetDetail(
 
     public static List<PlaygroundPetDetail> getListOf(
             List<Pet> pets,
-            PlaygroundMember petOwner,
+            PlaygroundMember playgroundMember,
             boolean isMyPet
     ) {
         return pets.stream()
                 .map(pet -> PlaygroundPetDetail.of(
-                        petOwner.getId(),
+                        playgroundMember.getMember().getId(),
                         pet,
-                        petOwner.getMessage(),
-                        petOwner.isInside(),
+                        playgroundMember.getMessage(),
+                        playgroundMember.isInside(),
                         isMyPet
                 ))
                 .toList();

--- a/backend/src/main/java/com/happy/friendogly/playground/dto/response/detail/PlaygroundPetDetail.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/dto/response/detail/PlaygroundPetDetail.java
@@ -18,7 +18,7 @@ public record PlaygroundPetDetail(
         boolean isMine
 ) {
 
-    public static PlaygroundPetDetail dummyOf(
+    public static PlaygroundPetDetail of(
             Long memberId,
             Pet pet,
             String message,

--- a/backend/src/main/java/com/happy/friendogly/playground/dto/response/detail/PlaygroundPetDetail.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/dto/response/detail/PlaygroundPetDetail.java
@@ -28,7 +28,7 @@ public record PlaygroundPetDetail(
         return new PlaygroundPetDetail(
                 memberId,
                 pet.getId(),
-                pet.getName().toString(),
+                pet.getName().getValue(),
                 pet.getBirthDate().getValue(),
                 pet.getSizeType(),
                 pet.getGender(),

--- a/backend/src/main/java/com/happy/friendogly/playground/dto/response/detail/PlaygroundPetDetail.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/dto/response/detail/PlaygroundPetDetail.java
@@ -36,7 +36,7 @@ public record PlaygroundPetDetail(
                 .toList();
     }
 
-    private static PlaygroundPetDetail of(
+    public static PlaygroundPetDetail of(
             Long memberId,
             Pet pet,
             String message,

--- a/backend/src/main/java/com/happy/friendogly/playground/dto/response/detail/PlaygroundPetDetail.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/dto/response/detail/PlaygroundPetDetail.java
@@ -3,7 +3,9 @@ package com.happy.friendogly.playground.dto.response.detail;
 import com.happy.friendogly.pet.domain.Gender;
 import com.happy.friendogly.pet.domain.Pet;
 import com.happy.friendogly.pet.domain.SizeType;
+import com.happy.friendogly.playground.domain.PlaygroundMember;
 import java.time.LocalDate;
+import java.util.List;
 
 public record PlaygroundPetDetail(
         Long memberId,
@@ -18,7 +20,23 @@ public record PlaygroundPetDetail(
         boolean isMine
 ) {
 
-    public static PlaygroundPetDetail of(
+    public static List<PlaygroundPetDetail> getListOf(
+            List<Pet> pets,
+            PlaygroundMember petOwner,
+            boolean isMyPet
+    ) {
+        return pets.stream()
+                .map(pet -> PlaygroundPetDetail.of(
+                        petOwner.getId(),
+                        pet,
+                        petOwner.getMessage(),
+                        petOwner.isInside(),
+                        isMyPet
+                ))
+                .toList();
+    }
+
+    private static PlaygroundPetDetail of(
             Long memberId,
             Pet pet,
             String message,

--- a/backend/src/main/java/com/happy/friendogly/playground/repository/PlaygroundMemberRepository.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/repository/PlaygroundMemberRepository.java
@@ -9,4 +9,6 @@ public interface PlaygroundMemberRepository extends JpaRepository<PlaygroundMemb
 
     @EntityGraph(attributePaths = "member")
     List<PlaygroundMember> findAllByPlaygroundId(Long playgroundId);
+
+    boolean existsByPlaygroundIdAndMemberId(Long playgroundId, Long memberId);
 }

--- a/backend/src/main/java/com/happy/friendogly/playground/repository/PlaygroundMemberRepository.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/repository/PlaygroundMemberRepository.java
@@ -1,8 +1,12 @@
 package com.happy.friendogly.playground.repository;
 
 import com.happy.friendogly.playground.domain.PlaygroundMember;
+import java.util.List;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PlaygroundMemberRepository extends JpaRepository<PlaygroundMember, Long> {
 
+    @EntityGraph(value = "graph.PlaygroundMember")
+    List<PlaygroundMember> findByPlaygroundId(Long playgroundId);
 }

--- a/backend/src/main/java/com/happy/friendogly/playground/repository/PlaygroundMemberRepository.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/repository/PlaygroundMemberRepository.java
@@ -11,4 +11,6 @@ public interface PlaygroundMemberRepository extends JpaRepository<PlaygroundMemb
     List<PlaygroundMember> findAllByPlaygroundId(Long playgroundId);
 
     boolean existsByPlaygroundIdAndMemberId(Long playgroundId, Long memberId);
+
+    boolean existsByMemberId(Long memberId);
 }

--- a/backend/src/main/java/com/happy/friendogly/playground/repository/PlaygroundMemberRepository.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/repository/PlaygroundMemberRepository.java
@@ -7,6 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PlaygroundMemberRepository extends JpaRepository<PlaygroundMember, Long> {
 
-    @EntityGraph(value = "graph.PlaygroundMember")
-    List<PlaygroundMember> findByPlaygroundId(Long playgroundId);
+    @EntityGraph(attributePaths = "member")
+    List<PlaygroundMember> findAllByPlaygroundId(Long playgroundId);
 }

--- a/backend/src/main/java/com/happy/friendogly/playground/repository/PlaygroundRepository.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/repository/PlaygroundRepository.java
@@ -2,6 +2,7 @@ package com.happy.friendogly.playground.repository;
 
 import com.happy.friendogly.exception.FriendoglyException;
 import com.happy.friendogly.playground.domain.Playground;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PlaygroundRepository extends JpaRepository<Playground, Long> {
@@ -9,4 +10,25 @@ public interface PlaygroundRepository extends JpaRepository<Playground, Long> {
     default Playground getById(Long id) {
         return findById(id).orElseThrow(() -> new FriendoglyException("놀이터 정보를 찾지 못했습니다."));
     }
+
+    default List<Playground> findAllByLatitudeBetweenAndLongitudeBetween(
+            double startLatitude,
+            double endLatitude,
+            double startLongitude,
+            double endLongitude
+    ) {
+        return findAllByLocation_LatitudeBetweenAndLocation_LongitudeBetween(
+                startLatitude,
+                endLatitude,
+                startLongitude,
+                endLongitude
+        );
+    }
+
+    List<Playground> findAllByLocation_LatitudeBetweenAndLocation_LongitudeBetween(
+            double startLatitude,
+            double endLatitude,
+            double startLongitude,
+            double endLongitude
+    );
 }

--- a/backend/src/main/java/com/happy/friendogly/playground/repository/PlaygroundRepository.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/repository/PlaygroundRepository.java
@@ -1,8 +1,12 @@
 package com.happy.friendogly.playground.repository;
 
+import com.happy.friendogly.exception.FriendoglyException;
 import com.happy.friendogly.playground.domain.Playground;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PlaygroundRepository extends JpaRepository<Playground, Long> {
 
+    default Playground getById(Long id) {
+        return findById(id).orElseThrow(() -> new FriendoglyException("놀이터 정보를 찾지 못했습니다."));
+    }
 }

--- a/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundCommandService.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundCommandService.java
@@ -1,5 +1,9 @@
 package com.happy.friendogly.playground.service;
 
+import com.happy.friendogly.playground.domain.Location;
+import com.happy.friendogly.playground.domain.Playground;
+import com.happy.friendogly.playground.dto.request.SavePlaygroundRequest;
+import com.happy.friendogly.playground.dto.response.SavePlaygroundResponse;
 import com.happy.friendogly.playground.repository.PlaygroundMemberRepository;
 import com.happy.friendogly.playground.repository.PlaygroundRepository;
 import org.springframework.stereotype.Service;
@@ -18,5 +22,13 @@ public class PlaygroundCommandService {
     ) {
         this.playgroundRepository = playgroundRepository;
         this.playgroundMemberRepository = playgroundMemberRepository;
+    }
+
+    public SavePlaygroundResponse save(SavePlaygroundRequest request, Long memberId) {
+        Playground savedPlayground = playgroundRepository.save(
+                new Playground(new Location(request.latitude(), request.longitude()))
+        );
+        
+        return SavePlaygroundResponse.from(savedPlayground);
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundCommandService.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundCommandService.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PlaygroundCommandService {
 
     public static final int PLAYGROUND_EXCEPTION_DISTANCE_THRESHOLD = 300;
+
     private final PlaygroundRepository playgroundRepository;
     private final PlaygroundMemberRepository playgroundMemberRepository;
     private final MemberRepository memberRepository;
@@ -35,12 +36,15 @@ public class PlaygroundCommandService {
 
     public SavePlaygroundResponse save(SavePlaygroundRequest request, Long memberId) {
         Member member = memberRepository.getById(memberId);
+
         validateExistParticipatingPlayground(member);
         validateOverlapPlayground(request.latitude(), request.longitude());
+
         Playground savedPlayground = playgroundRepository.save(
                 new Playground(new Location(request.latitude(), request.longitude()))
         );
         playgroundMemberRepository.save(new PlaygroundMember(savedPlayground, member));
+
         return SavePlaygroundResponse.from(savedPlayground);
     }
 

--- a/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundCommandService.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundCommandService.java
@@ -1,5 +1,6 @@
 package com.happy.friendogly.playground.service;
 
+import com.happy.friendogly.exception.FriendoglyException;
 import com.happy.friendogly.member.domain.Member;
 import com.happy.friendogly.member.repository.MemberRepository;
 import com.happy.friendogly.playground.domain.Location;
@@ -31,11 +32,17 @@ public class PlaygroundCommandService {
 
     public SavePlaygroundResponse save(SavePlaygroundRequest request, Long memberId) {
         Member member = memberRepository.getById(memberId);
-
+        validateExistParticipatingPlayground(member);
         Playground savedPlayground = playgroundRepository.save(
                 new Playground(new Location(request.latitude(), request.longitude()))
         );
         playgroundMemberRepository.save(new PlaygroundMember(savedPlayground, member));
         return SavePlaygroundResponse.from(savedPlayground);
+    }
+
+    private void validateExistParticipatingPlayground(Member member) {
+        if (playgroundMemberRepository.existsByMemberId(member.getId())) {
+            throw new FriendoglyException("이미 참여한 놀이터가 존재합니다.");
+        }
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundCommandService.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundCommandService.java
@@ -10,6 +10,8 @@ import com.happy.friendogly.playground.dto.request.SavePlaygroundRequest;
 import com.happy.friendogly.playground.dto.response.SavePlaygroundResponse;
 import com.happy.friendogly.playground.repository.PlaygroundMemberRepository;
 import com.happy.friendogly.playground.repository.PlaygroundRepository;
+import com.happy.friendogly.utils.GeoCalculator;
+import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class PlaygroundCommandService {
 
+    public static final int PLAYGROUND_EXCEPTION_DISTANCE_THRESHOLD = 300;
     private final PlaygroundRepository playgroundRepository;
     private final PlaygroundMemberRepository playgroundMemberRepository;
     private final MemberRepository memberRepository;
@@ -33,6 +36,7 @@ public class PlaygroundCommandService {
     public SavePlaygroundResponse save(SavePlaygroundRequest request, Long memberId) {
         Member member = memberRepository.getById(memberId);
         validateExistParticipatingPlayground(member);
+        validateOverlapPlayground(request.latitude(), request.longitude());
         Playground savedPlayground = playgroundRepository.save(
                 new Playground(new Location(request.latitude(), request.longitude()))
         );
@@ -43,6 +47,29 @@ public class PlaygroundCommandService {
     private void validateExistParticipatingPlayground(Member member) {
         if (playgroundMemberRepository.existsByMemberId(member.getId())) {
             throw new FriendoglyException("이미 참여한 놀이터가 존재합니다.");
+        }
+    }
+
+    private void validateOverlapPlayground(double latitude, double longitude) {
+        Location location = new Location(latitude, longitude);
+        double startLatitude = GeoCalculator.calculateLatitudeOffset(latitude,
+                -PLAYGROUND_EXCEPTION_DISTANCE_THRESHOLD);
+        double endLatitude = GeoCalculator.calculateLatitudeOffset(latitude,
+                PLAYGROUND_EXCEPTION_DISTANCE_THRESHOLD);
+        double startLongitude = GeoCalculator.calculateLongitudeOffset(latitude, longitude,
+                -PLAYGROUND_EXCEPTION_DISTANCE_THRESHOLD);
+        double endLongitude = GeoCalculator.calculateLongitudeOffset(latitude, longitude,
+                PLAYGROUND_EXCEPTION_DISTANCE_THRESHOLD);
+
+        List<Playground> playgrounds = playgroundRepository.
+                findAllByLatitudeBetweenAndLongitudeBetween(startLatitude, endLatitude, startLongitude, endLongitude);
+
+        boolean isExistWithinRadius = playgrounds.stream()
+                .anyMatch(playground -> location.isWithin(playground.getLocation(),
+                        PLAYGROUND_EXCEPTION_DISTANCE_THRESHOLD));
+
+        if (isExistWithinRadius) {
+            throw new FriendoglyException("생성할 놀이터 범위내에 겹치는 다른 놀이터 범위가 있습니다.");
         }
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundCommandService.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundCommandService.java
@@ -1,7 +1,10 @@
 package com.happy.friendogly.playground.service;
 
+import com.happy.friendogly.member.domain.Member;
+import com.happy.friendogly.member.repository.MemberRepository;
 import com.happy.friendogly.playground.domain.Location;
 import com.happy.friendogly.playground.domain.Playground;
+import com.happy.friendogly.playground.domain.PlaygroundMember;
 import com.happy.friendogly.playground.dto.request.SavePlaygroundRequest;
 import com.happy.friendogly.playground.dto.response.SavePlaygroundResponse;
 import com.happy.friendogly.playground.repository.PlaygroundMemberRepository;
@@ -15,20 +18,24 @@ public class PlaygroundCommandService {
 
     private final PlaygroundRepository playgroundRepository;
     private final PlaygroundMemberRepository playgroundMemberRepository;
+    private final MemberRepository memberRepository;
 
     public PlaygroundCommandService(
             PlaygroundRepository playgroundRepository,
-            PlaygroundMemberRepository playgroundMemberRepository
-    ) {
+            PlaygroundMemberRepository playgroundMemberRepository,
+            MemberRepository memberRepository) {
         this.playgroundRepository = playgroundRepository;
         this.playgroundMemberRepository = playgroundMemberRepository;
+        this.memberRepository = memberRepository;
     }
 
     public SavePlaygroundResponse save(SavePlaygroundRequest request, Long memberId) {
+        Member member = memberRepository.getById(memberId);
+
         Playground savedPlayground = playgroundRepository.save(
                 new Playground(new Location(request.latitude(), request.longitude()))
         );
-        
+        playgroundMemberRepository.save(new PlaygroundMember(savedPlayground, member));
         return SavePlaygroundResponse.from(savedPlayground);
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundCommandService.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundCommandService.java
@@ -12,8 +12,10 @@ public class PlaygroundCommandService {
     private final PlaygroundRepository playgroundRepository;
     private final PlaygroundMemberRepository playgroundMemberRepository;
 
-    public PlaygroundCommandService(PlaygroundRepository playgroundRepository,
-                                    PlaygroundMemberRepository playgroundMemberRepository) {
+    public PlaygroundCommandService(
+            PlaygroundRepository playgroundRepository,
+            PlaygroundMemberRepository playgroundMemberRepository
+    ) {
         this.playgroundRepository = playgroundRepository;
         this.playgroundMemberRepository = playgroundMemberRepository;
     }

--- a/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundQueryService.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundQueryService.java
@@ -76,21 +76,13 @@ public class PlaygroundQueryService {
 
     public List<FindPlaygroundLocationResponse> findLocations(Long memberId) {
         List<Playground> playgrounds = playgroundRepository.findAll();
-        List<FindPlaygroundLocationResponse> playgroundLocationResponses = new ArrayList<>();
-        for (Playground playground : playgrounds) {
-            List<PlaygroundMember> playgroundMembers = playgroundMemberRepository
-                    .findAllByPlaygroundId(playground.getId());
-            boolean isParticipating = playgroundMembers.stream()
-                    .anyMatch(playgroundMember -> playgroundMember.equalsMemberId(memberId));
-            playgroundLocationResponses.add(
-                    new FindPlaygroundLocationResponse(
-                            playground.getId(),
-                            playground.getLocation().getLatitude(),
-                            playground.getLocation().getLongitude(),
-                            isParticipating
-                    )
-            );
-        }
-        return playgroundLocationResponses;
+
+        return playgrounds.stream()
+                .map(playground -> new FindPlaygroundLocationResponse(
+                        playground.getId(),
+                        playground.getLocation().getLatitude(),
+                        playground.getLocation().getLongitude(),
+                        playgroundMemberRepository.existsByPlaygroundIdAndMemberId(playground.getId(), memberId)
+                )).toList();
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundQueryService.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundQueryService.java
@@ -1,7 +1,16 @@
 package com.happy.friendogly.playground.service;
 
+import com.happy.friendogly.member.domain.Member;
+import com.happy.friendogly.pet.domain.Pet;
+import com.happy.friendogly.pet.repository.PetRepository;
+import com.happy.friendogly.playground.domain.Playground;
+import com.happy.friendogly.playground.domain.PlaygroundMember;
+import com.happy.friendogly.playground.dto.response.FindPlaygroundDetailResponse;
+import com.happy.friendogly.playground.dto.response.detail.PlaygroundPetDetail;
 import com.happy.friendogly.playground.repository.PlaygroundMemberRepository;
 import com.happy.friendogly.playground.repository.PlaygroundRepository;
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,10 +20,72 @@ public class PlaygroundQueryService {
 
     private final PlaygroundRepository playgroundRepository;
     private final PlaygroundMemberRepository playgroundMemberRepository;
+    private final PetRepository petRepository;
 
-    public PlaygroundQueryService(PlaygroundRepository playgroundRepository,
-                                  PlaygroundMemberRepository playgroundMemberRepository) {
+    public PlaygroundQueryService(
+            PlaygroundRepository playgroundRepository,
+            PlaygroundMemberRepository playgroundMemberRepository,
+            PetRepository petRepository
+    ) {
         this.playgroundRepository = playgroundRepository;
         this.playgroundMemberRepository = playgroundMemberRepository;
+        this.petRepository = petRepository;
+    }
+
+    public FindPlaygroundDetailResponse findDetailById(Long callMemberId, Long playgroundId) {
+        Playground playground = playgroundRepository.getById(playgroundId);
+        List<PlaygroundMember> playgroundMembers = playgroundMemberRepository.findByPlaygroundId(playgroundId);
+
+        int totalPetCount = 0;
+        int arrivedPetCount = 0;
+
+        List<PlaygroundPetDetail> playgroundPetDetails = new ArrayList<>();
+
+        for (PlaygroundMember playgroundMember : playgroundMembers) {
+            Member member = playgroundMember.getMember();
+            boolean isMyPet = member.getId().equals(callMemberId);
+
+            List<Pet> pets = petRepository.findByMemberId(member.getId());
+            totalPetCount += pets.size();
+            arrivedPetCount += getArrivedPetCount(playgroundMember, pets);
+
+            playgroundPetDetails.addAll(
+                    getPlaygroundPetDetails(pets, playgroundMember, isMyPet)
+            );
+        }
+
+        boolean isParticipating = playgroundMembers.stream()
+                .anyMatch(playgroundMember -> playgroundMember.equalsMemberId(callMemberId));
+
+        return new FindPlaygroundDetailResponse(
+                playground.getId(),
+                totalPetCount,
+                arrivedPetCount,
+                isParticipating,
+                playgroundPetDetails
+        );
+    }
+
+    private int getArrivedPetCount(PlaygroundMember playgroundMember, List<Pet> pets) {
+        if (playgroundMember.isInside()) {
+            return pets.size();
+        }
+        return 0;
+    }
+
+    private List<PlaygroundPetDetail> getPlaygroundPetDetails(
+            List<Pet> pets,
+            PlaygroundMember petOwner,
+            boolean isMyPet
+    ) {
+        return pets.stream()
+                .map(pet -> PlaygroundPetDetail.of(
+                        petOwner.getId(),
+                        pet,
+                        petOwner.getMessage(),
+                        petOwner.isInside(),
+                        isMyPet
+                ))
+                .toList();
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundQueryService.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundQueryService.java
@@ -50,7 +50,7 @@ public class PlaygroundQueryService {
             arrivedPetCount += getArrivedPetCount(playgroundMember, pets);
 
             playgroundPetDetails.addAll(
-                    getPlaygroundPetDetails(pets, playgroundMember, isMyPet)
+                    PlaygroundPetDetail.getListOf(pets, playgroundMember, isMyPet)
             );
         }
 
@@ -71,21 +71,5 @@ public class PlaygroundQueryService {
             return pets.size();
         }
         return 0;
-    }
-
-    private List<PlaygroundPetDetail> getPlaygroundPetDetails(
-            List<Pet> pets,
-            PlaygroundMember petOwner,
-            boolean isMyPet
-    ) {
-        return pets.stream()
-                .map(pet -> PlaygroundPetDetail.of(
-                        petOwner.getId(),
-                        pet,
-                        petOwner.getMessage(),
-                        petOwner.isInside(),
-                        isMyPet
-                ))
-                .toList();
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundQueryService.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundQueryService.java
@@ -32,7 +32,7 @@ public class PlaygroundQueryService {
         this.petRepository = petRepository;
     }
 
-    public FindPlaygroundDetailResponse findDetailById(Long callMemberId, Long playgroundId) {
+    public FindPlaygroundDetailResponse findDetail(Long callMemberId, Long playgroundId) {
         Playground playground = playgroundRepository.getById(playgroundId);
         List<PlaygroundMember> playgroundMembers = playgroundMemberRepository.findByPlaygroundId(playgroundId);
 

--- a/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundQueryService.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundQueryService.java
@@ -6,6 +6,7 @@ import com.happy.friendogly.pet.repository.PetRepository;
 import com.happy.friendogly.playground.domain.Playground;
 import com.happy.friendogly.playground.domain.PlaygroundMember;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundDetailResponse;
+import com.happy.friendogly.playground.dto.response.FindPlaygroundLocationResponse;
 import com.happy.friendogly.playground.dto.response.detail.PlaygroundPetDetail;
 import com.happy.friendogly.playground.repository.PlaygroundMemberRepository;
 import com.happy.friendogly.playground.repository.PlaygroundRepository;
@@ -71,5 +72,25 @@ public class PlaygroundQueryService {
             return pets.size();
         }
         return 0;
+    }
+
+    public List<FindPlaygroundLocationResponse> findLocations(Long memberId) {
+        List<Playground> playgrounds = playgroundRepository.findAll();
+        List<FindPlaygroundLocationResponse> playgroundLocationResponses = new ArrayList<>();
+        for (Playground playground : playgrounds) {
+            List<PlaygroundMember> playgroundMembers = playgroundMemberRepository
+                    .findAllByPlaygroundId(playground.getId());
+            boolean isParticipating = playgroundMembers.stream()
+                    .anyMatch(playgroundMember -> playgroundMember.equalsMemberId(memberId));
+            playgroundLocationResponses.add(
+                    new FindPlaygroundLocationResponse(
+                            playground.getId(),
+                            playground.getLocation().getLatitude(),
+                            playground.getLocation().getLongitude(),
+                            isParticipating
+                    )
+            );
+        }
+        return playgroundLocationResponses;
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundQueryService.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundQueryService.java
@@ -34,7 +34,7 @@ public class PlaygroundQueryService {
 
     public FindPlaygroundDetailResponse findDetail(Long callMemberId, Long playgroundId) {
         Playground playground = playgroundRepository.getById(playgroundId);
-        List<PlaygroundMember> playgroundMembers = playgroundMemberRepository.findByPlaygroundId(playgroundId);
+        List<PlaygroundMember> playgroundMembers = playgroundMemberRepository.findAllByPlaygroundId(playgroundId);
 
         int totalPetCount = 0;
         int arrivedPetCount = 0;

--- a/backend/src/main/java/com/happy/friendogly/utils/GeoCalculator.java
+++ b/backend/src/main/java/com/happy/friendogly/utils/GeoCalculator.java
@@ -1,0 +1,20 @@
+package com.happy.friendogly.utils;
+
+public class GeoCalculator {
+
+    private static final double ONE_DEGREE_LATITUDE_METER = 111000.0;
+    private static final double EARTH_CIRCUMFERENCE_AT_EQUATOR_METER = 40075017;
+
+    public static double calculateLatitudeOffset(double latitude, double distanceMeters) {
+        double latitudeOffset = distanceMeters / ONE_DEGREE_LATITUDE_METER;
+        return latitude + latitudeOffset;
+    }
+
+    public static double calculateLongitudeOffset(double latitude, double longitude, double distanceMeters) {
+        double oneDegreeLongitudeMeter =
+                Math.cos(Math.toRadians(latitude)) * (EARTH_CIRCUMFERENCE_AT_EQUATOR_METER / 360.0);
+
+        double longitudeOffset = distanceMeters / oneDegreeLongitudeMeter;
+        return longitude + longitudeOffset;
+    }
+}

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -97,3 +97,12 @@ INSERT INTO club_pet (club_id, pet_id)
 VALUES (1, 6),
        (2, 5),
        (2, 7);
+
+INSERT INTO playground (latitude, longitude)
+VALUES (37.514062, 127.100972),
+        (37.520740, 127.121328);
+
+INSERT INTO playground_member (playground_id, member_id, message, is_inside, exit_time)
+VALUES (1, 2, '강아지 3마리 보유', true, null),
+        (1, 1, '강아지 2마리 보유', false, null),
+        (2, 3, '강아지 1마리 보유' ,true, null);

--- a/backend/src/test/java/com/happy/friendogly/docs/PlaygroundApiDocsTest.java
+++ b/backend/src/test/java/com/happy/friendogly/docs/PlaygroundApiDocsTest.java
@@ -89,7 +89,8 @@ public class PlaygroundApiDocsTest extends RestDocsTest {
     @Test
     void find() throws Exception {
         mockMvc
-                .perform(get("/playgrounds/{id}", 1L))
+                .perform(get("/playgrounds/{id}", 1L)
+                        .header(HttpHeaders.AUTHORIZATION, getMemberToken()))
                 .andDo(document("playgrounds/find",
                         getDocumentRequest(),
                         getDocumentResponse(),
@@ -104,6 +105,7 @@ public class PlaygroundApiDocsTest extends RestDocsTest {
                                         fieldWithPath("data.id").description("놀이터의 ID"),
                                         fieldWithPath("data.totalPetCount").description("놀이터에 참여한 전체 강아지 수"),
                                         fieldWithPath("data.arrivedPetCount").description("놀이터에 도착한 강아지 수"),
+                                        fieldWithPath("data.isParticipating").description("놀이터에 참여했는지 여부"),
                                         fieldWithPath("data.playgroundPetDetails.[].memberId")
                                                 .description("강아지 주인 멤버ID"),
                                         fieldWithPath("data.playgroundPetDetails.[].petId")

--- a/backend/src/test/java/com/happy/friendogly/docs/PlaygroundApiDocsTest.java
+++ b/backend/src/test/java/com/happy/friendogly/docs/PlaygroundApiDocsTest.java
@@ -22,6 +22,7 @@ import com.happy.friendogly.playground.controller.PlaygroundController;
 import com.happy.friendogly.playground.dto.request.SavePlaygroundRequest;
 import com.happy.friendogly.playground.dto.request.UpdatePlaygroundArrivalRequest;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundDetailResponse;
+import com.happy.friendogly.playground.dto.response.FindPlaygroundLocationResponse;
 import com.happy.friendogly.playground.dto.response.detail.PlaygroundPetDetail;
 import com.happy.friendogly.playground.service.PlaygroundCommandService;
 import com.happy.friendogly.playground.service.PlaygroundQueryService;
@@ -185,6 +186,17 @@ public class PlaygroundApiDocsTest extends RestDocsTest {
     @DisplayName("모든 놀이터의 위치 정보를 조회")
     @Test
     void findAllLocation() throws Exception {
+
+        List<FindPlaygroundLocationResponse> response = List.of(
+                new FindPlaygroundLocationResponse(1L, 37.5173316, 127.1011661, true),
+                new FindPlaygroundLocationResponse(2L, 37.5185122, 127.098778, false),
+                new FindPlaygroundLocationResponse(3L, 37.5136533, 127.0983182, false),
+                new FindPlaygroundLocationResponse(4L, 37.5131474, 127.1042528, false)
+        );
+
+        when(playgroundQueryService.findLocations(anyLong()))
+                .thenReturn(response);
+
         mockMvc
                 .perform(get("/playgrounds/locations")
                         .header(HttpHeaders.AUTHORIZATION, getMemberToken())
@@ -200,7 +212,7 @@ public class PlaygroundApiDocsTest extends RestDocsTest {
                                         fieldWithPath("data.[].id").description("놀이터의 ID"),
                                         fieldWithPath("data.[].latitude").description("놀이터의 위도"),
                                         fieldWithPath("data.[].longitude").description("놀이터의 경도"),
-                                        fieldWithPath("data.[].isParticipated").description("놀이터 참여 유무")
+                                        fieldWithPath("data.[].isParticipating").description("놀이터 참여 유무")
                                 )
                                 .responseSchema(Schema.schema("PlaygroundLocationResponse"))
                                 .build()

--- a/backend/src/test/java/com/happy/friendogly/docs/PlaygroundApiDocsTest.java
+++ b/backend/src/test/java/com/happy/friendogly/docs/PlaygroundApiDocsTest.java
@@ -3,6 +3,7 @@ package com.happy.friendogly.docs;
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -23,6 +24,7 @@ import com.happy.friendogly.playground.dto.request.SavePlaygroundRequest;
 import com.happy.friendogly.playground.dto.request.UpdatePlaygroundArrivalRequest;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundDetailResponse;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundLocationResponse;
+import com.happy.friendogly.playground.dto.response.SavePlaygroundResponse;
 import com.happy.friendogly.playground.dto.response.detail.PlaygroundPetDetail;
 import com.happy.friendogly.playground.service.PlaygroundCommandService;
 import com.happy.friendogly.playground.service.PlaygroundQueryService;
@@ -45,6 +47,16 @@ public class PlaygroundApiDocsTest extends RestDocsTest {
     @Test
     void save() throws Exception {
         SavePlaygroundRequest request = new SavePlaygroundRequest(37.5173316, 127.1011661);
+
+        SavePlaygroundResponse response = new SavePlaygroundResponse(
+                1L,
+                request.latitude(),
+                request.longitude()
+        );
+
+        when(playgroundCommandService.save(any(), anyLong()))
+                .thenReturn(response);
+
         mockMvc
                 .perform(post("/playgrounds")
                         .header(HttpHeaders.AUTHORIZATION, getMemberToken())

--- a/backend/src/test/java/com/happy/friendogly/docs/PlaygroundApiDocsTest.java
+++ b/backend/src/test/java/com/happy/friendogly/docs/PlaygroundApiDocsTest.java
@@ -3,6 +3,8 @@ package com.happy.friendogly.docs;
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
@@ -12,14 +14,31 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
+import com.happy.friendogly.member.domain.Member;
+import com.happy.friendogly.pet.domain.Gender;
+import com.happy.friendogly.pet.domain.Pet;
+import com.happy.friendogly.pet.domain.SizeType;
 import com.happy.friendogly.playground.controller.PlaygroundController;
 import com.happy.friendogly.playground.dto.request.SavePlaygroundRequest;
 import com.happy.friendogly.playground.dto.request.UpdatePlaygroundArrivalRequest;
+import com.happy.friendogly.playground.dto.response.FindPlaygroundDetailResponse;
+import com.happy.friendogly.playground.dto.response.detail.PlaygroundPetDetail;
+import com.happy.friendogly.playground.service.PlaygroundCommandService;
+import com.happy.friendogly.playground.service.PlaygroundQueryService;
+import java.time.LocalDate;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.http.HttpHeaders;
 
 public class PlaygroundApiDocsTest extends RestDocsTest {
+
+    @Mock
+    private PlaygroundQueryService playgroundQueryService;
+
+    @Mock
+    private PlaygroundCommandService playgroundCommandService;
 
     @DisplayName("놀이터를 저장")
     @Test
@@ -88,6 +107,35 @@ public class PlaygroundApiDocsTest extends RestDocsTest {
     @DisplayName("놀이터의 정보를 조회")
     @Test
     void find() throws Exception {
+
+        Pet dummyPet1 = new Pet(
+                new Member("김도선", "tag1", "imgaeUrl"),
+                "초코",
+                "뛰어놀기 좋아해요",
+                LocalDate.of(2024, 9, 27),
+                SizeType.LARGE,
+                Gender.FEMALE,
+                "https://i.pinimg.com/564x/d1/62/cb/d162cb12dfa0011a7bd67188a14d661c.jpg"
+        );
+        FindPlaygroundDetailResponse response = new FindPlaygroundDetailResponse(
+                1L,
+                3,
+                0,
+                false,
+                List.of(
+                        PlaygroundPetDetail.of(
+                                1L,
+                                dummyPet1,
+                                null,
+                                true,
+                                false
+                        )
+                )
+        );
+
+        when(playgroundQueryService.findDetail(anyLong(), anyLong()))
+                .thenReturn(response);
+
         mockMvc
                 .perform(get("/playgrounds/{id}", 1L)
                         .header(HttpHeaders.AUTHORIZATION, getMemberToken()))
@@ -187,6 +235,6 @@ public class PlaygroundApiDocsTest extends RestDocsTest {
 
     @Override
     protected Object controller() {
-        return new PlaygroundController();
+        return new PlaygroundController(playgroundCommandService, playgroundQueryService);
     }
 }

--- a/backend/src/test/java/com/happy/friendogly/playground/repository/PlaygroundRepositoryTest.java
+++ b/backend/src/test/java/com/happy/friendogly/playground/repository/PlaygroundRepositoryTest.java
@@ -1,0 +1,38 @@
+package com.happy.friendogly.playground.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.happy.friendogly.playground.domain.Location;
+import com.happy.friendogly.playground.domain.Playground;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class PlaygroundRepositoryTest {
+
+    @Autowired
+    PlaygroundRepository playgroundRepository;
+
+    @DisplayName("주어진 위도, 경도 사이에 있는 놀이터를 찾을 수 있다.")
+    @Test
+    void findAllByLatitudeBetweenAndLongitudeBetween() {
+        // given
+        playgroundRepository.save(
+                new Playground(new Location(10, 10))
+        );
+        playgroundRepository.save(
+                new Playground(new Location(10, 12))
+        );
+
+        // when
+        List<Playground> playgrounds = playgroundRepository
+                .findAllByLocation_LatitudeBetweenAndLocation_LongitudeBetween(9, 11, 9, 11);
+
+        // then
+        assertThat(playgrounds.size()).isOne();
+    }
+
+}

--- a/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundCommandServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundCommandServiceTest.java
@@ -77,9 +77,9 @@ class PlaygroundCommandServiceTest extends PlaygroundServiceTest {
         Member member = saveMember("김도선");
         double latitude = 37.516382;
         double longitudeA = 127.120040;
-        double longitudeFar300mFromA = 127.123430;
+        double longitudeFar299mFromA = 127.123430;
         savePlayground(latitude, longitudeA);
-        SavePlaygroundRequest request = new SavePlaygroundRequest(latitude, longitudeFar300mFromA);
+        SavePlaygroundRequest request = new SavePlaygroundRequest(latitude, longitudeFar299mFromA);
 
         // when, then
         assertThatThrownBy(() -> playgroundCommandService.save(request, member.getId()))

--- a/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundCommandServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundCommandServiceTest.java
@@ -30,9 +30,10 @@ class PlaygroundCommandServiceTest extends PlaygroundServiceTest {
         SavePlaygroundResponse response = playgroundCommandService.save(request, member.getId());
 
         // then
-        assertAll(() -> assertThat(response.id()).isEqualTo(1), // todo: 테스트 격리 안되서 id가 틀릴 위험 있음
+        assertAll(
                 () -> assertThat(response.latitude()).isEqualTo(request.latitude()),
-                () -> assertThat(response.longitude()).isEqualTo(request.longitude()));
+                () -> assertThat(response.longitude()).isEqualTo(request.longitude())
+        );
     }
 
 
@@ -68,7 +69,6 @@ class PlaygroundCommandServiceTest extends PlaygroundServiceTest {
                 .hasMessage("이미 참여한 놀이터가 존재합니다.");
 
     }
-    // 이미 참여한 놀이터가 있다.
     // 겹치는 범위안에 놀이터가 있다.
 
 }

--- a/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundCommandServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundCommandServiceTest.java
@@ -26,14 +26,28 @@ class PlaygroundCommandServiceTest extends PlaygroundServiceTest {
         SavePlaygroundResponse response = playgroundCommandService.save(request, member.getId());
 
         // then
-        assertAll(
-                () -> assertThat(response.id()).isEqualTo(1), // todo: 테스트 격리 안되서 id가 틀릴 위험 있음
+        assertAll(() -> assertThat(response.id()).isEqualTo(1), // todo: 테스트 격리 안되서 id가 틀릴 위험 있음
                 () -> assertThat(response.latitude()).isEqualTo(request.latitude()),
-                () -> assertThat(response.longitude()).isEqualTo(request.longitude())
-        );
+                () -> assertThat(response.longitude()).isEqualTo(request.longitude()));
+    }
+
+
+    @DisplayName("멤버가 놀이터를 등록하면 해당 멤버는 놀이터에 자동으로 참가")
+    @Test
+    void autoParticipatePlaygroundWhenCreate() {
+        // given
+        Member member = saveMember("김도선");
+        SavePlaygroundRequest request = new SavePlaygroundRequest(37.5173316, 127.1011661);
+
+        // when
+        SavePlaygroundResponse response = playgroundCommandService.save(request, member.getId());
+        boolean isParticipating = playgroundMemberRepository
+                .existsByPlaygroundIdAndMemberId(response.id(), member.getId());
+
+        // then
+        assertThat(isParticipating).isTrue();
     }
     // 이미 참여한 놀이터가 있다.
     // 겹치는 범위안에 놀이터가 있다.
 
-    // 등록하면 자동으로 참가
 }

--- a/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundCommandServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundCommandServiceTest.java
@@ -1,9 +1,13 @@
 package com.happy.friendogly.playground.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.happy.friendogly.exception.FriendoglyException;
 import com.happy.friendogly.member.domain.Member;
+import com.happy.friendogly.playground.domain.Playground;
+import com.happy.friendogly.playground.domain.PlaygroundMember;
 import com.happy.friendogly.playground.dto.request.SavePlaygroundRequest;
 import com.happy.friendogly.playground.dto.response.SavePlaygroundResponse;
 import org.junit.jupiter.api.DisplayName;
@@ -46,6 +50,23 @@ class PlaygroundCommandServiceTest extends PlaygroundServiceTest {
 
         // then
         assertThat(isParticipating).isTrue();
+    }
+
+    @DisplayName("이미 참여한 놀이터가 있을 경우 예외가 발생한다.")
+    @Test
+    void throwExceptionWhenAlreadyParticipateOther() {
+        // given
+        Playground playground = savePlayground();
+        Member member = saveMember("김도선");
+        playgroundMemberRepository.save(new PlaygroundMember(playground, member));
+
+        SavePlaygroundRequest request = new SavePlaygroundRequest(37.5173316, 127.1011661);
+
+        // when, then
+        assertThatThrownBy(() -> playgroundCommandService.save(request, member.getId()))
+                .isInstanceOf(FriendoglyException.class)
+                .hasMessage("이미 참여한 놀이터가 존재합니다.");
+
     }
     // 이미 참여한 놀이터가 있다.
     // 겹치는 범위안에 놀이터가 있다.

--- a/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundCommandServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundCommandServiceTest.java
@@ -69,6 +69,22 @@ class PlaygroundCommandServiceTest extends PlaygroundServiceTest {
                 .hasMessage("이미 참여한 놀이터가 존재합니다.");
 
     }
-    // 겹치는 범위안에 놀이터가 있다.
+
+    @DisplayName("놀이터 생성시, 놀이터 범위에 다른 겹치는 놀이터 범위가 존재하면 예외가 발생한다.")
+    @Test
+    void throwExceptionWhenOverlapPlaygroundScope() {
+        // given
+        Member member = saveMember("김도선");
+        double latitude = 37.516382;
+        double longitudeA = 127.120040;
+        double longitudeFar300mFromA = 127.123430;
+        savePlayground(latitude, longitudeA);
+        SavePlaygroundRequest request = new SavePlaygroundRequest(latitude, longitudeFar300mFromA);
+
+        // when, then
+        assertThatThrownBy(() -> playgroundCommandService.save(request, member.getId()))
+                .isInstanceOf(FriendoglyException.class)
+                .hasMessage("생성할 놀이터 범위내에 겹치는 다른 놀이터 범위가 있습니다.");
+    }
 
 }

--- a/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundCommandServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundCommandServiceTest.java
@@ -1,0 +1,39 @@
+package com.happy.friendogly.playground.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.happy.friendogly.member.domain.Member;
+import com.happy.friendogly.playground.dto.request.SavePlaygroundRequest;
+import com.happy.friendogly.playground.dto.response.SavePlaygroundResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class PlaygroundCommandServiceTest extends PlaygroundServiceTest {
+
+    @Autowired
+    PlaygroundCommandService playgroundCommandService;
+
+    @DisplayName("놀이터를 등록할 수 있다.")
+    @Test
+    void save() {
+        // given
+        Member member = saveMember("김도선");
+        SavePlaygroundRequest request = new SavePlaygroundRequest(37.5173316, 127.1011661);
+
+        // when
+        SavePlaygroundResponse response = playgroundCommandService.save(request, member.getId());
+
+        // then
+        assertAll(
+                () -> assertThat(response.id()).isEqualTo(1), // todo: 테스트 격리 안되서 id가 틀릴 위험 있음
+                () -> assertThat(response.latitude()).isEqualTo(request.latitude()),
+                () -> assertThat(response.longitude()).isEqualTo(request.longitude())
+        );
+    }
+    // 이미 참여한 놀이터가 있다.
+    // 겹치는 범위안에 놀이터가 있다.
+
+    // 등록하면 자동으로 참가
+}

--- a/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundQueryServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundQueryServiceTest.java
@@ -47,7 +47,7 @@ class PlaygroundQueryServiceTest extends PlaygroundServiceTest {
         );
 
         // when
-        FindPlaygroundDetailResponse response = playgroundQueryService.findDetailById(1L, 1L);
+        FindPlaygroundDetailResponse response = playgroundQueryService.findDetail(1L, 1L);
 
         // then
         assertAll(

--- a/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundQueryServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundQueryServiceTest.java
@@ -7,6 +7,8 @@ import com.happy.friendogly.member.domain.Member;
 import com.happy.friendogly.playground.domain.Playground;
 import com.happy.friendogly.playground.domain.PlaygroundMember;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundDetailResponse;
+import com.happy.friendogly.playground.dto.response.FindPlaygroundLocationResponse;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -56,5 +58,64 @@ class PlaygroundQueryServiceTest extends PlaygroundServiceTest {
                 () -> assertThat(response.arrivedPetCount()).isEqualTo(3),
                 () -> assertThat(response.playgroundPetDetails().size()).isEqualTo(4)
         );
+    }
+
+    @DisplayName("놀이터들의 위치를 조회한다.")
+    @Test
+    void findLocations() {
+        // given
+        double expectedLatitude = 37.5173316;
+        double expectedLongitude = 127.1011661;
+        Playground playground = savePlayground(expectedLatitude, expectedLongitude);
+
+        // when
+        List<FindPlaygroundLocationResponse> response = playgroundQueryService.findLocations(1L);
+
+        // then
+        assertAll(
+                () -> assertThat(response.get(0).latitude()).isEqualTo(expectedLatitude),
+                () -> assertThat(response.get(0).longitude()).isEqualTo(expectedLongitude)
+        );
+    }
+
+    @DisplayName("놀이터들의 위치를 조회할 때, 내가 참여했는 지 알 수있다(true)")
+    @Test
+    void findLocationsWithIsParticipatingTrue() {
+        // given
+        Member member1 = saveMember("member1");
+        savePet(member1);
+
+        Playground playground = savePlayground();
+        playgroundMemberRepository.save(
+                new PlaygroundMember(
+                        playground,
+                        member1,
+                        "message",
+                        false,
+                        null
+                )
+        );
+
+        // when
+        List<FindPlaygroundLocationResponse> response = playgroundQueryService.findLocations(member1.getId());
+
+        // then
+        assertThat(response.get(0).isParticipating()).isEqualTo(true);
+    }
+
+    @DisplayName("놀이터들의 위치를 조회할 때, 내가 참여했는 지 알 수있다(true)")
+    @Test
+    void findLocationsWithIsParticipatingFalse() {
+        // given
+        Member member1 = saveMember("member1");
+        savePet(member1);
+
+        savePlayground();
+
+        // when
+        List<FindPlaygroundLocationResponse> response = playgroundQueryService.findLocations(member1.getId());
+
+        // then
+        assertThat(response.get(0).isParticipating()).isEqualTo(false);
     }
 }

--- a/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundQueryServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundQueryServiceTest.java
@@ -1,0 +1,60 @@
+package com.happy.friendogly.playground.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.happy.friendogly.member.domain.Member;
+import com.happy.friendogly.playground.domain.Playground;
+import com.happy.friendogly.playground.domain.PlaygroundMember;
+import com.happy.friendogly.playground.dto.response.FindPlaygroundDetailResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class PlaygroundQueryServiceTest extends PlaygroundServiceTest {
+
+    @Autowired
+    private PlaygroundQueryService playgroundQueryService;
+
+    @DisplayName("놀이터 상세정보를 조회한다.")
+    @Test
+    void findPlaygroundDetail() {
+        // given
+        Member member1 = saveMember("member1");
+        Member member2 = saveMember("member2");
+        savePet(member1);
+        savePet(member1);
+        savePet(member1);
+        savePet(member2);
+        Playground playground = savePlayground();
+        playgroundMemberRepository.save(
+                new PlaygroundMember(
+                        playground,
+                        member1,
+                        "message",
+                        true,
+                        null
+                )
+        );
+        playgroundMemberRepository.save(
+                new PlaygroundMember(
+                        playground,
+                        member2,
+                        "message",
+                        false,
+                        null
+                )
+        );
+
+        // when
+        FindPlaygroundDetailResponse response = playgroundQueryService.findDetailById(1L, 1L);
+
+        // then
+        assertAll(
+                () -> assertThat(response.id()).isEqualTo(1L),
+                () -> assertThat(response.totalPetCount()).isEqualTo(4),
+                () -> assertThat(response.arrivedPetCount()).isEqualTo(3),
+                () -> assertThat(response.playgroundPetDetails().size()).isEqualTo(4)
+        );
+    }
+}

--- a/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundQueryServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundQueryServiceTest.java
@@ -47,11 +47,11 @@ class PlaygroundQueryServiceTest extends PlaygroundServiceTest {
         );
 
         // when
-        FindPlaygroundDetailResponse response = playgroundQueryService.findDetail(1L, 1L);
+        FindPlaygroundDetailResponse response = playgroundQueryService.findDetail(member1.getId(), playground.getId());
 
         // then
         assertAll(
-                () -> assertThat(response.id()).isEqualTo(1L),
+                () -> assertThat(response.id()).isEqualTo(playground.getId()),
                 () -> assertThat(response.totalPetCount()).isEqualTo(4),
                 () -> assertThat(response.arrivedPetCount()).isEqualTo(3),
                 () -> assertThat(response.playgroundPetDetails().size()).isEqualTo(4)

--- a/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundServiceTest.java
@@ -36,4 +36,10 @@ public abstract class PlaygroundServiceTest extends ServiceTest {
                 new Playground(new Location(37.5173316, 127.1011661))
         );
     }
+
+    protected Playground savePlayground(double latitude, double longitude) {
+        return playgroundRepository.save(
+                new Playground(new Location(latitude, longitude))
+        );
+    }
 }

--- a/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundServiceTest.java
@@ -1,0 +1,39 @@
+package com.happy.friendogly.playground.service;
+
+import com.happy.friendogly.member.domain.Member;
+import com.happy.friendogly.pet.domain.Gender;
+import com.happy.friendogly.pet.domain.Pet;
+import com.happy.friendogly.pet.domain.SizeType;
+import com.happy.friendogly.playground.domain.Location;
+import com.happy.friendogly.playground.domain.Playground;
+import com.happy.friendogly.support.ServiceTest;
+import java.time.LocalDate;
+
+public abstract class PlaygroundServiceTest extends ServiceTest {
+
+    protected Member saveMember(String name) {
+        return memberRepository.save(
+                new Member(name, "tag", "imageurl")
+        );
+    }
+
+    protected Pet savePet(Member member) {
+        return petRepository.save(
+                new Pet(
+                        member,
+                        "petName",
+                        "description",
+                        LocalDate.of(2023, 10, 02),
+                        SizeType.LARGE,
+                        Gender.FEMALE,
+                        "imgaeUrl"
+                )
+        );
+    }
+
+    protected Playground savePlayground() {
+        return playgroundRepository.save(
+                new Playground(new Location(37.5173316, 127.1011661))
+        );
+    }
+}

--- a/backend/src/test/java/com/happy/friendogly/support/ServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/support/ServiceTest.java
@@ -7,6 +7,8 @@ import com.happy.friendogly.footprint.repository.FootprintRepository;
 import com.happy.friendogly.member.repository.MemberRepository;
 import com.happy.friendogly.notification.repository.DeviceTokenRepository;
 import com.happy.friendogly.pet.repository.PetRepository;
+import com.happy.friendogly.playground.repository.PlaygroundMemberRepository;
+import com.happy.friendogly.playground.repository.PlaygroundRepository;
 import java.util.TimeZone;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,6 +41,12 @@ public abstract class ServiceTest {
     protected ChatMessageRepository chatMessageRepository;
 
     @Autowired
+    protected PlaygroundRepository playgroundRepository;
+
+    @Autowired
+    protected PlaygroundMemberRepository playgroundMemberRepository;
+
+    @Autowired
     protected JdbcTemplate jdbcTemplate;
 
     @BeforeAll
@@ -51,6 +59,8 @@ public abstract class ServiceTest {
         jdbcTemplate.update("""
                 SET REFERENTIAL_INTEGRITY FALSE;
                                 
+                DELETE FROM playground_member;
+                DELETE FROM playground;
                 DELETE FROM chat_room;
                 DELETE FROM chat_room_member;
                 DELETE FROM club;

--- a/backend/src/test/java/com/happy/friendogly/utils/GeoCalculatorTest.java
+++ b/backend/src/test/java/com/happy/friendogly/utils/GeoCalculatorTest.java
@@ -1,0 +1,48 @@
+package com.happy.friendogly.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.happy.friendogly.playground.domain.Location;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class GeoCalculatorTest {
+
+    @DisplayName("특정 위도에서 300m 떨어진 위도를 구할 수 있다.")
+    @Test
+    void findFar300mLatitude() {
+        // given
+        double latitude = 37.516382;
+        Location locationA = new Location(latitude, 10);
+
+        // when
+        double calculatedFar300mLatitude = GeoCalculator.calculateLatitudeOffset(latitude, 300);
+        Location locationB = new Location(calculatedFar300mLatitude, 10);
+
+        // then
+        assertAll( // 오차범위가 존재하기 때문에 B가 A기준으로 299안에 없고, 301안에는 있는 것으로 검증하겠다.
+                () -> assertThat(locationA.isWithin(locationB, 299)).isFalse(),
+                () -> assertThat(locationA.isWithin(locationB, 301)).isTrue()
+        );
+    }
+
+    @DisplayName("특정 경도에서 300m 떨어진 경도를 구할 수 있다.")
+    @Test
+    void findFar300mLongitude() {
+        // given
+        double latitude = 37.516382;
+        double longitude = 127.120040;
+        Location locationA = new Location(latitude, longitude);
+
+        // when
+        double calculatedFar300mLongitude = GeoCalculator.calculateLongitudeOffset(latitude, longitude, 300);
+        Location locationB = new Location(latitude, calculatedFar300mLongitude);
+
+        // then
+        assertAll( // 오차범위가 존재하기 때문에 B가 A기준으로 299안에 없고, 301안에는 있는 것으로 검증하겠다.
+                () -> assertThat(locationA.isWithin(locationB, 299)).isFalse(),
+                () -> assertThat(locationA.isWithin(locationB, 301)).isTrue()
+        );
+    }
+}


### PR DESCRIPTION
## 이슈
- close #602 

## 개발 사항
- 놀이터 상세 조회 API 구현
![image](https://github.com/user-attachments/assets/58bb01e0-2d13-4c81-97eb-bc8f13d06354)

## 리뷰 요청 사항
- service를 최대한 짧게 해보려 했으나 비즈니스 로직 상, 더 줄일 수가 없었음. 혹시 방법 떠오르는 사람 있으면 말해주세요
- pet에 대해서는 member수 만큼 N+1터지는데 어쩔 수 없는 부분이겠죠?

## 전달 사항 
- response 응답 값 설명
  - totalPetCount와 arrivedPetCount는 사진상에는 없지만, 왠지 사용할 것 같다고 요청와서 존재하는 필드(피그마에 사용하는 버전 그림도 있음)
  - isParticipating: 참여 여부에 따라,  버튼이 참여하기, 나가기로 다르게 보임
  - PlaygroundPetDetail: 강아지 정보들, 강아지의 상태메세지와 도착유무 또한 있음.
