### PR TITLE
[BE] refactor: 알림 서비스 다른 도메인 의존성 제거

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/chatsocket/service/ChatSocketCommandService.java
+++ b/backend/src/main/java/com/happy/friendogly/chatsocket/service/ChatSocketCommandService.java
@@ -4,20 +4,20 @@ import static com.happy.friendogly.chatsocket.domain.MessageType.CHAT;
 import static com.happy.friendogly.chatsocket.domain.MessageType.ENTER;
 import static com.happy.friendogly.chatsocket.domain.MessageType.LEAVE;
 
-import com.happy.friendogly.chatsocket.template.ChatTemplate;
 import com.happy.friendogly.chatmessage.domain.ChatMessage;
+import com.happy.friendogly.chatmessage.repository.ChatMessageRepository;
 import com.happy.friendogly.chatroom.domain.ChatRoom;
+import com.happy.friendogly.chatroom.repository.ChatRoomRepository;
 import com.happy.friendogly.chatsocket.domain.MessageType;
 import com.happy.friendogly.chatsocket.dto.request.ChatMessageSocketRequest;
 import com.happy.friendogly.chatsocket.dto.response.ChatMessageSocketResponse;
-import com.happy.friendogly.chatmessage.repository.ChatMessageRepository;
-import com.happy.friendogly.chatroom.repository.ChatRoomRepository;
+import com.happy.friendogly.chatsocket.template.ChatTemplate;
 import com.happy.friendogly.club.domain.Club;
 import com.happy.friendogly.club.repository.ClubRepository;
 import com.happy.friendogly.exception.FriendoglyException;
 import com.happy.friendogly.member.domain.Member;
 import com.happy.friendogly.member.repository.MemberRepository;
