### PR TITLE
[AN] fix: 핸드폰 gps 종료시 무한 로딩 현상 수정

### DIFF
--- a/android/app/src/androidTest/java/com/happy/friendogly/RecentPetsDatabaseTest.kt
+++ b/android/app/src/androidTest/java/com/happy/friendogly/RecentPetsDatabaseTest.kt
@@ -72,6 +72,7 @@ class RecentPetsDatabaseTest {
         private val DUMMY_RECENT_PET =
             RecentPetEntity(
                 memberId = 0L,
+                petId = 0L,
                 imgUrl = "imageUrl",
                 name = "땡이",
                 birthday = LocalDate(2024, 10, 2),

--- a/android/app/src/main/java/com/happy/friendogly/presentation/ui/permission/AlarmPermission.kt
+++ b/android/app/src/main/java/com/happy/friendogly/presentation/ui/permission/AlarmPermission.kt
@@ -19,6 +19,7 @@ import com.happy.friendogly.firebase.analytics.AnalyticsHelper
 import com.happy.friendogly.presentation.dialog.AlertDialogModel
 import com.happy.friendogly.presentation.dialog.DefaultCoralAlertDialog
 import com.happy.friendogly.presentation.utils.logPermissionAlarmDenied
+import com.happy.friendogly.presentation.utils.logPermissionLocationDenied
 import java.lang.ref.WeakReference
 
 class AlarmPermission private constructor(
@@ -137,6 +138,26 @@ class AlarmPermission private constructor(
             },
         )
 
+    private fun AppCompatActivity.createGPSDialog(): DialogFragment =
+        DefaultCoralAlertDialog(
+            alertDialogModel =
+                AlertDialogModel(
+                    getString(R.string.location_gps_dialog_title),
+                    getString(R.string.location_gps_dialog_body),
+                    getString(R.string.permission_cancel),
+                    getString(R.string.permission_go_setting),
+                ),
+            clickToNegative = {
+                isPermitted(false)
+                analyticsHelper.logPermissionLocationDenied()
+            },
+            clickToPositive = {
+                val intent =
+                    Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)
+                settingStartActivity.launch(intent)
+            },
+        )
+
     private fun Fragment.createDialog(): DialogFragment =
         DefaultCoralAlertDialog(
             alertDialogModel =
@@ -157,12 +178,41 @@ class AlarmPermission private constructor(
             },
         )
 
+    private fun Fragment.createGPSDialog(): DialogFragment =
+        DefaultCoralAlertDialog(
+            alertDialogModel =
+                AlertDialogModel(
+                    getString(R.string.location_gps_dialog_title),
+                    getString(R.string.location_gps_dialog_body),
+                    getString(R.string.permission_cancel),
+                    getString(R.string.permission_go_setting),
+                ),
+            clickToNegative = {
+                isPermitted(false)
+                analyticsHelper.logPermissionLocationDenied()
+            },
+            clickToPositive = {
+                val intent =
+                    Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)
+                settingStartActivity.launch(intent)
+            },
+        )
+
     override fun createAlarmDialog(): DialogFragment {
         val lifecycleOwner = lifecycleOwnerRef.get() ?: error("$lifecycleOwnerRef is null")
         return if (lifecycleOwner is AppCompatActivity) {
             lifecycleOwner.createDialog()
         } else {
             (lifecycleOwner as Fragment).createDialog()
+        }
+    }
+
+    override fun createGPSDialog(): DialogFragment {
+        val lifecycleOwner = lifecycleOwnerRef.get() ?: error("$lifecycleOwnerRef is null")
+        return if (lifecycleOwner is AppCompatActivity) {
+            lifecycleOwner.createGPSDialog()
+        } else {
+            (lifecycleOwner as Fragment).createGPSDialog()
         }
     }
 

