### PR TITLE
[BE] 모임 예외 처리 추가

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/club/domain/Club.java
+++ b/backend/src/main/java/com/happy/friendogly/club/domain/Club.java
@@ -147,7 +147,7 @@ public class Club {
 
     public void addClubMember(Member member) {
         validateAlreadyExists(member);
-        validateMemberCapacity();
+        validateStatus();
 
         ClubMember clubMember = ClubMember.create(this, member);
         clubMembers.add(clubMember);
@@ -167,9 +167,9 @@ public class Club {
                 .anyMatch(clubMember -> clubMember.isSameMember(member));
     }
 
-    private void validateMemberCapacity() {
-        if (memberCapacity.isCapacityReached(countClubMember())) {
-            throw new FriendoglyException("최대 인원을 초과하여 모임에 참여할 수 없습니다.");
+    private void validateStatus() {
+        if (status.isFull() || status.isClosed()) {
+            throw new FriendoglyException("최대 인원을 초과했거나, 더이상 모임에 참여할 수 없는 상태입니다.");
         }
     }
 

--- a/backend/src/main/java/com/happy/friendogly/club/domain/Club.java
+++ b/backend/src/main/java/com/happy/friendogly/club/domain/Club.java
@@ -267,8 +267,8 @@ public class Club {
     }
 
     private void updateStatus(String status) {
-        if (this.status.isFull()) {
-            return;
+        if (this.status.isFull() && Status.toStatus(status).isOpen()) {
+            throw new FriendoglyException("인원이 가득찬 모임은 다시 OPEN 상태로 변경할 수 없습니다.");
         }
         this.status = Status.toStatus(status);
     }

--- a/backend/src/main/java/com/happy/friendogly/club/domain/Status.java
+++ b/backend/src/main/java/com/happy/friendogly/club/domain/Status.java
@@ -16,10 +16,14 @@ public enum Status {
     }
 
     public boolean isOpen() {
-        return this == Status.OPEN;
+        return this == OPEN;
+    }
+
+    public boolean isClosed() {
+        return this == CLOSED;
     }
 
     public boolean isFull() {
-        return this == Status.FULL;
+        return this == FULL;
     }
 }

--- a/backend/src/test/java/com/happy/friendogly/club/domain/ClubTest.java
+++ b/backend/src/test/java/com/happy/friendogly/club/domain/ClubTest.java
@@ -1,0 +1,45 @@
+package com.happy.friendogly.club.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.happy.friendogly.exception.FriendoglyException;
+import com.happy.friendogly.member.domain.Member;
+import com.happy.friendogly.pet.domain.Gender;
+import com.happy.friendogly.pet.domain.Pet;
+import com.happy.friendogly.pet.domain.SizeType;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class ClubTest {
+
+    private Member member = new Member("member", "1dfhf993", "imageUrl");
+    private Pet pet = new Pet(member, "뚱땡이", "설명", LocalDate.now().minusDays(1L), SizeType.SMALL, Gender.FEMALE, "imageUrl");
+
+    @DisplayName("인원이 가득찬 모임 상태를 OPEN으로 변경하면 예외가 발생한다.")
+    @Test
+    void update_FullToOpen_Fail() {
+        Club club = Club.create(
+                "title",
+                "content",
+                "서울특별시",
+                "송파구",
+                "신천동",
+                1,  // 정원 1명, 방장이 인원에 포함되므로, 모임 생성과 동시에 정원이 가득 참
+                member,
+                Arrays.stream(Gender.values()).collect(Collectors.toSet()),
+                Arrays.stream(SizeType.values()).collect(Collectors.toSet()),
+                "imageUrl",
+                List.of(pet)
+        );
+
+        assertThat(club.getStatus()).isEqualTo(Status.FULL);
+        assertThatThrownBy(() -> club.update("title", "content", Status.OPEN.name()))
+                .isExactlyInstanceOf(FriendoglyException.class)
+                .hasMessage("인원이 가득찬 모임은 다시 OPEN 상태로 변경할 수 없습니다.");
+    }
+}


### PR DESCRIPTION
## 이슈
- close #674 
- close #578 

## 개발 사항
- club status가 FULL일 때 OPEN으로 변경할 수 없도록 수정
- club 참여 시 status 검증 추가

## 전달 사항
- 일관성을 위해, 정원이 가득찬 모임인지 여부 판별 시 clubMember size 대신 status를 사용하도록 변경했습니다.
