### PR TITLE
[BE] refactor: 놀이터 알림 전송 비동기 호출로 변경

### DIFF
--- a/backend/src/main/java/com/happy/friendogly/AsyncExceptionHandler.java
+++ b/backend/src/main/java/com/happy/friendogly/AsyncExceptionHandler.java
@@ -1,0 +1,14 @@
+package com.happy.friendogly;
+
+import java.lang.reflect.Method;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+
+@Slf4j
+public class AsyncExceptionHandler implements AsyncUncaughtExceptionHandler {
+
+    @Override
+    public void handleUncaughtException(Throwable ex, Method method, Object... params) {
+        log.error(ex.getMessage(), ex);
+    }
+}

--- a/backend/src/main/java/com/happy/friendogly/FriendoglyApplication.java
+++ b/backend/src/main/java/com/happy/friendogly/FriendoglyApplication.java
@@ -4,10 +4,12 @@ import jakarta.annotation.PostConstruct;
 import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableAsync
 public class FriendoglyApplication {
 
     @PostConstruct

--- a/backend/src/main/java/com/happy/friendogly/FriendoglyApplication.java
+++ b/backend/src/main/java/com/happy/friendogly/FriendoglyApplication.java
@@ -4,12 +4,14 @@ import jakarta.annotation.PostConstruct;
 import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
 @EnableAsync
+@EnableRetry
 public class FriendoglyApplication {
 
     @PostConstruct

--- a/backend/src/main/java/com/happy/friendogly/config/AsyncConfig.java
+++ b/backend/src/main/java/com/happy/friendogly/config/AsyncConfig.java
@@ -4,10 +4,8 @@ import com.happy.friendogly.AsyncExceptionHandler;
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
-import org.springframework.scheduling.annotation.EnableAsync;
 
 @Configuration
-@EnableAsync
 public class AsyncConfig implements AsyncConfigurer {
 
     @Override

--- a/backend/src/main/java/com/happy/friendogly/config/AsyncConfig.java
+++ b/backend/src/main/java/com/happy/friendogly/config/AsyncConfig.java
@@ -1,0 +1,17 @@
+package com.happy.friendogly.config;
+
+import com.happy.friendogly.AsyncExceptionHandler;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return new AsyncExceptionHandler();
+    }
+}

--- a/backend/src/main/java/com/happy/friendogly/config/ThreadPoolConfig.java
+++ b/backend/src/main/java/com/happy/friendogly/config/ThreadPoolConfig.java
@@ -1,0 +1,42 @@
+package com.happy.friendogly.config;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class ThreadPoolConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(ThreadPoolConfig.class);
+
+    @Bean()
+    public Executor asyncThreadPoolExecutor() {
+        ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
+        threadPoolTaskExecutor.setThreadNamePrefix("Async-Thread-");
+        threadPoolTaskExecutor.setCorePoolSize(1);
+        threadPoolTaskExecutor.setMaxPoolSize(5);
+        threadPoolTaskExecutor.setQueueCapacity(40);
+        threadPoolTaskExecutor.setRejectedExecutionHandler(new RejectedExecutionHandler() {
+            @Override
+            public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+                log.warn("큐가 가득찼습니다. 가장 오래된 작업을 삭제합니다. ActiveCount: {}, PoolSize: {}, QueueSize: {}",
+                        executor.getActiveCount(),
+                        executor.getPoolSize(),
+                        executor.getQueue().size()
+                );
+
+                if (!executor.isShutdown()) {
+                    executor.getQueue().poll();
+                    executor.execute(r);
+                }
+            }
+        });
+        threadPoolTaskExecutor.initialize();
+        return threadPoolTaskExecutor;
+    }
+}

--- a/backend/src/main/java/com/happy/friendogly/notification/service/FcmNotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/FcmNotificationService.java
@@ -5,12 +5,15 @@ import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
 import com.google.firebase.messaging.MulticastMessage;
 import com.happy.friendogly.exception.FriendoglyException;
 import com.happy.friendogly.notification.domain.NotificationType;
 import java.util.List;
 import java.util.Map;
 import org.springframework.context.annotation.Profile;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,6 +62,15 @@ public class FcmNotificationService implements NotificationService {
     }
 
     @Override