--- a/android/app/src/main/java/com/happy/friendogly/presentation/ui/permission/LocationPermission.kt
+++ b/android/app/src/main/java/com/happy/friendogly/presentation/ui/permission/LocationPermission.kt
@@ -105,6 +105,26 @@ class LocationPermission private constructor(
             },
         )
 
+    private fun AppCompatActivity.createGPSDialog(): DialogFragment =
+        DefaultCoralAlertDialog(
+            alertDialogModel =
+                AlertDialogModel(
+                    getString(R.string.location_gps_dialog_title),
+                    getString(R.string.location_gps_dialog_body),
+                    getString(R.string.permission_cancel),
+                    getString(R.string.permission_go_setting),
+                ),
+            clickToNegative = {
+                isPermitted(false)
+                analyticsHelper.logPermissionLocationDenied()
+            },
+            clickToPositive = {
+                val intent =
+                    Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)
+                settingStartActivity.launch(intent)
+            },
+        )
+
     private fun Fragment.createDialog(): DialogFragment =
         DefaultCoralAlertDialog(
             alertDialogModel =
@@ -125,6 +145,26 @@ class LocationPermission private constructor(
             },
         )
 
+    private fun Fragment.createGPSDialog(): DialogFragment =
+        DefaultCoralAlertDialog(
+            alertDialogModel =
+                AlertDialogModel(
+                    getString(R.string.location_gps_dialog_title),
+                    getString(R.string.location_gps_dialog_body),
+                    getString(R.string.permission_cancel),
+                    getString(R.string.permission_go_setting),
+                ),
+            clickToNegative = {
+                isPermitted(false)
+                analyticsHelper.logPermissionLocationDenied()
+            },
+            clickToPositive = {
+                val intent =
+                    Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)
+                settingStartActivity.launch(intent)
+            },
+        )
+
     override fun createAlarmDialog(): DialogFragment {
         val lifecycleOwner = lifecycleOwnerRef.get() ?: error("$lifecycleOwnerRef is null")
         return if (lifecycleOwner is AppCompatActivity) {
@@ -132,6 +172,17 @@ class LocationPermission private constructor(
         } else {
             (lifecycleOwner as Fragment).createDialog()
         }
+    }
+
+    override fun createGPSDialog(): DialogFragment {
+        val lifecycleOwner = lifecycleOwnerRef.get() ?: error("$lifecycleOwnerRef is null")
+        return if (lifecycleOwner is AppCompatActivity) {
+            lifecycleOwner.createGPSDialog()
+        } else {
+            (lifecycleOwner as Fragment).createGPSDialog()
+        }
+
+        println("createGPSDialog")
     }
 
     override fun shouldShowRequestPermissionRationale(): Boolean {

--- a/android/app/src/main/java/com/happy/friendogly/presentation/ui/permission/Permission.kt
+++ b/android/app/src/main/java/com/happy/friendogly/presentation/ui/permission/Permission.kt
@@ -8,4 +8,6 @@ sealed class Permission(val permissionType: PermissionType) {
     abstract fun hasPermissions(): Boolean
 
     abstract fun createAlarmDialog(): DialogFragment
+
+    abstract fun createGPSDialog(): DialogFragment
 }

--- a/android/app/src/main/java/com/happy/friendogly/presentation/ui/playground/action/PlaygroundAlertAction.kt
+++ b/android/app/src/main/java/com/happy/friendogly/presentation/ui/playground/action/PlaygroundAlertAction.kt
@@ -1,6 +1,8 @@
 package com.happy.friendogly.presentation.ui.playground.action
 
 sealed interface PlaygroundAlertAction {
+    data object AlertHasNotGPSPermissionDialog : PlaygroundAlertAction
+
     data object AlertHasNotLocationPermissionDialog : PlaygroundAlertAction
 
     data object AlertHasNotPetDialog : PlaygroundAlertAction

--- a/android/app/src/main/java/com/happy/friendogly/presentation/ui/playground/state/PlaygroundUiState.kt
+++ b/android/app/src/main/java/com/happy/friendogly/presentation/ui/playground/state/PlaygroundUiState.kt
@@ -8,6 +8,8 @@ sealed interface PlaygroundUiState {
 
     data object LocationPermissionsNotGranted : PlaygroundUiState
 
+    data object GPSPermissionNotGranted : PlaygroundUiState
+
     data class FindingPlayground(val refreshBtnVisible: Boolean = false) : PlaygroundUiState
 
     data class RegisteringPlayground(

--- a/android/app/src/main/java/com/happy/friendogly/presentation/ui/playground/viewmodel/PlaygroundViewModel.kt
+++ b/android/app/src/main/java/com/happy/friendogly/presentation/ui/playground/viewmodel/PlaygroundViewModel.kt
@@ -34,6 +34,7 @@ import com.happy.friendogly.presentation.ui.playground.action.PlaygroundAlertAct
 import com.happy.friendogly.presentation.ui.playground.action.PlaygroundAlertAction.AlertFailToLoadPlaygroundsSnackbar
 import com.happy.friendogly.presentation.ui.playground.action.PlaygroundAlertAction.AlertFailToRegisterPlaygroundSnackbar
 import com.happy.friendogly.presentation.ui.playground.action.PlaygroundAlertAction.AlertFailToUpdatePlaygroundArrival
+import com.happy.friendogly.presentation.ui.playground.action.PlaygroundAlertAction.AlertHasNotGPSPermissionDialog
 import com.happy.friendogly.presentation.ui.playground.action.PlaygroundAlertAction.AlertHasNotLocationPermissionDialog
 import com.happy.friendogly.presentation.ui.playground.action.PlaygroundAlertAction.AlertHasNotPetDialog
 import com.happy.friendogly.presentation.ui.playground.action.PlaygroundAlertAction.AlertHelpBalloon
@@ -250,10 +251,18 @@ class PlaygroundViewModel
         }
 
         private fun runIfLocationPermissionGranted(action: () -> Unit) {
-            if (uiState.value !is PlaygroundUiState.LocationPermissionsNotGranted) {
-                action()
-            } else {
-                _alertAction.emit(AlertHasNotLocationPermissionDialog)
+            when (uiState.value) {
+                is PlaygroundUiState.GPSPermissionNotGranted -> {
+                    _alertAction.emit(AlertHasNotGPSPermissionDialog)
+                }
+
+                is PlaygroundUiState.LocationPermissionsNotGranted -> {
+                    _alertAction.emit(AlertHasNotLocationPermissionDialog)
+                }
+
+                else -> {
+                    action()
+                }
             }
         }
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -309,7 +309,9 @@
     <string name="alarm_dialog_body">알람을 설정하지 않으면, 채팅과 모임 알람을 받을 수 없어요!</string>
     <string name="alarm_dialog_body_playground">알림을 거부하여 모임 알림을 받을 수 없습니다.</string>
     <string name="location_dialog_title">위치 허용 사용 설정</string>
+    <string name="location_gps_dialog_title">GPS 허용 사용 설정</string>
     <string name="location_dialog_body">위치 설정하지 않으면, 친구를 찾을 수 없어요!</string>
+    <string name="location_gps_dialog_body">GPS 설정하지 않으면, 친구를 찾을 수 없어요!</string>
     <string name="permission_cancel">취소</string>
     <string name="permission_go_setting">설정</string>
     <string name="permission_denied_message">권한을 거부하여 기능을 사용할 수 없습니다.</string>


### PR DESCRIPTION
## 이슈
- close #766 

## 개발 사항
- 핸드폰 gps 껐을때 무한 로딩 현상 수정
- 핸드폰 gps 다시 켰을때 다시 정상적으로 로딩 후 데이터 불러오도록 수정

## 전달 사항 (없으면 삭제해 주세요)
- @jinuemong 모임 지도 설정에도 수정해주세여~
