### PR TITLE
[BE] chore: 존재하지 않는 경로로 요청 왔을 때, 예외 메시지만 로깅

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/happy/friendogly/GlobalExceptionHandler.java
@@ -88,7 +88,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(NoResourceFoundException.class)
     public ResponseEntity<ApiResponse<ErrorResponse>> handle(NoResourceFoundException exception) {
-        log.warn(exception.getMessage(), exception);
+        log.warn(exception.getMessage());
 
         ErrorResponse errorResponse = new ErrorResponse(
                 ErrorCode.DEFAULT_ERROR_CODE,


### PR DESCRIPTION
## 이슈
- close #727 

## 개발 사항
- 존재하지 않는 경로로 요청이 들어오면 stack trace를 모두 로깅하고 있어서 로그 확인이 어려움
- 예외 메시지만 로깅해서 어떤 경로로 공격을 시도했는지만 파악하도록 수정
