### PR TITLE
[BE] chore: 단일 DB로 변경, 인메모리 메시지 브로커 적용

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/chatsocket/config/RabbitMqConfig.java
+++ b/backend/src/main/java/com/happy/friendogly/chatsocket/config/RabbitMqConfig.java
@@ -26,7 +26,7 @@ import org.springframework.context.annotation.Profile;
 
 @Configuration
 @EnableRabbit
-@Profile("!local")
+@Profile("rabbit")
 public class RabbitMqConfig {
 
     private static final String CHAT_QUEUE_NAME = "chat.queue";

--- a/backend/src/main/java/com/happy/friendogly/chatsocket/config/WebSocketInMemoryConfig.java
+++ b/backend/src/main/java/com/happy/friendogly/chatsocket/config/WebSocketInMemoryConfig.java
@@ -12,16 +12,16 @@ import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBr
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
-@Profile("local")
+@Profile("local | dev | prod")
 @Configuration
 @EnableWebSocketMessageBroker
-public class WebSocketLocalConfig implements WebSocketMessageBrokerConfigurer {
+public class WebSocketInMemoryConfig implements WebSocketMessageBrokerConfigurer {
 
     private final WebSocketInterceptor webSocketInterceptor;
     private final WebSocketErrorHandler webSocketErrorHandler;
     private final JwtProvider jwtProvider;
 
-    public WebSocketLocalConfig(
+    public WebSocketInMemoryConfig(
             WebSocketInterceptor webSocketInterceptor,
             WebSocketErrorHandler webSocketErrorHandler,
             JwtProvider jwtProvider

--- a/backend/src/main/java/com/happy/friendogly/chatsocket/config/WebSocketInMemoryConfig.java
+++ b/backend/src/main/java/com/happy/friendogly/chatsocket/config/WebSocketInMemoryConfig.java
@@ -4,7 +4,6 @@ import com.happy.friendogly.auth.WebSocketArgumentResolver;
 import com.happy.friendogly.auth.service.jwt.JwtProvider;
 import java.util.List;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
@@ -12,7 +11,6 @@ import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBr
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
-@Profile("local | dev | prod")
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketInMemoryConfig implements WebSocketMessageBrokerConfigurer {

--- a/backend/src/main/java/com/happy/friendogly/chatsocket/config/WebSocketRabbitMqConfig.java
+++ b/backend/src/main/java/com/happy/friendogly/chatsocket/config/WebSocketRabbitMqConfig.java
@@ -14,7 +14,7 @@ import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBr
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
-@Profile("!local")
+@Profile("rabbit")
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketRabbitMqConfig implements WebSocketMessageBrokerConfigurer {

--- a/backend/src/main/java/com/happy/friendogly/chatsocket/config/WebSocketRabbitMqConfig.java
+++ b/backend/src/main/java/com/happy/friendogly/chatsocket/config/WebSocketRabbitMqConfig.java
@@ -14,7 +14,7 @@ import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBr
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
-@Profile("rabbit")
+@Profile("rabbit") // RabbitMQ가 필요한 상황에서는 해당 프로파일명을 변경해주세요.
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketRabbitMqConfig implements WebSocketMessageBrokerConfigurer {

--- a/backend/src/main/java/com/happy/friendogly/chatsocket/template/InMemoryChatTemplate.java
+++ b/backend/src/main/java/com/happy/friendogly/chatsocket/template/InMemoryChatTemplate.java
@@ -1,11 +1,9 @@
 package com.happy.friendogly.chatsocket.template;
 
-import org.springframework.context.annotation.Profile;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile("local | dev | prod")
 public class InMemoryChatTemplate implements ChatTemplate {
 
     private static final String TOPIC_CHAT_PREFIX = "/exchange/chat.exchange/room.";

--- a/backend/src/main/java/com/happy/friendogly/chatsocket/template/InMemoryChatTemplate.java
+++ b/backend/src/main/java/com/happy/friendogly/chatsocket/template/InMemoryChatTemplate.java
@@ -5,7 +5,7 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile("local")
+@Profile("local | dev | prod")
 public class InMemoryChatTemplate implements ChatTemplate {
 
     private static final String TOPIC_CHAT_PREFIX = "/exchange/chat.exchange/room.";

--- a/backend/src/main/java/com/happy/friendogly/chatsocket/template/RabbitChatTemplate.java
+++ b/backend/src/main/java/com/happy/friendogly/chatsocket/template/RabbitChatTemplate.java
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile("rabbit")
+@Profile("rabbit") // RabbitMQ가 필요한 상황에서는 해당 프로파일명을 변경해주세요.
 public class RabbitChatTemplate implements ChatTemplate {
 
     private final RabbitTemplate rabbitTemplate;

--- a/backend/src/main/java/com/happy/friendogly/chatsocket/template/RabbitChatTemplate.java
+++ b/backend/src/main/java/com/happy/friendogly/chatsocket/template/RabbitChatTemplate.java
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile("!local")
+@Profile("rabbit")
 public class RabbitChatTemplate implements ChatTemplate {
 
     private final RabbitTemplate rabbitTemplate;

--- a/backend/src/main/java/com/happy/friendogly/config/datasource/DataSourceConfig.java
+++ b/backend/src/main/java/com/happy/friendogly/config/datasource/DataSourceConfig.java
@@ -13,7 +13,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 
-@Profile("prod-replication")
+@Profile("prod-replication") // DB 이중화하는 경우 프로파일명을 변경해주세요.
 @Configuration
 public class DataSourceConfig {
 

--- a/backend/src/main/java/com/happy/friendogly/config/datasource/DataSourceConfig.java
+++ b/backend/src/main/java/com/happy/friendogly/config/datasource/DataSourceConfig.java
@@ -13,7 +13,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 
-@Profile("prod")
+@Profile("prod-replication")
 @Configuration
 public class DataSourceConfig {
 

--- a/backend/src/main/java/com/happy/friendogly/config/datasource/ReplicationRoutingDataSource.java
+++ b/backend/src/main/java/com/happy/friendogly/config/datasource/ReplicationRoutingDataSource.java
@@ -4,7 +4,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-@Profile("prod")
+@Profile("prod-replication")
 public class ReplicationRoutingDataSource extends AbstractRoutingDataSource {
 
     @Override

--- a/backend/src/main/java/com/happy/friendogly/config/datasource/ReplicationRoutingDataSource.java
+++ b/backend/src/main/java/com/happy/friendogly/config/datasource/ReplicationRoutingDataSource.java
@@ -4,7 +4,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-@Profile("prod-replication")
+@Profile("prod-replication") // DB 이중화하는 경우 프로파일명을 변경해주세요.
 public class ReplicationRoutingDataSource extends AbstractRoutingDataSource {
 
     @Override

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -37,3 +37,8 @@ spring:
   sql:
     init:
       data-locations:
+
+management:
+  health:
+    rabbit:
+      enabled: false

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -30,6 +30,7 @@ logging.level.org:
 file:
   firebase:
     path: firebase-friendogly-private-key.json
+
 management:
   health:
     rabbit:

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -27,17 +27,15 @@ management:
   server:
     port: 8081
 
+  health:
+    rabbit:
+      enabled: false
+
 file:
   firebase:
     path: firebase-friendogly-private-key.json
 
 spring:
-  rabbitmq:
-    host: ${RABBITMQ_PROD_HOST}
-    username: ${RABBITMQ_PROD_USERNAME}
-    password: ${RABBITMQ_PROD_PASSWORD}
-    port: 3100 # initial connection port: use 3100 instead of 5672
-    stomp-port: 9100 # STOMP port: use 9100 instead of 61613
   sql:
     init:
       data-locations:

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -41,21 +41,13 @@ spring:
   sql:
     init:
       data-locations:
+
   datasource:
-    writer:
-      hikari:
-        driver-class-name: com.mysql.cj.jdbc.Driver
-        jdbc-url: ${WRITER_MYSQL_URL}
-        read-only: false
-        username: ${MYSQL_USERNAME}
-        password: ${MYSQL_PASSWORD}
-    reader:
-      hikari:
-        driver-class-name: com.mysql.cj.jdbc.Driver
-        jdbc-url: ${READER_MYSQL_URL}
-        read-only: true
-        username: ${MYSQL_USERNAME}
-        password: ${MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${MYSQL_PROD_RDS_URL}
+    username: ${MYSQL_PROD_RDS_USERNAME}
+    password: ${MYSQL_PROD_RDS_PASSWORD}
+
   jpa:
     hibernate:
       ddl-auto: validate


### PR DESCRIPTION
## 이슈
- close #744 
- close #745 

## 개발 사항
- AWS 비용 지원이 종료됨에 따라 DB replication을 적용 해제하고 단일 DB 사용하는 방식으로 변경

## 전달 사항 (없으면 삭제해 주세요)
- 기존 코드는 최대한 살리는 방향으로 수정했습니다.
- RDS - EC2 연동 테스트 완료했습니다. 무중단 배포 스크립트에서 설정값을 수정한 후 merge하면 될 것 같아요.
- 메시지 브로커는 S3 설정이 완료되면 테스트 하면 될 것 같습니다.
