### PR TITLE
[BE] fix: 정원이 가득 찬 모임 상태를 OPEN으로 변경 가능한 현상 수정

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/club/domain/Club.java
+++ b/backend/src/main/java/com/happy/friendogly/club/domain/Club.java
@@ -267,7 +267,7 @@ public class Club {
     }
 
     private void updateStatus(String status) {
-        if (this.status.isFull() && Status.toStatus(status).isOpen()) {
+        if (memberCapacity.isCapacityReached(countClubMember()) && Status.toStatus(status).isOpen()) {
             throw new FriendoglyException("인원이 가득찬 모임은 다시 OPEN 상태로 변경할 수 없습니다.");
         }
         this.status = Status.toStatus(status);


### PR DESCRIPTION
## 이슈
- close #709 

## 개발 사항
- 정원이 가득 찬 모임 상태를 OPEN으로 변경 가능한 현상 수정

## 전달 사항
- 현재 status로만 검증을 하고 있었기 때문에, 인원이 가득 찬 상태에서 FULL -> CLOSED -> OPEN으로 변경할 수 있었음