### PR TITLE
PROD배포 Main브랜치로 변경

### DIFF
--- a/.github/workflows/backend-cd-workflow-prod.yml
+++ b/.github/workflows/backend-cd-workflow-prod.yml
@@ -2,7 +2,7 @@ name: deploy
 
 on:
   push:
-    branches: [ "release/backend" ]
+    branches: [ "main" ]
     paths:
       - "backend/**"
       


### PR DESCRIPTION
기존 release/backend는 develop의 자식이라 배포할 때마다 충돌나서 main을 배포브랜치로 변경