+    @Retryable(
+            retryFor = {RetryableFcmException.class},
+            maxAttempts = 3,
+            backoff = @Backoff(
+                    delay = 1_000,
+                    multiplier = 2,
+                    random = true
+            )
+    )
     public void sendNotificationToTopic(
             String title,
             String content,
@@ -74,6 +86,10 @@ public class FcmNotificationService implements NotificationService {
         try {
             firebaseMessaging.send(message);
         } catch (FirebaseMessagingException e) {
+            MessagingErrorCode errorCode = e.getMessagingErrorCode();
+            if(errorCode == MessagingErrorCode.INTERNAL || errorCode == MessagingErrorCode.UNAVAILABLE){
+                throw new RetryableFcmException("일시적인 FCM 서버 에러 발생", e);
+            }
             throw new FriendoglyException("FCM을 통해 Topic으로 알림을 보내는 과정에서 에러가 발생했습니다.", INTERNAL_SERVER_ERROR);
         }
     }

--- a/backend/src/main/java/com/happy/friendogly/notification/service/FcmNotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/FcmNotificationService.java
@@ -11,8 +11,10 @@ import com.happy.friendogly.exception.FriendoglyException;
 import com.happy.friendogly.notification.domain.NotificationType;
 import java.util.List;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
 import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional(readOnly = true)
 @Profile("!local")
+@Slf4j
 public class FcmNotificationService implements NotificationService {
 
     private final FirebaseMessaging firebaseMessaging;
@@ -87,11 +90,22 @@ public class FcmNotificationService implements NotificationService {
             firebaseMessaging.send(message);
         } catch (FirebaseMessagingException e) {
             MessagingErrorCode errorCode = e.getMessagingErrorCode();
-            if(errorCode == MessagingErrorCode.INTERNAL || errorCode == MessagingErrorCode.UNAVAILABLE){
+            if (errorCode == MessagingErrorCode.INTERNAL || errorCode == MessagingErrorCode.UNAVAILABLE) {
                 throw new RetryableFcmException("일시적인 FCM 서버 에러 발생", e);
             }
             throw new FriendoglyException("FCM을 통해 Topic으로 알림을 보내는 과정에서 에러가 발생했습니다.", INTERNAL_SERVER_ERROR);
         }
+    }
+
+    @Recover
+    public void recoverSendNotificationToTopic(
+            RetryableFcmException e,
+            String title,
+            String content,
+            NotificationType notificationType,
+            String topic
+    ) {
+        log.error(e.getMessage(),e);
     }
 
     @Override

--- a/backend/src/main/java/com/happy/friendogly/notification/service/RetryableFcmException.java
+++ b/backend/src/main/java/com/happy/friendogly/notification/service/RetryableFcmException.java
@@ -1,0 +1,8 @@
+package com.happy.friendogly.notification.service;
+
+public class RetryableFcmException extends RuntimeException {
+
+    public RetryableFcmException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundNotificationService.java
+++ b/backend/src/main/java/com/happy/friendogly/playground/service/PlaygroundNotificationService.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -31,6 +32,7 @@ public class PlaygroundNotificationService {
         this.notificationService = notificationService;
     }
 
+    @Async("asyncThreadPoolExecutor")
     public void sendJoinNotification(
             String newParticipatingMember,
             Playground playground

--- a/backend/src/test/java/com/happy/friendogly/notification/service/FcmNotificationServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/notification/service/FcmNotificationServiceTest.java
@@ -2,6 +2,7 @@ package com.happy.friendogly.notification.service;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.google.firebase.FirebaseApp;
@@ -9,11 +10,13 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.happy.friendogly.notification.domain.NotificationType;
 import java.util.List;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -36,5 +39,21 @@ class FcmNotificationServiceTest {
 
         // then
         verify(firebaseMessaging, never()).sendEachForMulticast(any());
+    }
+
+    @Disabled // 해당 테스트는 재시도 로직때문에 시간이 오래걸리므로 비활성화 했습니다.
+    @DisplayName("RetryableFcmException 예외 발생 시 재시도를 3회 수행한다.")
+    @Test
+    void retryThirdWhenRetryableFcmException() throws FirebaseMessagingException {
+        // given
+        Mockito.doThrow(new RetryableFcmException("재시도 가능한 FCM에러 발생", null))
+                .when(firebaseMessaging)
+                .send(any());
+
+        // when
+        fcmNotificationService.sendNotificationToTopic("title", "content", NotificationType.PLAYGROUND, "topic1");
+
+        // then
+        verify(firebaseMessaging, times(3)).send(any());
     }
 }

--- a/backend/src/test/java/com/happy/friendogly/notification/service/FcmNotificationServiceTest.java
+++ b/backend/src/test/java/com/happy/friendogly/notification/service/FcmNotificationServiceTest.java
@@ -2,7 +2,6 @@ package com.happy.friendogly.notification.service;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.google.firebase.FirebaseApp;
@@ -10,13 +9,11 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.happy.friendogly.notification.domain.NotificationType;
 import java.util.List;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -39,21 +36,5 @@ class FcmNotificationServiceTest {
 
         // then
         verify(firebaseMessaging, never()).sendEachForMulticast(any());
-    }
-
-    @Disabled // 해당 테스트는 재시도 로직때문에 시간이 오래걸리므로 비활성화 했습니다.
-    @DisplayName("RetryableFcmException 예외 발생 시 재시도를 3회 수행한다.")
-    @Test
-    void retryThirdWhenRetryableFcmException() throws FirebaseMessagingException {
-        // given
-        Mockito.doThrow(new RetryableFcmException("재시도 가능한 FCM에러 발생", null))
-                .when(firebaseMessaging)
-                .send(any());
-
-        // when
-        fcmNotificationService.sendNotificationToTopic("title", "content", NotificationType.PLAYGROUND, "topic1");
-
-        // then
-        verify(firebaseMessaging, times(3)).send(any());
     }
 }


### PR DESCRIPTION
## 이슈
- close #793 

## 개발 사항
- 놀이터 알림 전송 비동기로 변경
  - 비동기 스레드풀 생성
  - 포화정책은 DiscardOldPolicy를 기반
- 알림 전송 시 재시도 로직 추가

# 전달 사항 

## 1. 스레드풀 설정
일단 @Async어노테이션 적용 하고, 비동기 스레드풀은 아래와 같이 낮게 설정해서 시작했습니다.

```java
hreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
threadPoolTaskExecutor.setThreadNamePrefix("Async-Thread-");
threadPoolTaskExecutor.setCorePoolSize(2);
threadPoolTaskExecutor.setMaxPoolSize(2);
threadPoolTaskExecutor.setQueueCapacity(10);
threadPoolTaskExecutor.setRejectedExecutionHandler(new RejectedExecutionHandler() {
    @Override
    public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
        log.warn("비동기호출 reject. ActiveCount: {}, PoolSize: {}, QueueSize: {}",
                executor.getActiveCount(),
                executor.getPoolSize(),
                executor.getQueue().size()
        );
        throw new RejectedExecutionException("비동기호출 rejected.");
    }
});
```

그리고 **피크타임 시나리오 기준으로 테스트를 시작**했습니다. 해당 시나리오에서 **비동기 호출은 초당 8.2번 호출**됩니다.

그리고 **비동기 작업은 250~350ms**가 걸립니다.

코어 쓰레드 두개만으로는 Reject발생했고, 조금씩 늘려가며 **테스트 해본 결과 3~4개의 스레드가 있어야 피크타임 비동기 호출을 Reject없이 처리가능**했습니다.

해당 기준으로 아래와 같이 스레드풀을 설정했습니다.

### `CorePoolSize = 1`

평상시에는 3~4개의 스레드까지는 필요없습니다. 1개만으로도 초당 3개까지 비동기 호출을 감당할 수 있기에 충분하다고 생각했습니다.

### `MaxPoolSize = 5`

4개까지만 있어도 충분히 처리 가능했지만, 외부 요인으로 인한 지연 발생을 고려해서 1개 더 추가한 5로 설정했습니다.

### `QueueCapacity = 40`

큐사이즈는 빠른 reject을 하려면 낮게 줄이는 것이 맞지만, 해당 알림은 실시간 성이 크게 중요하지 않기 때문에 **조금**의 지연은 괜찮다고 판단했습니다. 피크타임 기준 5초안에 알림이 발송돼도 충분하다고 생각하여 5*8 = 40의 큐사이즈로 선정했습니다

### `스레드풀 포화정책`

기본적인 포화정책은 아래 네가지가 있습니다.

- AbortPolicy는 포화 상태일 경우, RejectedExecutionException을 발생시킵니다.
- DiscardPolicy는 포화 상태일 경우, 신규 요청을 무시합니다.
- DiscardOldestPolicy는 포화 상태일 경우, 작업 대기열에서 가장 오래된 요청을 버리고 신규 요청을 대기열에 추가합니다.
- CallerRunsPolicy는 포화 상태일 경우, 요청 스레드에서 해당 작업을 실행합니다.

꼭 완료되어야 한다면, 지연이 크게 되더라도 발송하는 방향으로 할 수 있습니다. 

하지만, 이 서비스의 경우 조금의 지연은 괜찮지만, 너무 늦게 받으면 오히려 당황할 수 있는 서비스이기에 오래된 작업을 버리는 **DiscardOldPolicy를 기반**으로 했습니다.

대신 **큐가 포화상태임을 알리기 위해 `RejectExecutionHandler` 를 커스텀하여 로그를 삽입**했습니다.

## 재시도 로직

재시도 로직을 구현하는 방법은 직접 구현하기, @Retryable, RetryTemplate 세가지가 있습니다(WebClient사용하지 않을 경우). 그 중에서 저는 @Retryable을 사용했습니다.

@Retryable을 사용한 이유는 직접 구현하지 않아도 재시도를 제공하고 RetryTemplate을 사용하면 알림로직의 가독성이 떨어지기 때문입니다.

```java
    @Retryable(
            retryFor = {RetryableFcmException.class},
            maxAttempts = 3,
            backoff = @Backoff(
                    delay = 1_000,
                    multiplier = 2,
                    random = true
            )
    )
    public void sendNotificationToTopic(
```

위 방식으로 구현했습니다. FCM에서는 1초→2초→4초 …의 지수 백오프 방식을 권장합니다. 

maxAttempts로 첫 호출을 포함해서 총 3번을 호출하며, 첫 딜레이는 1초로 *2씩하며 증가합니다.

random속성은 지터방식을 사용할 지 선택하는 것입니다. 

지터를 사용하지 않으면 동시에 여러 요청이 지연됐을 때, 재시도 시점이 또 동시에 몰리지 않도록 지수백오프에 랜덤한 값을 부여하는 방식이 지터입니다. 이전 지연시간 ~ 현재 지연시간 사이의 값으로 선정됩니다.

재시도 또한 실패시, @Recover를 통해 로그를 찍고 종료하게 됩니다. 해당 로그는 추후에 디스코드나 슬랙으로 알림이 갈 예정.
