### PR TITLE
[AN] test : 클럽 필터 로직 테스트

### DIFF
--- a/android/app/src/main/java/com/happy/friendogly/presentation/ui/club/common/model/ClubFilterSelector.kt
+++ b/android/app/src/main/java/com/happy/friendogly/presentation/ui/club/common/model/ClubFilterSelector.kt
@@ -6,7 +6,7 @@ import com.happy.friendogly.presentation.ui.club.common.model.clubfilter.ClubFil
 
 class ClubFilterSelector {
     private val _currentSelectedFilters: MutableLiveData<List<ClubFilter>> =
-        MutableLiveData()
+        MutableLiveData(emptyList())
     val currentSelectedFilters: LiveData<List<ClubFilter>> get() = _currentSelectedFilters
 
     fun addClubFilter(filter: ClubFilter) {

--- a/android/app/src/test/java/com/happy/friendogly/presentation/ui/club/common/model/ClubFilterSelectorTest.kt
+++ b/android/app/src/test/java/com/happy/friendogly/presentation/ui/club/common/model/ClubFilterSelectorTest.kt
@@ -1,0 +1,177 @@
+package com.happy.friendogly.presentation.ui.club.common.model
+
+import com.happy.friendogly.presentation.ui.club.common.model.clubfilter.ClubFilter
+import com.happy.friendogly.utils.InstantTaskExecutorExtension
+import com.happy.friendogly.utils.getOrAwaitValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(InstantTaskExecutorExtension::class)
+class ClubFilterSelectorTest {
+
+    private lateinit var clubFilterSelector: ClubFilterSelector
+
+    @BeforeEach
+    fun setUp() {
+        clubFilterSelector = ClubFilterSelector()
+    }
+
+    @Test
+    fun `필터를 추가하면 ClubFilterSelector에 해당 필터가 추가되어야 한다`() {
+        clubFilterSelector = ClubFilterSelector()
+        // given
+        val filter = ClubFilter.GenderFilter.Male
+
+        // when
+        clubFilterSelector.addClubFilter(filter)
+        val actualFilter = clubFilterSelector.currentSelectedFilters.getOrAwaitValue()
+
+        //then
+        assertThat(actualFilter.firstOrNull()).isEqualTo(filter)
+    }
+
+    @Test
+    fun `이미 추가 된 필터가 있다면 해당 필터는 추가되지 않아야 한다`() {
+        clubFilterSelector = ClubFilterSelector()
+        // given
+        val filter = ClubFilter.GenderFilter.Male
+        clubFilterSelector.addClubFilter(filter)
+
+        // when
+        clubFilterSelector.addClubFilter(filter)
+        val actualFilter = clubFilterSelector.currentSelectedFilters.getOrAwaitValue()
+
+        //then
+        assertThat(
+            actualFilter.count { it.filterName == filter.filterName }
+        ).isEqualTo(1)
+    }
+
+    @Test
+    fun `여러 필터를 추가하면 ClubFilterSelector에 모든 필터가 추가되어야 한다`() {
+        // given
+        val filter1 = ClubFilter.GenderFilter.Male
+        val filter2 = ClubFilter.SizeFilter.SmallDog
+
+        // when
+        clubFilterSelector.addClubFilter(filter1)
+        clubFilterSelector.addClubFilter(filter2)
+        val actualFilters = clubFilterSelector.currentSelectedFilters.getOrAwaitValue()
+
+        // then
+        assertThat(actualFilters).containsExactlyInAnyOrder(filter1, filter2)
+    }
+
+    @Test
+    fun `필터를 제거하면 해당 필터는 ClubFilterSelector에서 삭제되어야 한다`() {
+        // given
+        val filter = ClubFilter.GenderFilter.Male
+        clubFilterSelector.addClubFilter(filter)
+
+        // when
+        clubFilterSelector.removeClubFilter(filter)
+        val actualFilters = clubFilterSelector.currentSelectedFilters.getOrAwaitValue()
+
+        // then
+        assertThat(actualFilters).doesNotContain(filter)
+    }
+
+    @Test
+    fun `필터 목록을 초기화하면 주어진 필터들로 초기화되어야 한다`() {
+        // given
+        val filter1 = ClubFilter.GenderFilter.Male
+        val filter2 = ClubFilter.SizeFilter.SmallDog
+        val filtersToInit = listOf(filter1, filter2)
+
+        // when
+        clubFilterSelector.initClubFilter(filtersToInit)
+        val actualFilters = clubFilterSelector.currentSelectedFilters.getOrAwaitValue()
+
+        // then
+        assertThat(actualFilters).containsExactlyInAnyOrder(filter1, filter2)
+    }
+
+    @Test
+    fun `Gender 필터를 선택하면 해당 필터들만 반환되어야 한다`() {
+        // given
+        val filter1 = ClubFilter.GenderFilter.Male
+        val filter2 = ClubFilter.SizeFilter.SmallDog
+        clubFilterSelector.addClubFilter(filter1)
+        clubFilterSelector.addClubFilter(filter2)
+
+        // when
+        val genderFilters = clubFilterSelector.selectGenderFilters()
+
+        // then
+        assertThat(genderFilters).containsExactly(ClubFilter.GenderFilter.Male)
+    }
+
+    @Test
+    fun `Size 필터를 선택하면 해당 필터들만 반환되어야 한다`() {
+        // given
+        val filter1 = ClubFilter.GenderFilter.Male
+        val filter2 = ClubFilter.SizeFilter.SmallDog
+        clubFilterSelector.addClubFilter(filter1)
+        clubFilterSelector.addClubFilter(filter2)
+
+        // when
+        val sizeFilters = clubFilterSelector.selectSizeFilters()
+
+        // then
+        assertThat(sizeFilters).containsExactly(ClubFilter.SizeFilter.SmallDog)
+    }
+
+    @Test
+    fun `선택 된 GenderFilter가 있다면, GenderFilter를 확인하는 로직은 true를 반환해야 한다`() {
+        // given
+        clubFilterSelector.addClubFilter(ClubFilter.GenderFilter.Male)
+
+        // when
+        val containsGenderFilter = clubFilterSelector.isContainGenderFilter()
+
+        // then
+        assertThat(containsGenderFilter).isTrue()
+    }
+
+    @Test
+    fun `선택 된 GenderFilter가 없다면, GenderFilter를 확인하는 로직은 false를 반환해야 한다`() {
+        // given
+        clubFilterSelector.addClubFilter(ClubFilter.SizeFilter.SmallDog)
+
+        // when
+        val containsGenderFilter = clubFilterSelector.isContainGenderFilter()
+
+        // then
+        assertThat(containsGenderFilter).isFalse()
+    }
+
+    @Test
+    fun `선택 된 SizeFilter가 있다면, SizeFilter를 확인하는 로직은 true를 반환해야 한다`() {
+        // given
+        clubFilterSelector.addClubFilter(ClubFilter.SizeFilter.SmallDog)
+        clubFilterSelector.addClubFilter(ClubFilter.SizeFilter.BigDog)
+
+        // when
+        val containsSizeFilter = clubFilterSelector.isContainSizeFilter()
+
+        // then
+        assertThat(containsSizeFilter).isTrue()
+    }
+
+    @Test
+    fun `선택 된 SizeFilter가 없다면, SizeFilter를 확인하는 로직은 false를 반환해야 한다`() {
+        // given
+        clubFilterSelector.addClubFilter(ClubFilter.GenderFilter.Female)
+        clubFilterSelector.addClubFilter(ClubFilter.GenderFilter.Male)
+
+        // when
+        val containsSizeFilter = clubFilterSelector.isContainSizeFilter()
+
+        // then
+        assertThat(containsSizeFilter).isFalse()
+    }
+
+
+}

--- a/android/app/src/test/java/com/happy/friendogly/presentation/ui/club/common/model/ClubFilterSelectorTest.kt
+++ b/android/app/src/test/java/com/happy/friendogly/presentation/ui/club/common/model/ClubFilterSelectorTest.kt
@@ -19,7 +19,6 @@ class ClubFilterSelectorTest {
 
     @Test
     fun `필터를 추가하면 ClubFilterSelector에 해당 필터가 추가되어야 한다`() {
-        clubFilterSelector = ClubFilterSelector()
         // given
         val filter = ClubFilter.GenderFilter.Male
 
@@ -33,7 +32,6 @@ class ClubFilterSelectorTest {
 
     @Test
     fun `이미 추가 된 필터가 있다면 해당 필터는 추가되지 않아야 한다`() {
-        clubFilterSelector = ClubFilterSelector()
         // given
         val filter = ClubFilter.GenderFilter.Male
         clubFilterSelector.addClubFilter(filter)

--- a/android/app/src/test/java/com/happy/friendogly/presentation/ui/club/common/model/ClubFilterSelectorTest.kt
+++ b/android/app/src/test/java/com/happy/friendogly/presentation/ui/club/common/model/ClubFilterSelectorTest.kt
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.extension.ExtendWith
 
 @ExtendWith(InstantTaskExecutorExtension::class)
 class ClubFilterSelectorTest {
-
     private lateinit var clubFilterSelector: ClubFilterSelector
 
     @BeforeEach
@@ -28,7 +27,7 @@ class ClubFilterSelectorTest {
         clubFilterSelector.addClubFilter(filter)
         val actualFilter = clubFilterSelector.currentSelectedFilters.getOrAwaitValue()
 
-        //then
+        // then
         assertThat(actualFilter.firstOrNull()).isEqualTo(filter)
     }
 
@@ -43,9 +42,9 @@ class ClubFilterSelectorTest {
         clubFilterSelector.addClubFilter(filter)
         val actualFilter = clubFilterSelector.currentSelectedFilters.getOrAwaitValue()
 
-        //then
+        // then
         assertThat(
-            actualFilter.count { it.filterName == filter.filterName }
+            actualFilter.count { it.filterName == filter.filterName },
         ).isEqualTo(1)
     }
 
@@ -172,6 +171,4 @@ class ClubFilterSelectorTest {
         // then
         assertThat(containsSizeFilter).isFalse()
     }
-
-
 }


### PR DESCRIPTION
## 이슈
- close #733 

## 개발 사항
- 클럽 필터 로직에 대한 테스트를 작성했습니다.

## 전달 사항 (없으면 삭제해 주세요)
-  테스트 중 논리 오류 발견 후 수정이 있는데요, ClubFilterSelector를 `initClubFilter()`로직과 함께 사용하지 않으면 `currentSelectedFilters`가 초기화 되지 않아서 null 값으로 저장되고 있었습니다.
- -> null로 초기화 되는 경우 `addFilter()`에서 plus(1) 로직이 안먹어서 계속 null로 초기화 되는 문제 발생
- 다행히 뷰모델에서 항상 initClubFilter() 로직과 함께 사용하여 오류가 없었지만, 테스트 중에 발견했습니다. (라이브 데이터 테스트 시 클럽 필터를 추가해도 null?.plus(newFilter)로 추가되지 않음)
- 테스트 중 논리 오류 발견해서 수정했습니다.
