### PR TITLE
[BE] fix: 채팅방을 나가고 모임을 나가면 예외가 발생하던 버그 수정

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/chat/domain/ChatRoom.java
+++ b/backend/src/main/java/com/happy/friendogly/chat/domain/ChatRoom.java
@@ -68,12 +68,10 @@ public class ChatRoom {
     }
 
     public void removeMember(Member member) {
-        ChatRoomMember chatRoomMember = chatRoomMembers.stream()
+        chatRoomMembers.stream()
                 .filter(row -> row.hasMember(member))
                 .findAny()
-                .orElseThrow(() -> new FriendoglyException("자신이 참여한 채팅방만 나갈 수 있습니다."));
-
-        chatRoomMembers.remove(chatRoomMember);
+                .ifPresent(found -> chatRoomMembers.remove(found));
     }
 
     public boolean containsMember(Member member) {


### PR DESCRIPTION
## 이슈
- close #614 

## 개발 사항
- 채팅방을 나가고 모임을 나가면 예외가 발생하던 버그 수정
- 원인: 모임 나가기에 채팅방 나가기가 포함되어 있음. 근데 채팅방에 참여하지 않았는데 채팅방을 나가려고 시도하면 예외 터짐.
- 해결: 예외 발생 코드를 없앴음. 어차피 채팅방에 참여하고 있지 않으면 아무 데이터도 바뀌지 않기 때문에 의미 없는 검증임.