### PR TITLE
[BE] fix: 이미지 용량 제한을 5MB로 설정

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/infra/S3StorageManager.java
+++ b/backend/src/main/java/com/happy/friendogly/infra/S3StorageManager.java
@@ -29,7 +29,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 public class S3StorageManager implements FileStorageManager {
 
     private static final String IMAGE_MIME_TYPE_PREFIX = "image/";
-    private static final int FILE_SIZE_LIMIT = 1;
+    private static final int FILE_SIZE_LIMIT = 5;
     private static final int MB = 1_048_576;
 
     @Value("${aws.s3.bucket-name}")

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 spring:
   servlet:
     multipart:
-      max-file-size: 6MB
-      max-request-size: 6MB
+      max-file-size: 5MB
+      max-request-size: 5MB
   jpa:
     defer-datasource-initialization: true
   application:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,4 +1,8 @@
 spring:
+  servlet:
+    multipart:
+      max-file-size: 6MB
+      max-request-size: 6MB
   jpa:
     defer-datasource-initialization: true
   application:


### PR DESCRIPTION
## 이슈
- close #641 

## 개발 사항
- (기존) 1MB 초과하는 이미지 업로드 불가
- (변경) 5MB 초과하는 이미지 업로드 불가

## 전달 사항 (없으면 삭제해 주세요)
- prod-a, prod-b, dev에서 nginx 설정 및 restart 완료했습니다! 설정 방법은 #641  참고
- **용량 제한 설정값: nginx 10MB, Spring 5MB, 서비스 코드 5MB**