### PR TITLE
[BE] refactor: 놀이터 상세조회 쿼리 반복 호출 개선

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/pet/repository/PetRepository.java
+++ b/backend/src/main/java/com/happy/friendogly/pet/repository/PetRepository.java
@@ -35,4 +35,12 @@ public interface PetRepository extends JpaRepository<Pet, Long> {
     boolean existsByMemberId(Long memberId);
 
     void deleteAllByMemberId(Long memberId);
+
+    @Query("""
+            SELECT p
+            FROM Pet p
+            WHERE p.member.id
+            IN :memberIds
+            """)
+    List<Pet> findAllByMemberIds(List<Long> memberIds);
 }

--- a/backend/src/test/java/com/happy/friendogly/pet/repository/PetRepositoryTest.java
+++ b/backend/src/test/java/com/happy/friendogly/pet/repository/PetRepositoryTest.java
@@ -1,0 +1,64 @@
+package com.happy.friendogly.pet.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.happy.friendogly.member.domain.Member;
+import com.happy.friendogly.member.repository.MemberRepository;
+import com.happy.friendogly.pet.domain.Gender;
+import com.happy.friendogly.pet.domain.Pet;
+import com.happy.friendogly.pet.domain.SizeType;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class PetRepositoryTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    PetRepository petRepository;
+
+    @DisplayName("다수의 멤버 ID로 멤버들의 펫을 조회할 수 있다.")
+    @Disabled
+    @Test
+    void findAllByMemberIdIn() {
+        // given
+        Member savedMember1 = memberRepository.save(new Member("member1", "tag1", "imageUrl1"));
+        Member savedMember2 = memberRepository.save(new Member("member2", "tag2", "imageUrl2"));
+        petRepository.save(
+                new Pet(
+                        savedMember1,
+                        "name1",
+                        "description1",
+                        LocalDate.now(),
+                        SizeType.LARGE,
+                        Gender.FEMALE,
+                        "imageUrl1"
+                )
+        );
+        petRepository.save(
+                new Pet(
+                        savedMember2,
+                        "name2",
+                        "description2",
+                        LocalDate.now(),
+                        SizeType.LARGE,
+                        Gender.FEMALE,
+                        "imageUrl2"
+                )
+        );
+
+        // when
+        List<Pet> pets = petRepository.findAllByMemberIds(
+                List.of(savedMember1.getId(), savedMember2.getId()));
+
+        // then
+        assertThat(pets).hasSize(2);
+    }
+}


### PR DESCRIPTION
## 이슈
- close #787 

## 개발 사항
- 얼마나 개선 됐는 지 직접 테스트한 [🔗 노션 링크](https://just-date-658.notion.site/Scouter-173a71250d09805199acc8e1068c1969?pvs=4)
- 반복문에서 repository 반복호출 하는 코드 -> 반복문 수행전에 In절을 통한 단일 쿼리로 변경
