### PR TITLE
[AN] feat: 앱 이미지 저장 최적화

### DIFF
--- a/android/app/src/main/java/com/happy/friendogly/presentation/utils/BitmapUtil.kt
+++ b/android/app/src/main/java/com/happy/friendogly/presentation/utils/BitmapUtil.kt
@@ -23,11 +23,17 @@ fun saveBitmapToFile(
     if (!directory.exists()) {
         directory.mkdirs()
     }
-    val file = File(directory, "image.jpg")
-    val outputStream = FileOutputStream(file)
-    bitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
-    outputStream.flush()
-    outputStream.close()
+    val file = File(directory, "image.webp")
+    FileOutputStream(file).use { outputStream ->
+        val format =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                Bitmap.CompressFormat.WEBP_LOSSLESS
+            } else {
+                Bitmap.CompressFormat.JPEG
+            }
+        bitmap.compress(format, 100, outputStream)
+    }
+
     return file
 }
 
@@ -44,6 +50,4 @@ fun Uri.toBitmap(context: Context): Bitmap =
         ImageDecoder.decodeBitmap(source)
     }
 
-fun Bitmap.toSoftwareBitmap(): Bitmap {
-    return copy(Bitmap.Config.ARGB_8888, true)
-}
+fun Bitmap.toSoftwareBitmap(): Bitmap = copy(Bitmap.Config.ARGB_8888, true)

--- a/android/app/src/main/java/com/happy/friendogly/presentation/utils/BitmapUtil.kt
+++ b/android/app/src/main/java/com/happy/friendogly/presentation/utils/BitmapUtil.kt
@@ -50,4 +50,9 @@ fun Uri.toBitmap(context: Context): Bitmap =
         ImageDecoder.decodeBitmap(source)
     }
 
-fun Bitmap.toSoftwareBitmap(): Bitmap = copy(Bitmap.Config.ARGB_8888, true)
+fun Bitmap.toSoftwareBitmap(): Bitmap =
+    if (config == Bitmap.Config.ARGB_8888) {
+        this
+    } else {
+        copy(Bitmap.Config.ARGB_8888, true)
+    }


### PR DESCRIPTION
## 이슈
- close #144

## 개발 사항
- JPEG 파일을 WEBP 포맷으로 변경

## 전달 사항
- JPEG: 손실 압축 포맷으로, 이미지 품질을 조금 희생하면서 파일 크기를 줄입니다. 주로 사진이나 복잡한 이미지에 사용됩니다.
- PNG: 무손실 압축 포맷으로, 이미지 품질을 그대로 유지하면서도 파일 크기를 줄입니다. 투명한 배경을 가진 이미지에 자주 사용됩니다.
- WEBP_LOSSY: 손실 압축을 사용하는 WebP 포맷입니다. JPEG와 유사한 방식으로 이미지 품질을 약간 잃지만 더 작은 파일 크기를 얻습니다.
- WEBP_LOSSLESS: 무손실 압축을 사용하는 WebP 포맷으로, 이미지 품질을 완전히 유지합니다. PNG와 유사한 용도로 사용됩니다.

직접 촬영한 이미지와 웹에서 다운로드한 이미지를 비교한 결과는 다음과 같습니다

### 직접 촬영한 이미지
- WEBP_LOSSLESS : 4MB
- WEBP_LOSSY : 1MB
- JPEG : 2MB
- PNG : 5MB

### 웹 다운로드 이미지
- WEBP_LOSSLESS : 295510B
- WEBP_LOSSY : 103954B
- JPEG : 147763B
- PNG : 403697B

현재 반갑개 서비스 환경에서는 고화질 이미지보다 크기를 줄이는 것이 우선순위가 높다고 판단하여 `WEBP_LOSSY`로 압축 포맷을 선택했습니다.
