### PR TITLE
[BE] fix: 메시지가 남아있는 채로 모임 삭제가 불가능하던 버그 수정

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/chatmessage/domain/ChatMessage.java
+++ b/backend/src/main/java/com/happy/friendogly/chatmessage/domain/ChatMessage.java
@@ -27,9 +27,8 @@ public class ChatMessage {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "chat_room_id", nullable = false)
-    private ChatRoom chatRoom;
+    @Column(name = "chat_room_id", nullable = false)
+    private Long chatRoomId;
 
     @Enumerated(value = EnumType.STRING)
     @Column(name = "message_type", nullable = false)
@@ -51,7 +50,7 @@ public class ChatMessage {
             Member senderMember,
             String content
     ) {
-        this.chatRoom = chatRoom;
+        this.chatRoomId = chatRoom.getId();
         this.messageType = messageType;
         this.senderMember = senderMember;
         this.content = content;

--- a/backend/src/test/java/com/happy/friendogly/club/service/ClubCommandServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/club/service/ClubCommandServiceTest.java
@@ -3,7 +3,11 @@ package com.happy.friendogly.club.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+import com.happy.friendogly.chatmessage.domain.ChatMessage;
+import com.happy.friendogly.chatroom.domain.ChatRoom;
+import com.happy.friendogly.chatsocket.domain.MessageType;
 import com.happy.friendogly.club.domain.Club;
 import com.happy.friendogly.club.domain.Status;
 import com.happy.friendogly.club.dto.request.DeleteKickedMemberRequest;
@@ -278,6 +282,25 @@ class ClubCommandServiceTest extends ClubServiceTest {
         clubCommandService.deleteClubMember(savedClub.getId(), savedMember.getId());
 
         assertThat(clubRepository.findById(savedClub.getId()).isEmpty()).isTrue();
+    }
+
+    @DisplayName("채팅 메시지가 존재해도 모임을 삭제할 수 있다.")
+    @Test
+    void deleteClubWhenChatMessageExist() {
+        // given
+        Club club = createSavedClub(
+                savedMember,
+                List.of(savedPet),
+                Set.of(Gender.FEMALE, Gender.FEMALE_NEUTERED, Gender.MALE, Gender.MALE_NEUTERED),
+                Set.of(SizeType.SMALL)
+        );
+
+        ChatRoom chatRoom = club.getChatRoom();
+        ChatMessage chatMessage = new ChatMessage(chatRoom, MessageType.CHAT, savedMember, "메세지내용");
+        chatMessageRepository.save(chatMessage);
+
+        // when - then
+        assertDoesNotThrow(() -> clubCommandService.deleteClubMember(club.getId(), savedMember.getId()));
     }
 
     @DisplayName("Full 상태에서 회원이 모임에서 탈퇴하면 Open으로 바꾼다.")


### PR DESCRIPTION
## 이슈
- close #765

## 개발 사항
- `ChatRoom` - `ChatMessage` 간 연관관계 해제

## 전달 사항
- **클라이언트에서 테스트가 필요한 상황이므로 아직 merge 불가합니다**
  - (#794 해결 필요)