### PR TITLE
[BE] feat: 채팅방 목록 조회 시 최근 메시지를 같이 보여주는 API 생성

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/chatmessage/repository/ChatMessageRepository.java
+++ b/backend/src/main/java/com/happy/friendogly/chatmessage/repository/ChatMessageRepository.java
@@ -3,6 +3,7 @@ package com.happy.friendogly.chatmessage.repository;
 import com.happy.friendogly.chatmessage.domain.ChatMessage;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -17,5 +18,11 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 
     default List<ChatMessage> findAllByTimeRange(Long chatRoomId, LocalDateTime since, LocalDateTime until) {
         return findAllByChatRoomIdAndCreatedAtAfterAndCreatedAtBeforeOrderByCreatedAtAsc(chatRoomId, since, until);
+    }
+
+    Optional<ChatMessage> findFirstByChatRoomIdOrderByCreatedAtDesc(Long chatRoomId);
+
+    default Optional<ChatMessage> findRecentByChatRoomId(Long chatRoomId) {
+        return findFirstByChatRoomIdOrderByCreatedAtDesc(chatRoomId);
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/chatroom/controller/ChatRoomController.java
+++ b/backend/src/main/java/com/happy/friendogly/chatroom/controller/ChatRoomController.java
@@ -5,6 +5,7 @@ import com.happy.friendogly.chatroom.dto.request.SaveChatRoomRequest;
 import com.happy.friendogly.chatroom.dto.response.FindChatRoomMembersInfoResponse;
 import com.happy.friendogly.chatroom.dto.response.FindClubDetailsResponse;
 import com.happy.friendogly.chatroom.dto.response.FindMyChatRoomResponse;
+import com.happy.friendogly.chatroom.dto.response.FindMyChatRoomResponseV2;
 import com.happy.friendogly.chatroom.dto.response.SaveChatRoomResponse;
 import com.happy.friendogly.chatroom.service.ChatRoomCommandService;
 import com.happy.friendogly.chatroom.service.ChatRoomQueryService;
@@ -39,6 +40,11 @@ public class ChatRoomController {
     @GetMapping("/mine")
     public ApiResponse<FindMyChatRoomResponse> findMine(@Auth Long memberId) {
         return ApiResponse.ofSuccess(chatRoomQueryService.findMine(memberId));
+    }
+
+    @GetMapping("/mine/v2")
+    public ApiResponse<FindMyChatRoomResponseV2> findMineV2(@Auth Long memberId) {
+        return ApiResponse.ofSuccess(chatRoomQueryService.findMineV2(memberId));
     }
 
     @GetMapping("/{chatRoomId}")

--- a/backend/src/main/java/com/happy/friendogly/chatroom/dto/response/ChatRoomDetailV2.java
+++ b/backend/src/main/java/com/happy/friendogly/chatroom/dto/response/ChatRoomDetailV2.java
@@ -1,0 +1,26 @@
+package com.happy.friendogly.chatroom.dto.response;
+
+import com.happy.friendogly.chatroom.domain.ChatRoom;
+import java.time.LocalDateTime;
+
+public record ChatRoomDetailV2(
+        Long chatRoomId,
+        int memberCount,
+        String clubName,
+        String clubImageUrl,
+        String recentMessage,
+        LocalDateTime recentMessageCreatedAt
+) {
+
+    public ChatRoomDetailV2(ChatRoom chatRoom, String clubName, String clubImageUrl,
+            String recentMessage, LocalDateTime recentMessageCreatedAt) {
+        this(
+                chatRoom.getId(),
+                chatRoom.countMembers(),
+                clubName,
+                clubImageUrl,
+                recentMessage,
+                recentMessageCreatedAt
+        );
+    }
+}

--- a/backend/src/main/java/com/happy/friendogly/chatroom/dto/response/ChatRoomDetailV2.java
+++ b/backend/src/main/java/com/happy/friendogly/chatroom/dto/response/ChatRoomDetailV2.java
@@ -6,19 +6,19 @@ import java.time.LocalDateTime;
 public record ChatRoomDetailV2(
         Long chatRoomId,
         int memberCount,
-        String clubName,
-        String clubImageUrl,
+        String title,
+        String imageUrl,
         String recentMessage,
         LocalDateTime recentMessageCreatedAt
 ) {
 
-    public ChatRoomDetailV2(ChatRoom chatRoom, String clubName, String clubImageUrl,
+    public ChatRoomDetailV2(ChatRoom chatRoom, String title, String imageUrl,
             String recentMessage, LocalDateTime recentMessageCreatedAt) {
         this(
                 chatRoom.getId(),
                 chatRoom.countMembers(),
-                clubName,
-                clubImageUrl,
+                title,
+                imageUrl,
                 recentMessage,
                 recentMessageCreatedAt
         );

--- a/backend/src/main/java/com/happy/friendogly/chatroom/dto/response/FindMyChatRoomResponseV2.java
+++ b/backend/src/main/java/com/happy/friendogly/chatroom/dto/response/FindMyChatRoomResponseV2.java
@@ -1,0 +1,10 @@
+package com.happy.friendogly.chatroom.dto.response;
+
+import java.util.List;
+
+public record FindMyChatRoomResponseV2(
+        Long myMemberId,
+        List<ChatRoomDetailV2> chatRooms
+) {
+
+}

--- a/backend/src/main/java/com/happy/friendogly/chatroom/service/ChatRoomQueryService.java
+++ b/backend/src/main/java/com/happy/friendogly/chatroom/service/ChatRoomQueryService.java
@@ -76,7 +76,7 @@ public class ChatRoomQueryService {
 
         if (chatRoom.isPrivateChat()) {
             Optional<Member> otherMember = chatRoom.findMembers().stream()
-                    .filter(member -> myMemberId.equals(member.getId()))
+                    .filter(member -> !myMemberId.equals(member.getId()))
                     .findAny();
             String title = otherMember.map(member -> member.getName().getValue())
                     .orElse(null);

--- a/backend/src/test/java/com/happy/friendogly/chatroom/service/ChatRoomQueryServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/chatroom/service/ChatRoomQueryServiceTest.java
@@ -168,13 +168,13 @@ class ChatRoomQueryServiceTest extends ServiceTest {
                         .extracting(ChatRoomDetailV2::chatRoomId)
                         .containsExactly(chatRoom1.getId(), chatRoom2.getId()),
                 () -> assertThat(response.chatRooms())
-                        .extracting(ChatRoomDetailV2::clubName)
+                        .extracting(ChatRoomDetailV2::title)
                         .containsExactly("모임 제목1", "모임 제목2"),
                 () -> assertThat(response.chatRooms())
                         .extracting(ChatRoomDetailV2::memberCount)
                         .containsExactly(2, 2),
                 () -> assertThat(response.chatRooms())
-                        .extracting(ChatRoomDetailV2::clubImageUrl)
+                        .extracting(ChatRoomDetailV2::imageUrl)
                         .containsExactly("https://image.com", "https://image.com"),
                 () -> assertThat(response.chatRooms())
                         .extracting(ChatRoomDetailV2::recentMessage)

--- a/backend/src/test/java/com/happy/friendogly/chatroom/service/ChatRoomQueryServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/chatroom/service/ChatRoomQueryServiceTest.java
@@ -13,16 +13,18 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.happy.friendogly.chatroom.domain.ChatRoom;
 import com.happy.friendogly.chatroom.dto.response.ChatRoomDetail;
+import com.happy.friendogly.chatroom.dto.response.ChatRoomDetailV2;
 import com.happy.friendogly.chatroom.dto.response.FindChatRoomMembersInfoResponse;
 import com.happy.friendogly.chatroom.dto.response.FindClubDetailsResponse;
 import com.happy.friendogly.chatroom.dto.response.FindMyChatRoomResponse;
-import com.happy.friendogly.chatroom.service.ChatRoomQueryService;
+import com.happy.friendogly.chatroom.dto.response.FindMyChatRoomResponseV2;
 import com.happy.friendogly.club.domain.Club;
 import com.happy.friendogly.exception.FriendoglyException;
 import com.happy.friendogly.member.domain.Member;
 import com.happy.friendogly.pet.domain.Pet;
 import com.happy.friendogly.support.ServiceTest;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -117,6 +119,71 @@ class ChatRoomQueryServiceTest extends ServiceTest {
                 () -> assertThat(response.chatRooms())
                         .extracting(ChatRoomDetail::clubImageUrl)
                         .containsExactly("https://image.com", "https://image.com")
+        );
+    }
+
+    @DisplayName("참여중인 채팅방과, 각각의 최근 메시지를 조회한다.")
+    @Transactional
+    @Test
+    void findMineV2() {
+        // given (1): member3이 chatRoom1, chatRoom2에 참여
+        club1.addClubMember(member3);
+        club1.addClubPet(List.of(pet3));
+        club1.addChatRoomMember(member3);
+
+        club2.addClubMember(member3);
+        club2.addClubPet(List.of(pet3));
+        club2.addChatRoomMember(member3);
+
+        // given (2): chatRoom1, chatRoom2에서 채팅 발생
+        jdbcTemplate.update("""
+                        INSERT INTO chat_message (chat_room_id, message_type, member_id, content, created_at)
+                        VALUES
+                        (?, 'CHAT', ?, '1번방 예전 메시지', '2024-01-01T00:00:00'),
+                        (?, 'CHAT', ?, '1번방 최근 메시지', '2024-01-01T01:00:00'),
+                        (?, 'CHAT', ?, '1번방 예전 메시지', '2024-01-01T00:00:00'),
+                        (?, 'CHAT', ?, '1번방 예전 메시지', '2024-01-01T00:00:00'),
+
+                        (?, 'CHAT', ?, '2번방 예전 메시지', '2024-01-01T00:00:00'),
+                        (?, 'CHAT', ?, '2번방 예전 메시지', '2024-01-01T00:00:00'),
+                        (?, 'CHAT', ?, '2번방 최근 메시지', '2024-01-01T02:00:00'),
+                        (?, 'CHAT', ?, '2번방 예전 메시지', '2024-01-01T00:00:00');
+                        """,
+                chatRoom1.getId(), member1.getId(),
+                chatRoom1.getId(), member1.getId(),
+                chatRoom1.getId(), member1.getId(),
+                chatRoom1.getId(), member1.getId(),
+                chatRoom2.getId(), member1.getId(),
+                chatRoom2.getId(), member1.getId(),
+                chatRoom2.getId(), member1.getId(),
+                chatRoom2.getId(), member1.getId()
+        );
+
+        // when
+        FindMyChatRoomResponseV2 response = chatRoomQueryService.findMineV2(member3.getId());
+
+        // then
+        assertAll(
+                () -> assertThat(response.chatRooms())
+                        .extracting(ChatRoomDetailV2::chatRoomId)
+                        .containsExactly(chatRoom1.getId(), chatRoom2.getId()),
+                () -> assertThat(response.chatRooms())
+                        .extracting(ChatRoomDetailV2::clubName)
+                        .containsExactly("모임 제목1", "모임 제목2"),
+                () -> assertThat(response.chatRooms())
+                        .extracting(ChatRoomDetailV2::memberCount)
+                        .containsExactly(2, 2),
+                () -> assertThat(response.chatRooms())
+                        .extracting(ChatRoomDetailV2::clubImageUrl)
+                        .containsExactly("https://image.com", "https://image.com"),
+                () -> assertThat(response.chatRooms())
+                        .extracting(ChatRoomDetailV2::recentMessage)
+                        .containsExactly("1번방 최근 메시지", "2번방 최근 메시지"),
+                () -> assertThat(response.chatRooms())
+                        .extracting(ChatRoomDetailV2::recentMessageCreatedAt)
+                        .containsExactly(
+                                LocalDateTime.parse("2024-01-01T01:00:00"),
+                                LocalDateTime.parse("2024-01-01T02:00:00"))
         );
     }
 

--- a/backend/src/test/java/com/happy/friendogly/docs/ChatRoomApiDocsTest.java
+++ b/backend/src/test/java/com/happy/friendogly/docs/ChatRoomApiDocsTest.java
@@ -87,7 +87,7 @@ public class ChatRoomApiDocsTest extends RestDocsTest {
                 .andExpect(status().isOk());
     }
 
-    @DisplayName("내가 참여한 채팅방 목록 조회 - v1")
+    @DisplayName("내가 참여한 채팅방 목록 조회 (v1)")
     @Test
     void findMine() throws Exception {
         ChatRoomDetail detail1 = new ChatRoomDetail(3L, 5, "신천동 소형견 모임", "https://image1.com/image.jpg");
@@ -162,9 +162,12 @@ public class ChatRoomApiDocsTest extends RestDocsTest {
                                         fieldWithPath("data.myMemberId").description("나의 Member ID"),
                                         fieldWithPath("data.chatRooms.[].chatRoomId").description("채팅방 ID"),
                                         fieldWithPath("data.chatRooms.[].memberCount").description("채팅방 현재 인원"),
-                                        fieldWithPath("data.chatRooms.[].clubName").description("모임 이름 (모임 채팅방 아닌 경우 빈 문자열)"),
-                                        fieldWithPath("data.chatRooms.[].clubImageUrl").description("모임 이미지 URL (모임 채팅방 아닌 경우 빈 문자열)"),
-                                        fieldWithPath("data.chatRooms.[].recentMessage").description("가장 최근에 전송된 메시지 (채팅 하나도 없으면 null)"),
+                                        fieldWithPath("data.chatRooms.[].title").description(
+                                                "모임 이름 혹은 상대방 이름 (1대1 채팅방에서 상대방이 없으면 null)"),
+                                        fieldWithPath("data.chatRooms.[].imageUrl").description(
+                                                "모임 이미지 URL 혹은 상대방 프로필 사진 URL (nullable)"),
+                                        fieldWithPath("data.chatRooms.[].recentMessage").description(
+                                                "가장 최근에 전송된 메시지 (채팅 하나도 없으면 null)"),
                                         fieldWithPath("data.chatRooms.[].recentMessageCreatedAt").description(
                                                 "가장 최근에 메시지가 전송된 시간 (채팅 하나도 없으면 null)")
                                 )

--- a/backend/src/test/java/com/happy/friendogly/docs/ChatRoomApiDocsTest.java
+++ b/backend/src/test/java/com/happy/friendogly/docs/ChatRoomApiDocsTest.java
@@ -162,11 +162,11 @@ public class ChatRoomApiDocsTest extends RestDocsTest {
                                         fieldWithPath("data.myMemberId").description("나의 Member ID"),
                                         fieldWithPath("data.chatRooms.[].chatRoomId").description("채팅방 ID"),
                                         fieldWithPath("data.chatRooms.[].memberCount").description("채팅방 현재 인원"),
-                                        fieldWithPath("data.chatRooms.[].clubName").description("모임 이름"),
-                                        fieldWithPath("data.chatRooms.[].clubImageUrl").description("모임 이미지 URL"),
-                                        fieldWithPath("data.chatRooms.[].recentMessage").description("가장 최근에 전송된 메시지"),
+                                        fieldWithPath("data.chatRooms.[].clubName").description("모임 이름 (모임 채팅방 아닌 경우 빈 문자열)"),
+                                        fieldWithPath("data.chatRooms.[].clubImageUrl").description("모임 이미지 URL (모임 채팅방 아닌 경우 빈 문자열)"),
+                                        fieldWithPath("data.chatRooms.[].recentMessage").description("가장 최근에 전송된 메시지 (채팅 하나도 없으면 null)"),
                                         fieldWithPath("data.chatRooms.[].recentMessageCreatedAt").description(
-                                                "가장 최근에 메시지가 전송된 시간")
+                                                "가장 최근에 메시지가 전송된 시간 (채팅 하나도 없으면 null)")
                                 )
                                 .responseSchema(Schema.schema("FindMyChatRoomResponseV2"))
                                 .build()

--- a/backend/src/test/java/com/happy/friendogly/docs/ChatRoomApiDocsTest.java
+++ b/backend/src/test/java/com/happy/friendogly/docs/ChatRoomApiDocsTest.java
@@ -24,12 +24,15 @@ import com.epages.restdocs.apispec.Schema;
 import com.happy.friendogly.chatroom.controller.ChatRoomController;
 import com.happy.friendogly.chatroom.dto.request.SaveChatRoomRequest;
 import com.happy.friendogly.chatroom.dto.response.ChatRoomDetail;
+import com.happy.friendogly.chatroom.dto.response.ChatRoomDetailV2;
 import com.happy.friendogly.chatroom.dto.response.FindChatRoomMembersInfoResponse;
 import com.happy.friendogly.chatroom.dto.response.FindClubDetailsResponse;
 import com.happy.friendogly.chatroom.dto.response.FindMyChatRoomResponse;
+import com.happy.friendogly.chatroom.dto.response.FindMyChatRoomResponseV2;
 import com.happy.friendogly.chatroom.dto.response.SaveChatRoomResponse;
 import com.happy.friendogly.chatroom.service.ChatRoomCommandService;
 import com.happy.friendogly.chatroom.service.ChatRoomQueryService;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
@@ -84,7 +87,7 @@ public class ChatRoomApiDocsTest extends RestDocsTest {
                 .andExpect(status().isOk());
     }
 
-    @DisplayName("내가 참여한 채팅방 목록 조회")
+    @DisplayName("내가 참여한 채팅방 목록 조회 - v1")
     @Test
     void findMine() throws Exception {
         ChatRoomDetail detail1 = new ChatRoomDetail(3L, 5, "신천동 소형견 모임", "https://image1.com/image.jpg");
@@ -117,6 +120,55 @@ public class ChatRoomApiDocsTest extends RestDocsTest {
                                         fieldWithPath("data.chatRooms.[].clubImageUrl").description("모임 이미지 URL")
                                 )
                                 .responseSchema(Schema.schema("FindMyChatRoomResponse"))
+                                .build()
+                        )
+                ))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("내가 참여한 채팅방 목록 조회 (v2)")
+    @Test
+    void findMineV2() throws Exception {
+        ChatRoomDetailV2 detail1 = new ChatRoomDetailV2(
+                3L, 5, "신천동 소형견 모임", "https://image1.com/image.jpg",
+                "최근 메시지입니다 1", LocalDateTime.parse("2024-01-01T00:00:00"));
+        ChatRoomDetailV2 detail2 = new ChatRoomDetailV2(
+                7L, 5, "귀여운 강아지들 모임", "https://image2.com/image.jpg",
+                "recent message 2", LocalDateTime.parse("2024-01-01T01:00:00"));
+        ChatRoomDetailV2 detail3 = new ChatRoomDetailV2(
+                11L, 5, "서울 인싸견 모임", "https://image3.com/image.jpg",
+                "최근 메시지 3", LocalDateTime.parse("2024-01-01T02:00:00"));
+
+        FindMyChatRoomResponseV2 response = new FindMyChatRoomResponseV2(1L, List.of(detail1, detail2, detail3));
+
+        given(chatRoomQueryService.findMineV2(any()))
+                .willReturn(response);
+
+        mockMvc
+                .perform(get("/chat-rooms/mine/v2")
+                        .header(AUTHORIZATION, getMemberToken()))
+                .andDo(print())
+                .andDo(document("chat-rooms/findMineV2",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("ChatRoom API (v2)")
+                                .summary("내가 참여한 채팅방 목록 조회 API (v2)")
+                                .requestHeaders(
+                                        headerWithName(HttpHeaders.AUTHORIZATION).description("로그인한 회원의 access token")
+                                )
+                                .responseFields(
+                                        fieldWithPath("isSuccess").description("응답 성공 여부"),
+                                        fieldWithPath("data.myMemberId").description("나의 Member ID"),
+                                        fieldWithPath("data.chatRooms.[].chatRoomId").description("채팅방 ID"),
+                                        fieldWithPath("data.chatRooms.[].memberCount").description("채팅방 현재 인원"),
+                                        fieldWithPath("data.chatRooms.[].clubName").description("모임 이름"),
+                                        fieldWithPath("data.chatRooms.[].clubImageUrl").description("모임 이미지 URL"),
+                                        fieldWithPath("data.chatRooms.[].recentMessage").description("가장 최근에 전송된 메시지"),
+                                        fieldWithPath("data.chatRooms.[].recentMessageCreatedAt").description(
+                                                "가장 최근에 메시지가 전송된 시간")
+                                )
+                                .responseSchema(Schema.schema("FindMyChatRoomResponseV2"))
                                 .build()
                         )
                 ))


### PR DESCRIPTION
## 이슈
- close #732 

## 개발 사항
- 채팅방 목록 조회 시 최근 메시지를 같이 보여주는 API 생성
- 기존: 채팅방 ID, 채팅방 인원수, 모임 이름, 모임 이미지 URL
- 추가: 채팅방 ID, 채팅방 인원수, 모임 이름, 모임 이미지 URL + 최근 메시지 내용, 최근 메시지 전송 시간

## 전달 사항 (없으면 삭제해 주세요)
- 버전 대응을 위해 기존 API 유지하고 v2로 만들었습니다.