-import com.happy.friendogly.notification.service.NotificationService;
+import com.happy.friendogly.notification.service.ChatNotificationService;
 import java.time.LocalDateTime;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,7 +32,7 @@ public class ChatSocketCommandService {
     private final ClubRepository clubRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
-    private final NotificationService notificationService;
+    private final ChatNotificationService chatNotificationService;
     private final ChatTemplate template;
 
     public ChatSocketCommandService(
@@ -40,14 +40,14 @@ public class ChatSocketCommandService {
             ClubRepository clubRepository,
             ChatRoomRepository chatRoomRepository,
             ChatMessageRepository chatMessageRepository,
-            NotificationService notificationService,
+            ChatNotificationService chatNotificationService,
             ChatTemplate template
     ) {
         this.memberRepository = memberRepository;
         this.clubRepository = clubRepository;
         this.chatRoomRepository = chatRoomRepository;
         this.chatMessageRepository = chatMessageRepository;
-        this.notificationService = notificationService;
+        this.chatNotificationService = chatNotificationService;
         this.template = template;
     }
 
@@ -79,7 +79,7 @@ public class ChatSocketCommandService {
                 messageType, content, senderMember, LocalDateTime.now());
         Club club = clubRepository.getByChatRoomId(chatRoom.getId());
 
-        notificationService.sendChatNotification(chatRoom.getId(), chat, club);
+        chatNotificationService.sendChatNotification(chatRoom.getId(), chat, club);
         template.convertAndSend(chatRoom.getId(), chat);
         chatMessageRepository.save(new ChatMessage(chatRoom, messageType, senderMember, content));
     }

--- a/backend/src/main/java/com/happy/friendogly/notification/service/ChatNotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/ChatNotificationService.java
@@ -1,0 +1,44 @@
+package com.happy.friendogly.notification.service;
+
+import static com.happy.friendogly.notification.domain.NotificationType.CHAT;
+
+import com.happy.friendogly.chatsocket.dto.response.ChatMessageSocketResponse;
+import com.happy.friendogly.club.domain.Club;
+import com.happy.friendogly.notification.repository.DeviceTokenRepository;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ChatNotificationService {
+
+    private final DeviceTokenRepository deviceTokenRepository;
+    private final NotificationService notificationService;
+
+    public ChatNotificationService(
+            DeviceTokenRepository deviceTokenRepository,
+            NotificationService notificationService
+    ) {
+        this.deviceTokenRepository = deviceTokenRepository;
+        this.notificationService = notificationService;
+    }
+
+    public void sendChatNotification(Long chatRoomId, ChatMessageSocketResponse response, Club club) {
+        List<String> receiverTokens = deviceTokenRepository
+                .findAllByChatRoomIdWithoutMine(chatRoomId, response.senderMemberId());
+
+        Map<String, String> data = Map.of(
+                "chatRoomId", chatRoomId.toString(),
+                "messageType", response.messageType().toString(),
+                "senderMemberId", response.senderMemberId().toString(),
+                "senderName", response.senderName(),
+                "content", response.content(),
+                "createdAt", response.createdAt().toString(),
+                "profilePictureUrl", response.profilePictureUrl(),
+                "clubPictureUrl", club.getImageUrl(),
+                "clubTitle", club.getTitle().getValue()
+        );
+
+        notificationService.sendNotification("채팅", data, CHAT, receiverTokens);
+    }
+}

--- a/backend/src/main/java/com/happy/friendogly/notification/service/ChatNotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/ChatNotificationService.java
@@ -34,8 +34,8 @@ public class ChatNotificationService {
                 "senderName", response.senderName(),
                 "content", response.content(),
                 "createdAt", response.createdAt().toString(),
-                "profilePictureUrl", response.profilePictureUrl(),
-                "clubPictureUrl", club.getImageUrl(),
+                "profilePictureUrl", response.profilePictureUrl() == null ? "" : response.profilePictureUrl(),
+                "clubPictureUrl", club.getImageUrl() == null ? "" : club.getImageUrl(),
                 "clubTitle", club.getTitle().getValue()
         );
 

--- a/backend/src/main/java/com/happy/friendogly/notification/service/FakeNotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/FakeNotificationService.java
@@ -1,8 +1,8 @@
 package com.happy.friendogly.notification.service;
 
-import com.happy.friendogly.chatsocket.dto.response.ChatMessageSocketResponse;
-import com.happy.friendogly.club.domain.Club;
+import com.happy.friendogly.notification.domain.NotificationType;
 import java.util.List;
+import java.util.Map;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
@@ -11,22 +11,22 @@ import org.springframework.stereotype.Service;
 public class FakeNotificationService implements NotificationService {
 
     @Override
-    public void sendFootprintNotification(String title, String content, String receiverToken) {
+    public void sendNotification(
+            String title,
+            String content,
+            NotificationType notificationType,
+            List<String> receiverTokens
+    ) {
 
     }
 
     @Override
-    public void sendFootprintNotification(String title, String content, List<String> receiverTokens) {
-
-    }
-
-    @Override
-    public void sendChatNotification(Long chatRoomId, ChatMessageSocketResponse response, Club club) {
-
-    }
-
-    @Override
-    public void sendPlaygroundJoinNotification(String title, String content, List<String> receiverTokens) {
+    public void sendNotification(
+            String title,
+            Map<String, String> contents,
+            NotificationType notificationType,
+            List<String> receiverTokens
+    ) {
 
     }
 }

--- a/backend/src/main/java/com/happy/friendogly/notification/service/FcmNotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/FcmNotificationService.java
@@ -8,7 +8,6 @@ import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.MulticastMessage;
 import com.happy.friendogly.exception.FriendoglyException;
 import com.happy.friendogly.notification.domain.NotificationType;
-import com.happy.friendogly.notification.repository.DeviceTokenRepository;
 import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,14 +21,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class FcmNotificationService implements NotificationService {
 
     private final FirebaseMessaging firebaseMessaging;
-    private final DeviceTokenRepository deviceTokenRepository;
 
-    public FcmNotificationService(
-            @Autowired FirebaseApp firebaseApp,
-            DeviceTokenRepository deviceTokenRepository
-    ) {
+    public FcmNotificationService(@Autowired FirebaseApp firebaseApp) {
         this.firebaseMessaging = FirebaseMessaging.getInstance(firebaseApp);
-        this.deviceTokenRepository = deviceTokenRepository;
     }
 
     @Override

--- a/backend/src/main/java/com/happy/friendogly/notification/service/FootprintNotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/FootprintNotificationService.java
@@ -1,10 +1,9 @@
 package com.happy.friendogly.notification.service;
 
-import static com.happy.friendogly.notification.domain.NotificationType.FOOTPRINT;
-
 import com.happy.friendogly.footprint.domain.Footprint;
 import com.happy.friendogly.footprint.domain.WalkStatus;
 import com.happy.friendogly.notification.domain.DeviceToken;
+import com.happy.friendogly.notification.domain.NotificationType;
 import com.happy.friendogly.notification.repository.DeviceTokenRepository;
 import java.util.List;
 import java.util.Optional;
@@ -41,7 +40,7 @@ public class FootprintNotificationService {
         notificationService.sendNotification(
                 DEFAULT_TITLE,
                 content,
-                FOOTPRINT,
+                NotificationType.FOOTPRINT,
                 List.of(deviceTokenRepository.getByMemberId(memberId).getDeviceToken())
         );
     }
@@ -52,7 +51,7 @@ public class FootprintNotificationService {
         notificationService.sendNotification(
                 DEFAULT_TITLE,
                 "내 산책 장소에 " + comingMemberName + "님도 산책온대요!",
-                FOOTPRINT,
+                NotificationType.FOOTPRINT,
                 nearDeviceTokens
         );
     }
@@ -62,7 +61,7 @@ public class FootprintNotificationService {
 
         notificationService.sendNotification(DEFAULT_TITLE,
                 "내 산책장소에 " + startMemberName + "님이 산책을 시작했어요!",
-                FOOTPRINT,
+                NotificationType.FOOTPRINT,
                 nearDeviceTokens
         );
     }

--- a/backend/src/main/java/com/happy/friendogly/notification/service/FootprintNotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/FootprintNotificationService.java
@@ -1,5 +1,7 @@
 package com.happy.friendogly.notification.service;
 
+import static com.happy.friendogly.notification.domain.NotificationType.FOOTPRINT;
+
 import com.happy.friendogly.footprint.domain.Footprint;
 import com.happy.friendogly.footprint.domain.WalkStatus;
 import com.happy.friendogly.notification.domain.DeviceToken;
@@ -35,19 +37,21 @@ public class FootprintNotificationService {
             return;
         }
 
-        notificationService.sendFootprintNotification(
+        notificationService.sendNotification(
                 DEFAULT_TITLE,
                 content,
-                deviceTokenRepository.getByMemberId(memberId).getDeviceToken()
+                FOOTPRINT,
+                List.of(deviceTokenRepository.getByMemberId(memberId).getDeviceToken())
         );
     }
 
     public void sendWalkComingNotification(String comingMemberName, List<Footprint> nearFootprints) {
         List<String> nearDeviceTokens = toDeviceToken(nearFootprints);
 
-        notificationService.sendFootprintNotification(
+        notificationService.sendNotification(
                 DEFAULT_TITLE,
                 "내 산책 장소에 " + comingMemberName + "님도 산책온대요!",
+                FOOTPRINT,
                 nearDeviceTokens
         );
     }
@@ -55,8 +59,9 @@ public class FootprintNotificationService {
     public void sendWalkStartNotificationToNear(String startMemberName, List<Footprint> nearFootprints) {
         List<String> nearDeviceTokens = toDeviceToken(nearFootprints);
 
-        notificationService.sendFootprintNotification(DEFAULT_TITLE,
+        notificationService.sendNotification(DEFAULT_TITLE,
                 "내 산책장소에 " + startMemberName + "님이 산책을 시작했어요!",
+                FOOTPRINT,
                 nearDeviceTokens
         );
     }

--- a/backend/src/main/java/com/happy/friendogly/notification/service/FootprintNotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/FootprintNotificationService.java
@@ -13,7 +13,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class FootprintNotificationService {
 
-    private final String DEFAULT_TITLE = "반갑개";
+    private static final String DEFAULT_TITLE = "반갑개";
+    
     private final NotificationService notificationService;
     private final DeviceTokenRepository deviceTokenRepository;
 

--- a/backend/src/main/java/com/happy/friendogly/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/NotificationService.java
@@ -1,16 +1,22 @@
 package com.happy.friendogly.notification.service;
 
-import com.happy.friendogly.chatsocket.dto.response.ChatMessageSocketResponse;
-import com.happy.friendogly.club.domain.Club;
+import com.happy.friendogly.notification.domain.NotificationType;
 import java.util.List;
+import java.util.Map;
 
 public interface NotificationService {
 
-    void sendFootprintNotification(String title, String content, String receiverToken);
+    void sendNotification(
+            String title,
+            String content,
+            NotificationType notificationType,
+            List<String> receiverTokens
+    );
 
-    void sendFootprintNotification(String title, String content, List<String> receiverTokens);
-
-    void sendChatNotification(Long chatRoomId, ChatMessageSocketResponse response, Club club);
-
-    void sendPlaygroundJoinNotification(String title, String content, List<String> receiverTokens);
+    void sendNotification(
+            String title,
+            Map<String, String> contents,
+            NotificationType notificationType,
+            List<String> receiverTokens
+    );
 }

--- a/backend/src/main/java/com/happy/friendogly/notification/service/PlaygroundNotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/PlaygroundNotificationService.java
@@ -1,5 +1,7 @@
 package com.happy.friendogly.notification.service;
 
+import static com.happy.friendogly.notification.domain.NotificationType.PLAYGROUND;
+
 import com.happy.friendogly.notification.domain.DeviceToken;
 import com.happy.friendogly.notification.repository.DeviceTokenRepository;
 import com.happy.friendogly.playground.domain.PlaygroundMember;
@@ -15,19 +17,25 @@ public class PlaygroundNotificationService {
     private final DeviceTokenRepository deviceTokenRepository;
     private final NotificationService notificationService;
 
-    public PlaygroundNotificationService(DeviceTokenRepository deviceTokenRepository,
-                                         NotificationService notificationService) {
+    public PlaygroundNotificationService(
+            DeviceTokenRepository deviceTokenRepository,
+            NotificationService notificationService
+    ) {
         this.deviceTokenRepository = deviceTokenRepository;
         this.notificationService = notificationService;
     }
 
-    public void sendJoinNotification(String newParticipatingMember,
-                                     List<PlaygroundMember> existingParticipatingMembers) {
+    public void sendJoinNotification(
+            String newParticipatingMember,
+            List<PlaygroundMember> existingParticipatingMembers
+    ) {
         List<String> deviceTokens = toDeviceToken(existingParticipatingMembers);
         String content = newParticipatingMember + "님이 놀이터에 참여했습니다";
 
-        notificationService.sendPlaygroundJoinNotification(DEFAULT_TITLE,
+        notificationService.sendNotification(
+                DEFAULT_TITLE,
                 content,
+                PLAYGROUND,
                 deviceTokens
         );
     }

--- a/backend/src/main/java/com/happy/friendogly/notification/service/PlaygroundNotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/PlaygroundNotificationService.java
@@ -1,8 +1,7 @@
 package com.happy.friendogly.notification.service;
 
-import static com.happy.friendogly.notification.domain.NotificationType.PLAYGROUND;
-
 import com.happy.friendogly.notification.domain.DeviceToken;
+import com.happy.friendogly.notification.domain.NotificationType;
 import com.happy.friendogly.notification.repository.DeviceTokenRepository;
 import com.happy.friendogly.playground.domain.PlaygroundMember;
 import java.util.List;
@@ -35,7 +34,7 @@ public class PlaygroundNotificationService {
         notificationService.sendNotification(
                 DEFAULT_TITLE,
                 content,
-                PLAYGROUND,
+                NotificationType.PLAYGROUND,
                 deviceTokens
         );
     }

--- a/backend/src/main/java/com/happy/friendogly/notification/service/PlaygroundNotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/PlaygroundNotificationService.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class PlaygroundNotificationService {
 
-    private final String DEFAULT_TITLE = "반갑개";
+    private static final String DEFAULT_TITLE = "반갑개";
 
     private final DeviceTokenRepository deviceTokenRepository;
     private final NotificationService notificationService;

--- a/backend/src/test/java/com/happy/friendogly/notification/service/FcmNotificationServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/notification/service/FcmNotificationServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
+import com.happy.friendogly.notification.domain.NotificationType;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,7 +32,7 @@ class FcmNotificationServiceTest {
     @Test
     void sendFootprintNotification() throws FirebaseMessagingException {
         // when
-        fcmNotificationService.sendFootprintNotification("title", "content", List.of());
+        fcmNotificationService.sendNotification("title", "content", NotificationType.FOOTPRINT, List.of());
 
         // then
         verify(firebaseMessaging, never()).sendEachForMulticast(any());


### PR DESCRIPTION
## 이슈
- close #738 
- close #739 

## 개발 사항
- 알림 서비스 다른 도메인 의존성 제거
- ChatNotificationService 클래스 생성
- Chat 관련 알림 데이터 생성 시 Map.of() NPE 가능성 완화
  - null의 가능성이 큰 부분만 대처함