### PR TITLE
[BE] hotfix: 채팅 API 삭제로 인해 버그 발생하던 문제 해결

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/chat/controller/ChatSocketController.java
+++ b/backend/src/main/java/com/happy/friendogly/chat/controller/ChatSocketController.java
@@ -48,6 +48,15 @@ public class ChatSocketController {
         );
     }
 
+    @Deprecated
+    @MessageMapping("/enter/{chatRoomId}")
+    public void enter(
+            @WebSocketAuth Long memberId,
+            @DestinationVariable(value = "chatRoomId") Long chatRoomId
+    ) {
+        chatCommandService.sendEnter(memberId, chatRoomId);
+    }
+
     @MessageMapping("/chat/{chatRoomId}")
     public void sendMessage(
             @WebSocketAuth Long memberId,
@@ -55,6 +64,15 @@ public class ChatSocketController {
             @Payload ChatMessageSocketRequest request
     ) {
         chatCommandService.sendChat(memberId, chatRoomId, request);
+    }
+
+    @Deprecated
+    @MessageMapping("/leave/{chatRoomId}")
+    public void leave(
+            @WebSocketAuth Long memberId,
+            @DestinationVariable(value = "chatRoomId") Long chatRoomId
+    ) {
+        chatCommandService.sendLeave(memberId, chatRoomId);
     }
 
     @MessageExceptionHandler
@@ -65,23 +83,5 @@ public class ChatSocketController {
                 Collections.emptyList()
         );
         return new ResponseEntity<>(ApiResponse.ofError(errorResponse), exception.getHttpStatus());
-    }
-
-    // TODO: 다음 릴리즈에서 제거한다.
-    @MessageMapping("/enter/{chatRoomId}")
-    public void enter(
-            @WebSocketAuth Long memberId,
-            @DestinationVariable(value = "chatRoomId") Long chatRoomId
-    ) {
-        chatCommandService.sendEnter(memberId, chatRoomId);
-    }
-
-    // TODO: 다음 릴리즈에서 제거한다.
-    @MessageMapping("/leave/{chatRoomId}")
-    public void leave(
-            @WebSocketAuth Long memberId,
-            @DestinationVariable(value = "chatRoomId") Long chatRoomId
-    ) {
-        chatCommandService.sendLeave(memberId, chatRoomId);
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/chat/controller/ChatSocketController.java
+++ b/backend/src/main/java/com/happy/friendogly/chat/controller/ChatSocketController.java
@@ -66,4 +66,22 @@ public class ChatSocketController {
         );
         return new ResponseEntity<>(ApiResponse.ofError(errorResponse), exception.getHttpStatus());
     }
+
+    // TODO: 다음 릴리즈에서 제거한다.
+    @MessageMapping("/enter/{chatRoomId}")
+    public void enter(
+            @WebSocketAuth Long memberId,
+            @DestinationVariable(value = "chatRoomId") Long chatRoomId
+    ) {
+        chatCommandService.sendEnter(memberId, chatRoomId);
+    }
+
+    // TODO: 다음 릴리즈에서 제거한다.
+    @MessageMapping("/leave/{chatRoomId}")
+    public void leave(
+            @WebSocketAuth Long memberId,
+            @DestinationVariable(value = "chatRoomId") Long chatRoomId
+    ) {
+        chatCommandService.sendLeave(memberId, chatRoomId);
+    }
 }


### PR DESCRIPTION
## 이슈
- close #699 

## 개발 사항
- prod 환경에 채팅
- https://github.com/woowacourse-teams/2024-friendogly/pull/555 에서 작업한 내용이 prod로 올라가면서 API가 사라져버려 채팅이 되지 않고 있음
- 버전 대응 신경쓰면서 개발해야겠네요 ...  😭 