### PR TITLE
[BE] feat: 강퇴 API 구현

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/club/controller/ClubController.java
+++ b/backend/src/main/java/com/happy/friendogly/club/controller/ClubController.java
@@ -1,6 +1,7 @@
 package com.happy.friendogly.club.controller;
 
 import com.happy.friendogly.auth.Auth;
+import com.happy.friendogly.club.dto.request.DeleteKickedMemberRequest;
 import com.happy.friendogly.club.dto.request.FindClubByFilterRequest;
 import com.happy.friendogly.club.dto.request.SaveClubMemberRequest;
 import com.happy.friendogly.club.dto.request.SaveClubRequest;
@@ -106,4 +107,13 @@ public class ClubController {
         return ResponseEntity.ok(ApiResponse.ofSuccess(response));
     }
 
+    @DeleteMapping("/{clubId}/members/kick")
+    public ResponseEntity<Void> kickMember(
+            @Auth Long memberId,
+            @PathVariable Long clubId,
+            @RequestBody DeleteKickedMemberRequest request
+    ) {
+        clubCommandService.kickMember(clubId, memberId, request);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/backend/src/main/java/com/happy/friendogly/club/dto/request/DeleteKickedMemberRequest.java
+++ b/backend/src/main/java/com/happy/friendogly/club/dto/request/DeleteKickedMemberRequest.java
@@ -1,0 +1,10 @@
+package com.happy.friendogly.club.dto.request;
+
+import jakarta.validation.constraints.Positive;
+
+public record DeleteKickedMemberRequest(
+        @Positive(message = "강퇴 대상인 회원ID 필수입니다.")
+        Long kickedMemberId
+) {
+
+}

--- a/backend/src/main/java/com/happy/friendogly/club/dto/request/DeleteKickedMemberRequest.java
+++ b/backend/src/main/java/com/happy/friendogly/club/dto/request/DeleteKickedMemberRequest.java
@@ -1,9 +1,11 @@
 package com.happy.friendogly.club.dto.request;
 
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
 public record DeleteKickedMemberRequest(
-        @Positive(message = "강퇴 대상인 회원ID 필수입니다.")
+        @NotNull(message = "강퇴 대상인 회원ID 필수입니다.")
+        @Positive(message = "회원ID는 양수 입니다.")
         Long kickedMemberId
 ) {
 

--- a/backend/src/main/java/com/happy/friendogly/club/service/ClubCommandService.java
+++ b/backend/src/main/java/com/happy/friendogly/club/service/ClubCommandService.java
@@ -3,6 +3,7 @@ package com.happy.friendogly.club.service;
 
 import com.happy.friendogly.chat.service.ChatCommandService;
 import com.happy.friendogly.club.domain.Club;
+import com.happy.friendogly.club.dto.request.DeleteKickedMemberRequest;
 import com.happy.friendogly.club.dto.request.SaveClubMemberRequest;
 import com.happy.friendogly.club.dto.request.SaveClubRequest;
 import com.happy.friendogly.club.dto.request.UpdateClubRequest;
@@ -119,5 +120,22 @@ public class ClubCommandService {
             return new UpdateClubResponse(club);
         }
         throw new FriendoglyException("수정 권한이 없습니다.", HttpStatus.FORBIDDEN);
+    }
+
+    public void kickMember(Long clubId, Long memberId, DeleteKickedMemberRequest request) {
+        Club club = clubRepository.getById(clubId);
+        Member member = memberRepository.getById(memberId);
+        Member kickedMember = memberRepository.getById(request.kickedMemberId());
+        validateKick(club, kickedMember, member);
+        club.removeClubMember(kickedMember);
+    }
+
+    private void validateKick(Club club, Member owner, Member kickedMember) {
+        if (club.isOwner(kickedMember)) {
+            throw new FriendoglyException("자기 자신은 강퇴할 수 없습니다.");
+        }
+        if (!club.isOwner(owner)) {
+            throw new FriendoglyException("강퇴 권한이 없습니다.", HttpStatus.FORBIDDEN);
+        }
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/club/service/ClubCommandService.java
+++ b/backend/src/main/java/com/happy/friendogly/club/service/ClubCommandService.java
@@ -126,7 +126,7 @@ public class ClubCommandService {
         Club club = clubRepository.getById(clubId);
         Member member = memberRepository.getById(memberId);
         Member kickedMember = memberRepository.getById(request.kickedMemberId());
-        validateKick(club, kickedMember, member);
+        validateKick(club, member, kickedMember);
         club.removeClubMember(kickedMember);
         club.removeChatRoomMember(member);
     }

--- a/backend/src/main/java/com/happy/friendogly/club/service/ClubCommandService.java
+++ b/backend/src/main/java/com/happy/friendogly/club/service/ClubCommandService.java
@@ -131,11 +131,11 @@ public class ClubCommandService {
         club.removeChatRoomMember(member);
     }
 
-    private void validateKick(Club club, Member owner, Member kickedMember) {
+    private void validateKick(Club club, Member owner, Member memberToKick) {
         if (!club.isOwner(owner)) {
             throw new FriendoglyException("강퇴 권한이 없습니다.", HttpStatus.FORBIDDEN);
         }
-        if (club.isOwner(kickedMember)) {
+        if (club.isOwner(memberToKick)) {
             throw new FriendoglyException("자기 자신은 강퇴할 수 없습니다.");
         }
     }

--- a/backend/src/main/java/com/happy/friendogly/club/service/ClubCommandService.java
+++ b/backend/src/main/java/com/happy/friendogly/club/service/ClubCommandService.java
@@ -128,6 +128,7 @@ public class ClubCommandService {
         Member kickedMember = memberRepository.getById(request.kickedMemberId());
         validateKick(club, kickedMember, member);
         club.removeClubMember(kickedMember);
+        club.removeChatRoomMember(member);
     }
 
     private void validateKick(Club club, Member owner, Member kickedMember) {

--- a/backend/src/main/java/com/happy/friendogly/club/service/ClubCommandService.java
+++ b/backend/src/main/java/com/happy/friendogly/club/service/ClubCommandService.java
@@ -135,7 +135,8 @@ public class ClubCommandService {
         if (!club.isOwner(owner)) {
             throw new FriendoglyException("강퇴 권한이 없습니다.", HttpStatus.FORBIDDEN);
         }
-        if (club.isOwner(memberToKick)) {
+        //TODO: member Method로 위임
+        if (owner.getId().equals(memberToKick.getId())) {
             throw new FriendoglyException("자기 자신은 강퇴할 수 없습니다.");
         }
     }

--- a/backend/src/main/java/com/happy/friendogly/club/service/ClubCommandService.java
+++ b/backend/src/main/java/com/happy/friendogly/club/service/ClubCommandService.java
@@ -132,11 +132,11 @@ public class ClubCommandService {
     }
 
     private void validateKick(Club club, Member owner, Member kickedMember) {
-        if (club.isOwner(kickedMember)) {
-            throw new FriendoglyException("자기 자신은 강퇴할 수 없습니다.");
-        }
         if (!club.isOwner(owner)) {
             throw new FriendoglyException("강퇴 권한이 없습니다.", HttpStatus.FORBIDDEN);
+        }
+        if (club.isOwner(kickedMember)) {
+            throw new FriendoglyException("자기 자신은 강퇴할 수 없습니다.");
         }
     }
 }

--- a/backend/src/test/java/com/happy/friendogly/club/service/ClubCommandServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/club/service/ClubCommandServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.happy.friendogly.club.domain.Club;
+import com.happy.friendogly.club.dto.request.DeleteKickedMemberRequest;
 import com.happy.friendogly.club.dto.request.SaveClubMemberRequest;
 import com.happy.friendogly.club.dto.request.SaveClubRequest;
 import com.happy.friendogly.club.dto.request.UpdateClubRequest;
@@ -259,7 +260,7 @@ class ClubCommandServiceTest extends ClubServiceTest {
 
     @DisplayName("Full 상태에서 회원이 모임에서 탈퇴하면 Open으로 바꾼다.")
     @Test
-    void deleteClubMember_WhenFull(){
+    void deleteClubMember_WhenFull() {
         Club club = Club.create(
                 "강아지 산책시키실 분 모아요.",
                 "매주 주말에 정기적으로 산책 모임하실분만",
@@ -329,5 +330,67 @@ class ClubCommandServiceTest extends ClubServiceTest {
         assertThatThrownBy(() -> clubCommandService.update(club.getId(), savedMember2.getId(), request))
                 .isInstanceOf(FriendoglyException.class)
                 .hasMessage("수정 권한이 없습니다.");
+    }
+
+    @DisplayName("모임에서 강퇴한다.")
+    @Transactional
+    @Test
+    void kickMember() {
+        Club club = createSavedClub(
+                savedMember,
+                List.of(savedPet),
+                Set.of(Gender.FEMALE, Gender.FEMALE_NEUTERED, Gender.MALE, Gender.MALE_NEUTERED),
+                Set.of(SizeType.SMALL)
+        );
+        //member2 참여
+        Member savedMember2 = createSavedMember();
+        Pet savedPet2 = createSavedPet(savedMember2);
+        clubCommandService.joinClub(club.getId(), savedMember2.getId(),
+                new SaveClubMemberRequest(List.of(savedPet2.getId())));
+        //member3 참여
+        Member savedMember3 = createSavedMember();
+        Pet savedPet3 = createSavedPet(savedMember3);
+        clubCommandService.joinClub(club.getId(), savedMember3.getId(),
+                new SaveClubMemberRequest(List.of(savedPet3.getId())));
+
+        DeleteKickedMemberRequest request = new DeleteKickedMemberRequest(savedMember2.getId());
+        clubCommandService.kickMember(club.getId(), savedMember.getId(), request);
+
+        List<Member> actual = club.getClubMembers().stream()
+                .map(clubMember -> clubMember.getClubMemberId().getMember())
+                .toList();
+
+        assertAll(
+                () -> assertThat(actual).hasSize(2),
+                () -> assertThat(actual.contains(savedMember2)).isFalse()
+        );
+    }
+
+    @DisplayName("모임에서 강퇴한다.")
+    @Transactional
+    @Test
+    void kickMember_FailForbidden() {
+        Club club = createSavedClub(
+                savedMember,
+                List.of(savedPet),
+                Set.of(Gender.FEMALE, Gender.FEMALE_NEUTERED, Gender.MALE, Gender.MALE_NEUTERED),
+                Set.of(SizeType.SMALL)
+        );
+        //member2 참여
+        Member savedMember2 = createSavedMember();
+        Pet savedPet2 = createSavedPet(savedMember2);
+        clubCommandService.joinClub(club.getId(), savedMember2.getId(),
+                new SaveClubMemberRequest(List.of(savedPet2.getId())));
+        //member3 참여
+        Member savedMember3 = createSavedMember();
+        Pet savedPet3 = createSavedPet(savedMember3);
+        clubCommandService.joinClub(club.getId(), savedMember3.getId(),
+                new SaveClubMemberRequest(List.of(savedPet3.getId())));
+
+        DeleteKickedMemberRequest request = new DeleteKickedMemberRequest(savedMember2.getId());
+
+        assertThatThrownBy(() ->clubCommandService.kickMember(club.getId(), savedMember2.getId(), request))
+                .isInstanceOf(FriendoglyException.class)
+                .hasMessage("강퇴 권한이 없습니다.");
     }
 }

--- a/backend/src/test/java/com/happy/friendogly/club/service/ClubCommandServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/club/service/ClubCommandServiceTest.java
@@ -366,7 +366,7 @@ class ClubCommandServiceTest extends ClubServiceTest {
         );
     }
 
-    @DisplayName("모임에서 강퇴한다.")
+    @DisplayName("강퇴 권한이 없으면 예외가 발생한다.")
     @Transactional
     @Test
     void kickMember_FailForbidden() {

--- a/backend/src/test/java/com/happy/friendogly/docs/ClubApiDocsTest.java
+++ b/backend/src/test/java/com/happy/friendogly/docs/ClubApiDocsTest.java
@@ -680,7 +680,7 @@ public class ClubApiDocsTest extends RestDocsTest {
     @DisplayName("모임 방장이 특정 회원을 강퇴한다.")
     @Test
     void kick_204() throws Exception {
-        DeleteKickedMemberRequest request = new DeleteKickedMemberRequest( 2L);
+        DeleteKickedMemberRequest request = new DeleteKickedMemberRequest(2L);
         doNothing()
                 .when(clubCommandService)
                 .kickMember(1L, 1L, request);
@@ -712,7 +712,7 @@ public class ClubApiDocsTest extends RestDocsTest {
     @DisplayName("방장 권한이 없으면 403을 응답한다.")
     @Test
     void kick_403() throws Exception {
-        DeleteKickedMemberRequest request = new DeleteKickedMemberRequest( 2L);
+        DeleteKickedMemberRequest request = new DeleteKickedMemberRequest(2L);
         doThrow(new FriendoglyException("강퇴 권한이 없습니다.", HttpStatus.FORBIDDEN))
                 .when(clubCommandService)
                 .kickMember(1L, 1L, request);

--- a/backend/src/test/java/com/happy/friendogly/docs/ClubApiDocsTest.java
+++ b/backend/src/test/java/com/happy/friendogly/docs/ClubApiDocsTest.java
@@ -26,6 +26,7 @@ import com.epages.restdocs.apispec.SimpleType;
 import com.happy.friendogly.club.controller.ClubController;
 import com.happy.friendogly.club.domain.FilterCondition;
 import com.happy.friendogly.club.domain.Status;
+import com.happy.friendogly.club.dto.request.DeleteKickedMemberRequest;
 import com.happy.friendogly.club.dto.request.FindClubByFilterRequest;
 import com.happy.friendogly.club.dto.request.SaveClubMemberRequest;
 import com.happy.friendogly.club.dto.request.SaveClubRequest;
@@ -672,6 +673,71 @@ public class ClubApiDocsTest extends RestDocsTest {
                                 )
                                 .requestSchema(Schema.schema("UpdateClubRequest"))
                                 .responseSchema(Schema.schema("UpdateClubResponse"))
+                                .build())
+                ));
+    }
+
+    @DisplayName("모임 방장이 특정 회원을 강퇴한다.")
+    @Test
+    void kick_204() throws Exception {
+        DeleteKickedMemberRequest request = new DeleteKickedMemberRequest( 2L);
+        doNothing()
+                .when(clubCommandService)
+                .kickMember(1L, 1L, request);
+
+        mockMvc.perform(delete("/clubs/{clubId}/members/kick", 1L)
+                        .header(HttpHeaders.AUTHORIZATION, getMemberToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent())
+                .andDo(document("clubs/{clubId}/members/kick/204",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Club API")
+                                .summary("모임 강퇴 API")
+                                .requestHeaders(
+                                        headerWithName(HttpHeaders.AUTHORIZATION).description("로그인한 회원의 access token")
+                                )
+                                .pathParameters(
+                                        parameterWithName("clubId").description("모임 Id")
+                                )
+                                .requestFields(
+                                        fieldWithPath("kickedMemberId").type(JsonFieldType.NUMBER).description("강퇴 대상 회원 Id")
+                                )
+                                .build())
+                ));
+    }
+
+    @DisplayName("방장 권한이 없으면 403을 응답한다.")
+    @Test
+    void kick_403() throws Exception {
+        DeleteKickedMemberRequest request = new DeleteKickedMemberRequest( 2L);
+        doThrow(new FriendoglyException("강퇴 권한이 없습니다.", HttpStatus.FORBIDDEN))
+                .when(clubCommandService)
+                .kickMember(1L, 1L, request);
+
+
+        mockMvc.perform(delete("/clubs/{clubId}/members/kick", 1L)
+                        .header(HttpHeaders.AUTHORIZATION, getMemberToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden())
+                .andDo(document("clubs/{clubId}/members/kick/403",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Club API")
+                                .summary("모임 강퇴 API")
+                                .requestHeaders(
+                                        headerWithName(HttpHeaders.AUTHORIZATION).description("로그인한 회원의 access token")
+                                )
+                                .pathParameters(
+                                        parameterWithName("clubId").description("모임 Id")
+                                )
+                                .requestFields(
+                                        fieldWithPath("kickedMemberId").type(JsonFieldType.NUMBER).description("강퇴 대상 회원 Id")
+                                )
                                 .build())
                 ));
     }

--- a/backend/src/test/java/com/happy/friendogly/support/ServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/support/ServiceTest.java
@@ -73,6 +73,7 @@ public abstract class ServiceTest {
                 DELETE FROM kakao_member;
                 DELETE FROM member;
                 DELETE FROM pet;
+                DELETE FROM chat_message;
                                 
                 SET REFERENTIAL_INTEGRITY TRUE;
                 """);


### PR DESCRIPTION
## 이슈
- close #556

## 개발 사항
- 모임 강퇴 API 구현했습니다.
- 방장이 아니면 403, 자기 자신을 강퇴하려고 하면 예외처리를 추가했어요.

