### PR TITLE
[AN] 최신 SDK 대응 및 v1.1.2 배포

### DIFF
--- a/.github/workflows/android-cd.yml
+++ b/.github/workflows/android-cd.yml
@@ -72,7 +72,7 @@ jobs:
           ./gradlew :app:assembleRelease
 
       - name: Upload Release Build to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release-artifacts
           path: android/app/build/outputs/apk/release/

--- a/.github/workflows/android-pull-request-ci.yml
+++ b/.github/workflows/android-pull-request-ci.yml
@@ -99,7 +99,7 @@ jobs:
         run: ./gradlew ktlintCheck
 
       - name: Upload Event File
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Event File
           path: ${{ github.event_path }}
@@ -117,7 +117,7 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Test Results
           path: "**/test-results/**/*.xml"

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
 applicationId = "com.happy.friendogly"
-compileSdk = "34"
+compileSdk = "35"
 minSdk = "26"
-targetSdk = "34"
-versionCode = "15"
-versionName = "1.1.0"
+targetSdk = "35"
+versionCode = "16"
+versionName = "1.1.1"
 
 agp = "8.3.0"
 kotlin = "1.9.21"

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ compileSdk = "35"
 minSdk = "26"
 targetSdk = "35"
 versionCode = "16"
-versionName = "1.1.1"
+versionName = "1.1.2"
 
 agp = "8.3.0"
 kotlin = "1.9.21"


### PR DESCRIPTION
## 이슈
- close #802 

## 개발 사항
- compileSdk와 targetSdk를 각각 Android 15(API 수준 35)로 상향 조정
- v1.1.2 릴리즈 배포
- upload-artifact@v3  -> v4로 변경

