### PR TITLE
[BE] refactor: 놀이터 전체조회->범위조회로 변경

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/playground/controller/PlaygroundController.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/controller/PlaygroundController.java
@@ -2,9 +2,12 @@ package com.happy.friendogly.playground.controller;
 
 import com.happy.friendogly.auth.Auth;
 import com.happy.friendogly.common.ApiResponse;
+import com.happy.friendogly.playground.domain.Location;
+import com.happy.friendogly.playground.domain.Playground;
 import com.happy.friendogly.playground.dto.request.SavePlaygroundRequest;
 import com.happy.friendogly.playground.dto.request.UpdatePlaygroundArrivalRequest;
 import com.happy.friendogly.playground.dto.request.UpdatePlaygroundMemberMessageRequest;
+import com.happy.friendogly.playground.dto.response.FindMyPlaygroundLocation;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundDetailResponse;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundLocationResponse;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundSummaryResponse;
@@ -25,11 +28,17 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/playgrounds")
 public class PlaygroundController {
+
+    private static final String MIN_KOREA_LATITUDE = "33.0637";
+    private static final String MAX_KOREA_LATITUDE = "43.0042";
+    private static final String MIN_KOREA_LONGITUDE = "124.1104";
+    private static final String MAX_KOREA_LONGITUDE = "131.4220";
 
     private final PlaygroundCommandService playgroundCommandService;
     private final PlaygroundQueryService playgroundQueryService;
@@ -64,8 +73,24 @@ public class PlaygroundController {
     }
 
     @GetMapping("/locations")
-    public ApiResponse<List<FindPlaygroundLocationResponse>> findAllLocation(@Auth Long memberId) {
-        return ApiResponse.ofSuccess(playgroundQueryService.findLocations(memberId));
+    public ApiResponse<List<FindPlaygroundLocationResponse>> findAllLocations(
+            @Auth Long memberId,
+            @RequestParam(defaultValue = MIN_KOREA_LATITUDE) double startLatitude,
+            @RequestParam(defaultValue = MAX_KOREA_LATITUDE) double endLatitude,
+            @RequestParam(defaultValue = MIN_KOREA_LONGITUDE) double startLongitude,
+            @RequestParam(defaultValue = MAX_KOREA_LONGITUDE) double endLongitude
+    ) {
+        List<FindPlaygroundLocationResponse> dummy = List.of(
+                new FindPlaygroundLocationResponse(new Playground(new Location(37.5173316, 127.101161)), false),
+                new FindPlaygroundLocationResponse(new Playground(new Location(37.5143316, 127.131161)), true)
+        );
+        return ApiResponse.ofSuccess(dummy);
+    }
+
+    @GetMapping("/locations/mine")
+    public ApiResponse<FindMyPlaygroundLocation> findMyLocation(@Auth Long memberId) {
+        FindMyPlaygroundLocation dummy = new FindMyPlaygroundLocation(1L, 37.5173316, 127.101161);
+        return ApiResponse.ofSuccess(dummy);
     }
 
     @PatchMapping("/arrival")

--- a/backend/src/main/java/com/happy/friendogly/playground/controller/PlaygroundController.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/controller/PlaygroundController.java
@@ -2,12 +2,10 @@ package com.happy.friendogly.playground.controller;
 
 import com.happy.friendogly.auth.Auth;
 import com.happy.friendogly.common.ApiResponse;
-import com.happy.friendogly.playground.domain.Location;
-import com.happy.friendogly.playground.domain.Playground;
 import com.happy.friendogly.playground.dto.request.SavePlaygroundRequest;
 import com.happy.friendogly.playground.dto.request.UpdatePlaygroundArrivalRequest;
 import com.happy.friendogly.playground.dto.request.UpdatePlaygroundMemberMessageRequest;
-import com.happy.friendogly.playground.dto.response.FindMyPlaygroundLocation;
+import com.happy.friendogly.playground.dto.response.FindMyPlaygroundLocationResponse;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundDetailResponse;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundLocationResponse;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundSummaryResponse;
@@ -80,15 +78,18 @@ public class PlaygroundController {
             @RequestParam(defaultValue = MIN_KOREA_LONGITUDE) double startLongitude,
             @RequestParam(defaultValue = MAX_KOREA_LONGITUDE) double endLongitude
     ) {
-        List<FindPlaygroundLocationResponse> dummy = List.of(
-                new FindPlaygroundLocationResponse(new Playground(new Location(37.5173316, 127.101161)), false),
-                new FindPlaygroundLocationResponse(new Playground(new Location(37.5143316, 127.131161)), true)
+        List<FindPlaygroundLocationResponse> findPlaygroundLocationResponses = playgroundQueryService.findLocations(
+                memberId,
+                startLatitude,
+                endLatitude,
+                startLongitude,
+                endLongitude
         );
-        return ApiResponse.ofSuccess(dummy);
+        return ApiResponse.ofSuccess(findPlaygroundLocationResponses);
     }
 
     @GetMapping("/locations/mine")
-    public ApiResponse<FindMyPlaygroundLocation> findMyLocation(@Auth Long memberId) {
+    public ApiResponse<FindMyPlaygroundLocationResponse> findMyLocation(@Auth Long memberId) {
         return ApiResponse.ofSuccess(playgroundQueryService.findMyPlaygroundLocation(memberId));
     }
 

--- a/backend/src/main/java/com/happy/friendogly/playground/controller/PlaygroundController.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/controller/PlaygroundController.java
@@ -89,8 +89,7 @@ public class PlaygroundController {
 
     @GetMapping("/locations/mine")
     public ApiResponse<FindMyPlaygroundLocation> findMyLocation(@Auth Long memberId) {
-        FindMyPlaygroundLocation dummy = new FindMyPlaygroundLocation(1L, 37.5173316, 127.101161);
-        return ApiResponse.ofSuccess(dummy);
+        return ApiResponse.ofSuccess(playgroundQueryService.findMyPlaygroundLocation(memberId));
     }
 
     @PatchMapping("/arrival")

--- a/backend/src/main/java/com/happy/friendogly/playground/dto/response/FindMyPlaygroundLocation.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/dto/response/FindMyPlaygroundLocation.java
@@ -1,0 +1,9 @@
+package com.happy.friendogly.playground.dto.response;
+
+public record FindMyPlaygroundLocation(
+        Long id,
+        double latitude,
+        double longitude
+) {
+
+}

--- a/backend/src/main/java/com/happy/friendogly/playground/dto/response/FindMyPlaygroundLocationResponse.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/dto/response/FindMyPlaygroundLocationResponse.java
@@ -1,6 +1,6 @@
 package com.happy.friendogly.playground.dto.response;
 
-public record FindMyPlaygroundLocation(
+public record FindMyPlaygroundLocationResponse(
         Long id,
         double latitude,
         double longitude

--- a/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundQueryService.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundQueryService.java
@@ -5,7 +5,7 @@ import com.happy.friendogly.pet.domain.Pet;
 import com.happy.friendogly.pet.repository.PetRepository;
 import com.happy.friendogly.playground.domain.Playground;
 import com.happy.friendogly.playground.domain.PlaygroundMember;
-import com.happy.friendogly.playground.dto.response.FindMyPlaygroundLocation;
+import com.happy.friendogly.playground.dto.response.FindMyPlaygroundLocationResponse;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundDetailResponse;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundLocationResponse;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundSummaryResponse;
@@ -85,8 +85,19 @@ public class PlaygroundQueryService {
         return 0;
     }
 
-    public List<FindPlaygroundLocationResponse> findLocations(Long memberId) {
-        List<Playground> playgrounds = playgroundRepository.findAll();
+    public List<FindPlaygroundLocationResponse> findLocations(
+            Long memberId,
+            double startLatitude,
+            double endLatitude,
+            double startLongitude,
+            double endLongitude
+    ) {
+        List<Playground> playgrounds = playgroundRepository.findAllByLatitudeBetweenAndLongitudeBetween(
+                startLatitude,
+                endLatitude,
+                startLongitude,
+                endLongitude
+        );
         Optional<PlaygroundMember> playgroundMember = playgroundMemberRepository.findByMemberId(memberId);
 
         if (playgroundMember.isPresent()) {
@@ -139,10 +150,10 @@ public class PlaygroundQueryService {
         return petImageUrls;
     }
 
-    public FindMyPlaygroundLocation findMyPlaygroundLocation(Long memberId) {
+    public FindMyPlaygroundLocationResponse findMyPlaygroundLocation(Long memberId) {
         PlaygroundMember playgroundMember = playgroundMemberRepository.getByMemberId(memberId);
         Playground playground = playgroundMember.getPlayground();
-        return new FindMyPlaygroundLocation(
+        return new FindMyPlaygroundLocationResponse(
                 playground.getId(),
                 playground.getLocation().getLatitude(),
                 playground.getLocation().getLongitude()

--- a/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundQueryService.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundQueryService.java
@@ -5,6 +5,7 @@ import com.happy.friendogly.pet.domain.Pet;
 import com.happy.friendogly.pet.repository.PetRepository;
 import com.happy.friendogly.playground.domain.Playground;
 import com.happy.friendogly.playground.domain.PlaygroundMember;
+import com.happy.friendogly.playground.dto.response.FindMyPlaygroundLocation;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundDetailResponse;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundLocationResponse;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundSummaryResponse;
@@ -136,5 +137,15 @@ public class PlaygroundQueryService {
             return petImageUrls.subList(0, MAX_PET_PREVIEW_IMAGE_COUNT);
         }
         return petImageUrls;
+    }
+
+    public FindMyPlaygroundLocation findMyPlaygroundLocation(Long memberId) {
+        PlaygroundMember playgroundMember = playgroundMemberRepository.getByMemberId(memberId);
+        Playground playground = playgroundMember.getPlayground();
+        return new FindMyPlaygroundLocation(
+                playground.getId(),
+                playground.getLocation().getLatitude(),
+                playground.getLocation().getLongitude()
+        );
     }
 }

--- a/backend/src/test/java/com/happy/friendogly/docs/PlaygroundApiDocsTest.java
+++ b/backend/src/test/java/com/happy/friendogly/docs/PlaygroundApiDocsTest.java
@@ -5,6 +5,7 @@ import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
@@ -30,7 +31,7 @@ import com.happy.friendogly.playground.domain.PlaygroundMember;
 import com.happy.friendogly.playground.dto.request.SavePlaygroundRequest;
 import com.happy.friendogly.playground.dto.request.UpdatePlaygroundArrivalRequest;
 import com.happy.friendogly.playground.dto.request.UpdatePlaygroundMemberMessageRequest;
-import com.happy.friendogly.playground.dto.response.FindMyPlaygroundLocation;
+import com.happy.friendogly.playground.dto.response.FindMyPlaygroundLocationResponse;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundDetailResponse;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundLocationResponse;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundSummaryResponse;
@@ -223,8 +224,8 @@ public class PlaygroundApiDocsTest extends RestDocsTest {
                 new FindPlaygroundLocationResponse(4L, 37.5131474, 127.1042528, false)
         );
 
-//        when(playgroundQueryService.findLocations(anyLong()))
-//                .thenReturn(response);
+        when(playgroundQueryService.findLocations(anyLong(),anyDouble(),anyDouble(),anyDouble(),anyDouble()))
+                .thenReturn(response);
 
         mockMvc
                 .perform(get("/playgrounds/locations")
@@ -279,7 +280,10 @@ public class PlaygroundApiDocsTest extends RestDocsTest {
     @Test
     void findMyPlaygroundLocation() throws Exception {
 
-        FindMyPlaygroundLocation findMyPlaygroundLocation = new FindMyPlaygroundLocation(1L, 37.5173316, 127.1011661);
+        FindMyPlaygroundLocationResponse response = new FindMyPlaygroundLocationResponse(1L, 37.5173316, 127.1011661);
+
+        when(playgroundQueryService.findMyPlaygroundLocation(anyLong()))
+                .thenReturn(response);
 
         mockMvc
                 .perform(get("/playgrounds/locations/mine")

--- a/backend/src/test/java/com/happy/friendogly/docs/PlaygroundApiDocsTest.java
+++ b/backend/src/test/java/com/happy/friendogly/docs/PlaygroundApiDocsTest.java
@@ -18,6 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
+import com.epages.restdocs.apispec.SimpleType;
 import com.happy.friendogly.member.domain.Member;
 import com.happy.friendogly.pet.domain.Gender;
 import com.happy.friendogly.pet.domain.Pet;
@@ -29,6 +30,7 @@ import com.happy.friendogly.playground.domain.PlaygroundMember;
 import com.happy.friendogly.playground.dto.request.SavePlaygroundRequest;
 import com.happy.friendogly.playground.dto.request.UpdatePlaygroundArrivalRequest;
 import com.happy.friendogly.playground.dto.request.UpdatePlaygroundMemberMessageRequest;
+import com.happy.friendogly.playground.dto.response.FindMyPlaygroundLocation;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundDetailResponse;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundLocationResponse;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundSummaryResponse;
@@ -221,12 +223,16 @@ public class PlaygroundApiDocsTest extends RestDocsTest {
                 new FindPlaygroundLocationResponse(4L, 37.5131474, 127.1042528, false)
         );
 
-        when(playgroundQueryService.findLocations(anyLong()))
-                .thenReturn(response);
+//        when(playgroundQueryService.findLocations(anyLong()))
+//                .thenReturn(response);
 
         mockMvc
                 .perform(get("/playgrounds/locations")
                         .header(HttpHeaders.AUTHORIZATION, getMemberToken())
+                        .queryParam("startLatitude", "37.5131474")
+                        .queryParam("endLatitude", "37.5183316")
+                        .queryParam("startLongitude", "127.0983182")
+                        .queryParam("endLongitude", "127.1042528")
                 )
                 .andDo(document("playgrounds/findLocations",
                         getDocumentRequest(),
@@ -234,6 +240,27 @@ public class PlaygroundApiDocsTest extends RestDocsTest {
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Playground API")
                                 .summary("전체 놀이터 위치 조회 API")
+                                .requestHeaders(
+                                        headerWithName(HttpHeaders.AUTHORIZATION).description("로그인한 회원의 access token")
+                                )
+                                .queryParameters(
+                                        parameterWithName("startLatitude")
+                                                .type(SimpleType.NUMBER)
+                                                .description("시작위도(default - 한국극단위도)")
+                                                .optional(),
+                                        parameterWithName("endLatitude")
+                                                .type(SimpleType.NUMBER)
+                                                .description("끝위도(default - 한국극단위도)")
+                                                .optional(),
+                                        parameterWithName("startLongitude")
+                                                .type(SimpleType.NUMBER)
+                                                .description("시작경도(default - 한국극단경도)")
+                                                .optional(),
+                                        parameterWithName("endLongitude")
+                                                .type(SimpleType.NUMBER)
+                                                .description("끝경도(default - 한국극단경도)")
+                                                .optional()
+                                )
                                 .responseFields(
                                         fieldWithPath("isSuccess").description("응답 성공 여부"),
                                         fieldWithPath("data.[].id").description("놀이터의 ID"),
@@ -242,6 +269,38 @@ public class PlaygroundApiDocsTest extends RestDocsTest {
                                         fieldWithPath("data.[].isParticipating").description("놀이터 참여 유무")
                                 )
                                 .responseSchema(Schema.schema("PlaygroundLocationResponse"))
+                                .build()
+                        )
+                ))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("참여한 놀이터의 위치를 조회")
+    @Test
+    void findMyPlaygroundLocation() throws Exception {
+
+        FindMyPlaygroundLocation findMyPlaygroundLocation = new FindMyPlaygroundLocation(1L, 37.5173316, 127.1011661);
+
+        mockMvc
+                .perform(get("/playgrounds/locations/mine")
+                        .header(HttpHeaders.AUTHORIZATION, getMemberToken())
+                )
+                .andDo(document("playgrounds/findMyPlaygroundLocations",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Playground API")
+                                .summary("참여한 놀이터 위치 조회 API")
+                                .requestHeaders(
+                                        headerWithName(HttpHeaders.AUTHORIZATION).description("로그인한 회원의 access token")
+                                )
+                                .responseFields(
+                                        fieldWithPath("isSuccess").description("응답 성공 여부"),
+                                        fieldWithPath("data.id").description("놀이터의 ID"),
+                                        fieldWithPath("data.latitude").description("놀이터의 위도"),
+                                        fieldWithPath("data.longitude").description("놀이터의 경도")
+                                )
+                                .responseSchema(Schema.schema("MyPlaygroundLocationResponse"))
                                 .build()
                         )
                 ))

--- a/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundQueryServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundQueryServiceTest.java
@@ -9,6 +9,7 @@ import com.happy.friendogly.pet.domain.Pet;
 import com.happy.friendogly.pet.domain.SizeType;
 import com.happy.friendogly.playground.domain.Playground;
 import com.happy.friendogly.playground.domain.PlaygroundMember;
+import com.happy.friendogly.playground.dto.response.FindMyPlaygroundLocation;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundDetailResponse;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundLocationResponse;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundSummaryResponse;
@@ -161,6 +162,21 @@ class PlaygroundQueryServiceTest extends PlaygroundServiceTest {
 
         // then
         assertThat(response.get(0).isParticipating()).isEqualTo(false);
+    }
+
+    @DisplayName("내가 참여한 놀이터의 위치를 조회할 수 있다.")
+    @Test
+    void findMyPlaygroundLocations() {
+        // given
+        Member member = saveMember("member1");
+        Playground playground = savePlayground();
+        savePlaygroundMember(playground, member);
+
+        // when
+        FindMyPlaygroundLocation myPlaygroundLocation = playgroundQueryService.findMyPlaygroundLocation(member.getId());
+
+        // then
+        assertThat(myPlaygroundLocation.id()).isEqualTo(playground.getId());
     }
 
     @DisplayName("놀이터의 요약정보를 조회한다.")

--- a/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundQueryServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/playground/service/PlaygroundQueryServiceTest.java
@@ -9,7 +9,7 @@ import com.happy.friendogly.pet.domain.Pet;
 import com.happy.friendogly.pet.domain.SizeType;
 import com.happy.friendogly.playground.domain.Playground;
 import com.happy.friendogly.playground.domain.PlaygroundMember;
-import com.happy.friendogly.playground.dto.response.FindMyPlaygroundLocation;
+import com.happy.friendogly.playground.dto.response.FindMyPlaygroundLocationResponse;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundDetailResponse;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundLocationResponse;
 import com.happy.friendogly.playground.dto.response.FindPlaygroundSummaryResponse;
@@ -113,12 +113,41 @@ class PlaygroundQueryServiceTest extends PlaygroundServiceTest {
         Playground playground = savePlayground(expectedLatitude, expectedLongitude);
 
         // when
-        List<FindPlaygroundLocationResponse> response = playgroundQueryService.findLocations(1L);
+        List<FindPlaygroundLocationResponse> response = playgroundQueryService.findLocations(
+                1L,
+                37.0,
+                38.0,
+                127.0,
+                128.0
+        );
 
         // then
         assertAll(
                 () -> assertThat(response.get(0).latitude()).isEqualTo(expectedLatitude),
                 () -> assertThat(response.get(0).longitude()).isEqualTo(expectedLongitude)
+        );
+    }
+
+    @DisplayName("특정 범위내의 놀이터들의 위치를 조회할 수 있다.")
+    @Test
+    void findLocationsWithRange() {
+        // given
+        Playground insidePlayground = savePlayground(37.5173316, 127.1011661);
+        Playground outsidePlayground = savePlayground(38.5173316, 128.1011661);
+
+        // when
+        List<FindPlaygroundLocationResponse> playgroundsLocation = playgroundQueryService.findLocations(
+                1L,
+                37.0,
+                38.0,
+                127.0,
+                128.0
+        );
+
+        // then
+        assertAll(
+                () -> assertThat(playgroundsLocation).hasSize(1),
+                () -> assertThat(playgroundsLocation.get(0).id()).isEqualTo(insidePlayground.getId())
         );
     }
 
@@ -142,7 +171,13 @@ class PlaygroundQueryServiceTest extends PlaygroundServiceTest {
         );
 
         // when
-        List<FindPlaygroundLocationResponse> response = playgroundQueryService.findLocations(member1.getId());
+        List<FindPlaygroundLocationResponse> response = playgroundQueryService.findLocations(
+                member1.getId(),
+                37.0,
+                38.0,
+                127.0,
+                128.0
+        );
 
         // then
         assertThat(response.get(0).isParticipating()).isEqualTo(true);
@@ -158,7 +193,13 @@ class PlaygroundQueryServiceTest extends PlaygroundServiceTest {
         savePlayground();
 
         // when
-        List<FindPlaygroundLocationResponse> response = playgroundQueryService.findLocations(member1.getId());
+        List<FindPlaygroundLocationResponse> response = playgroundQueryService.findLocations(
+                member1.getId(),
+                37.0,
+                38.0,
+                127.0,
+                128.0
+        );
 
         // then
         assertThat(response.get(0).isParticipating()).isEqualTo(false);
@@ -173,7 +214,7 @@ class PlaygroundQueryServiceTest extends PlaygroundServiceTest {
         savePlaygroundMember(playground, member);
 
         // when
-        FindMyPlaygroundLocation myPlaygroundLocation = playgroundQueryService.findMyPlaygroundLocation(member.getId());
+        FindMyPlaygroundLocationResponse myPlaygroundLocation = playgroundQueryService.findMyPlaygroundLocation(member.getId());
 
         // then
         assertThat(myPlaygroundLocation.id()).isEqualTo(playground.getId());


### PR DESCRIPTION
## 이슈
- close #772 

## 개발 사항
- 놀이터 전체조회를 위도경도 범위로 조회하도록 변경했습니다.
  - 위도 경도 기본 값으로 한국 극단지점위치로 했습니다. 이로 인해, 이전 안드로이드어플 버전은 자동으로 한국 전체범위조회로 조회됩니다
- 내가 참여한 놀이터 조회API 구현
  - 범위조회로 바뀌었지만, 참여한 놀이터는 항상 지도에 있어야 하기 때문에, 내가 참여한 놀이터 조회API를 별도로 만들었습니다.
